### PR TITLE
Added ip address to the WOL packet

### DIFF
--- a/bin/LG_Buddy_Common
+++ b/bin/LG_Buddy_Common
@@ -106,10 +106,11 @@ lg_buddy_expected_app() {
 }
 
 lg_buddy_send_wol() {
-    local mac="$1"
+    local ip="$1"
+    local mac="$2"
 
     if command -v wakeonlan >/dev/null 2>&1; then
-        wakeonlan "$mac"
+        wakeonlan -i "$ip" "$mac"
     elif command -v wol >/dev/null 2>&1; then
         wol "$mac"
     else

--- a/bin/LG_Buddy_Screen_On
+++ b/bin/LG_Buddy_Screen_On
@@ -59,7 +59,7 @@ fi
 log "Screen unblank failed. Falling back to full wake."
 
 log "Sending initial Wake-on-LAN packet..."
-lg_buddy_send_wol "$tv_mac" || true
+lg_buddy_send_wol "$tv_ip" "$tv_mac" || true
 
 # Wait for TV to fully wake up and accept WebSocket connections
 sleep 6
@@ -74,7 +74,7 @@ for i in 1 2 3 4 5 6; do
 
     retry_delay=$(( (i * 2) > 30 ? 30 : (i * 2) ))
     log "Wake attempt $i failed. Resending WoL and retrying in ${retry_delay}s..."
-    lg_buddy_send_wol "$tv_mac" || true
+    lg_buddy_send_wol "$tv_ip" "$tv_mac" || true
     sleep "$retry_delay"
 done
 

--- a/bin/LG_Buddy_Startup
+++ b/bin/LG_Buddy_Startup
@@ -39,7 +39,7 @@ else
     fi
 fi
 
-lg_buddy_send_wol "$tv_mac" || true
+lg_buddy_send_wol "$tv_ip" "$tv_mac" || true
 
 # Let the TV fully bring up its WebSocket endpoint after WoL.
 sleep 6
@@ -51,7 +51,7 @@ for i in 1 2 3 4 5 6; do
     fi
     retry_delay=$(( (i * 2) > 30 ? 30 : (i * 2) ))
     echo "Attempt $i failed, retrying in ${retry_delay}s..."
-    lg_buddy_send_wol "$tv_mac" || true
+    lg_buddy_send_wol "$tv_ip" "$tv_mac" || true
     sleep "$retry_delay"
 done
 


### PR DESCRIPTION
Pass the TV's IP address to wakeonlan -i so the magic packet is sent to the correct subnet broadcast address instead of the default 255.255.255.255
`lg_buddy_send_wol()` now takes ip as the first argument and mac as the second
All call sites in `LG_Buddy_Screen_On` and `LG_Buddy_Startup` updated to pass `$tv_ip`

Without -i, wakeonlan broadcasts to 255.255.255.255, which may not reach the TV on networks where directed broadcast is required or where the host has multiple interfaces. Using the configured tv_ip ensures the WOL packet is routed to the correct subnet.