### PR TITLE
Add structured settings API and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,23 @@ On first use, you may need to accept a pairing prompt on the TV:
 
 LG Buddy is mostly automatic after installation.
 
-- To change settings later, run `./configure.sh`
+- To inspect settings, run `lg-buddy settings list`
+- To change supported screen settings, use `lg-buddy settings set <key> <value>`
+- To rerun full setup for TV IP, MAC address, or HDMI input, run `./configure.sh`
 - To check the screen monitor, run `systemctl --user status LG_Buddy_screen.service`
 - To remove LG Buddy, run `./uninstall.sh`
 
-Advanced session restore behavior can be tuned in `config.env`:
+The settings CLI is a structured layer over `config.env`. These examples write
+the same file that manual editing and `configure.sh` use:
+
+```bash
+lg-buddy settings describe screen.restore_policy
+lg-buddy settings set screen.idle_timeout 600
+lg-buddy settings set screen.restore_policy aggressive
+lg-buddy settings unset screen.restore_policy
+```
+
+Advanced session restore behavior can also be tuned directly in `config.env`:
 
 ```ini
 screen_idle_timeout=300
@@ -105,7 +117,10 @@ Set `screen_restore_policy=aggressive` to let session wake/activity and system w
 
 `system_sleep_wake_policy=enabled` is the default. Set
 `system_sleep_wake_policy=disabled` in `config.env` and rerun `./install.sh` if
-you do not want LG Buddy to control the TV around system sleep and wake.
+you do not want LG Buddy to control the TV around system sleep and wake. The
+structured key `system.sleep_wake_policy` is currently read-only in
+`lg-buddy settings` until lifecycle service and NetworkManager hook changes have
+a dedicated apply path.
 
 ## More Help
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ The settings CLI is a structured layer over `config.env`. These examples write
 the same file that manual editing and `configure.sh` use:
 
 ```bash
+lg-buddy settings describe tv.input
+lg-buddy settings set tv.input HDMI_2
 lg-buddy settings describe screen.restore_policy
 lg-buddy settings set screen.idle_timeout 600
 lg-buddy settings set screen.restore_policy aggressive
@@ -102,13 +104,20 @@ lg-buddy settings set system.sleep_wake_policy disabled
 lg-buddy settings unset screen.restore_policy
 ```
 
-Advanced session restore behavior can also be tuned directly in `config.env`:
+Settings can also be edited directly in `config.env`:
 
 ```ini
+tvs_primary_ip=192.168.1.100
+tvs_primary_mac=aa:bb:cc:dd:ee:ff
+tvs_primary_input=HDMI_2
 screen_idle_timeout=300
 screen_restore_policy=conservative
 system_sleep_wake_policy=enabled
 ```
+
+`tv_ip`, `tv_mac`, and `input` are still accepted as legacy single-TV keys, but
+new writes use the `tvs_primary_*` shape so the storage can grow later without
+changing the current single-TV settings interface.
 
 `screen_restore_policy=conservative` is the default. LG Buddy only restores when a matching LG Buddy marker says it previously blanked or powered off the TV.
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ system_sleep_wake_policy=enabled
 new writes use the `tvs_primary_*` shape so the storage can grow later without
 changing the current single-TV settings interface.
 
+If a direct `config.env` edit leaves a value malformed, `lg-buddy settings list`
+and `describe` show it as invalid instead of silently treating it as default or
+missing. `lg-buddy settings get <key>` fails with the validation error so the
+bad entry can be fixed with `settings set`, `settings unset` when supported, or
+by editing `config.env`.
+
 `screen_restore_policy=conservative` is the default. LG Buddy only restores when a matching LG Buddy marker says it previously blanked or powered off the TV.
 
 Set `screen_restore_policy=aggressive` to let session wake/activity and system wake restore the TV even when no LG Buddy marker exists. This is intentionally more aggressive and can turn the TV on in cases where another device or a manual action powered it off.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ On first use, you may need to accept a pairing prompt on the TV:
 LG Buddy is mostly automatic after installation.
 
 - To inspect settings, run `lg-buddy settings list`
-- To change supported screen settings, use `lg-buddy settings set <key> <value>`
+- To change supported settings, use `lg-buddy settings set <key> <value>`
 - To rerun full setup for TV IP, MAC address, or HDMI input, run `./configure.sh`
 - To check the screen monitor, run `systemctl --user status LG_Buddy_screen.service`
 - To remove LG Buddy, run `./uninstall.sh`
@@ -98,6 +98,7 @@ the same file that manual editing and `configure.sh` use:
 lg-buddy settings describe screen.restore_policy
 lg-buddy settings set screen.idle_timeout 600
 lg-buddy settings set screen.restore_policy aggressive
+lg-buddy settings set system.sleep_wake_policy disabled
 lg-buddy settings unset screen.restore_policy
 ```
 
@@ -116,11 +117,9 @@ Set `screen_restore_policy=aggressive` to let session wake/activity and system w
 `marker_only` is still accepted as a legacy alias for `conservative`.
 
 `system_sleep_wake_policy=enabled` is the default. Set
-`system_sleep_wake_policy=disabled` in `config.env` and rerun `./install.sh` if
-you do not want LG Buddy to control the TV around system sleep and wake. The
-structured key `system.sleep_wake_policy` is currently read-only in
-`lg-buddy settings` until lifecycle service and NetworkManager hook changes have
-a dedicated apply path.
+`system_sleep_wake_policy=disabled` if you do not want LG Buddy to control the
+TV around system sleep and wake. The lifecycle service and NetworkManager
+pre-down hook stay installed and no-op while the policy is disabled.
 
 ## More Help
 

--- a/bin/LG_Buddy_Common
+++ b/bin/LG_Buddy_Common
@@ -10,6 +10,7 @@ fi
 LG_BUDDY_POINTER_FILE="${LG_BUDDY_INSTALL_DIR}/config-path"
 LG_BUDDY_DEFAULT_SCREEN_BACKEND="auto"
 LG_BUDDY_DEFAULT_IDLE_TIMEOUT=300
+LG_BUDDY_MAX_IDLE_TIMEOUT=86400
 LG_BUDDY_DEFAULT_SCREEN_RESTORE_POLICY="conservative"
 LG_BUDDY_DEFAULT_SYSTEM_SLEEP_WAKE_POLICY="enabled"
 
@@ -101,6 +102,58 @@ lg_buddy_config_get_valid_any() {
     echo "$default_value"
 }
 
+lg_buddy_strip_leading_zeroes() {
+    local value="$1"
+
+    while [ "${value#0}" != "$value" ]; do
+        value="${value#0}"
+    done
+
+    echo "${value:-0}"
+}
+
+lg_buddy_decimal_greater_than() {
+    local left=""
+    local right=""
+
+    left="$(lg_buddy_strip_leading_zeroes "$1")"
+    right="$(lg_buddy_strip_leading_zeroes "$2")"
+
+    if [ "${#left}" -gt "${#right}" ]; then
+        return 0
+    fi
+    if [ "${#left}" -lt "${#right}" ]; then
+        return 1
+    fi
+
+    [[ "$left" > "$right" ]]
+}
+
+lg_buddy_validate_idle_timeout() {
+    local value=""
+
+    [[ "$1" =~ ^[0-9]+$ ]] || return 1
+
+    value="$(lg_buddy_strip_leading_zeroes "$1")"
+    [ "$value" != "0" ]
+}
+
+lg_buddy_normalize_idle_timeout() {
+    local value="$1"
+
+    if ! lg_buddy_validate_idle_timeout "$value"; then
+        echo "$LG_BUDDY_DEFAULT_IDLE_TIMEOUT"
+        return 0
+    fi
+
+    value="$(lg_buddy_strip_leading_zeroes "$value")"
+    if lg_buddy_decimal_greater_than "$value" "$LG_BUDDY_MAX_IDLE_TIMEOUT"; then
+        echo "$LG_BUDDY_MAX_IDLE_TIMEOUT"
+    else
+        echo "$value"
+    fi
+}
+
 lg_buddy_load_config() {
     LG_BUDDY_CONFIG_FILE="$(lg_buddy_effective_config_path)" || {
         echo "LG Buddy: could not determine config path."
@@ -117,6 +170,7 @@ lg_buddy_load_config() {
     input="$(lg_buddy_config_get_valid_any '^HDMI_[1-4]$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_input" "input")"
     screen_backend="$(lg_buddy_config_get_valid "screen_backend" '^(auto|gnome|swayidle)$' "$LG_BUDDY_DEFAULT_SCREEN_BACKEND" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_timeout="$(lg_buddy_config_get_valid "screen_idle_timeout" '^[0-9]+$' "$LG_BUDDY_DEFAULT_IDLE_TIMEOUT" "$LG_BUDDY_CONFIG_FILE")"
+    screen_idle_timeout="$(lg_buddy_normalize_idle_timeout "$screen_idle_timeout")"
     screen_restore_policy="$(lg_buddy_config_get_valid "screen_restore_policy" '^(marker_only|conservative|aggressive)$' "$LG_BUDDY_DEFAULT_SCREEN_RESTORE_POLICY" "$LG_BUDDY_CONFIG_FILE")"
     system_sleep_wake_policy="$(lg_buddy_config_get_valid "system_sleep_wake_policy" '^(enabled|disabled)$' "$LG_BUDDY_DEFAULT_SYSTEM_SLEEP_WAKE_POLICY" "$LG_BUDDY_CONFIG_FILE")"
 

--- a/bin/LG_Buddy_Common
+++ b/bin/LG_Buddy_Common
@@ -81,6 +81,26 @@ lg_buddy_config_get_valid() {
     fi
 }
 
+lg_buddy_config_get_valid_any() {
+    local regex="$1"
+    local default_value="$2"
+    local config_file="$3"
+    local value=""
+    local key=""
+
+    shift 3
+
+    for key in "$@"; do
+        value="$(lg_buddy_config_get_raw "$key" "$config_file")" || value=""
+        if [ -n "$value" ] && [[ "$value" =~ $regex ]]; then
+            echo "$value"
+            return 0
+        fi
+    done
+
+    echo "$default_value"
+}
+
 lg_buddy_load_config() {
     LG_BUDDY_CONFIG_FILE="$(lg_buddy_effective_config_path)" || {
         echo "LG Buddy: could not determine config path."
@@ -92,9 +112,9 @@ lg_buddy_load_config() {
         return 1
     fi
 
-    tv_ip="$(lg_buddy_config_get_valid "tv_ip" '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' "" "$LG_BUDDY_CONFIG_FILE")"
-    tv_mac="$(lg_buddy_config_get_valid "tv_mac" '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' "" "$LG_BUDDY_CONFIG_FILE")"
-    input="$(lg_buddy_config_get_valid "input" '^HDMI_[1-4]$' "" "$LG_BUDDY_CONFIG_FILE")"
+    tv_ip="$(lg_buddy_config_get_valid_any '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_ip" "tv_ip")"
+    tv_mac="$(lg_buddy_config_get_valid_any '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_mac" "tv_mac")"
+    input="$(lg_buddy_config_get_valid_any '^HDMI_[1-4]$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_input" "input")"
     screen_backend="$(lg_buddy_config_get_valid "screen_backend" '^(auto|gnome|swayidle)$' "$LG_BUDDY_DEFAULT_SCREEN_BACKEND" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_timeout="$(lg_buddy_config_get_valid "screen_idle_timeout" '^[0-9]+$' "$LG_BUDDY_DEFAULT_IDLE_TIMEOUT" "$LG_BUDDY_CONFIG_FILE")"
     screen_restore_policy="$(lg_buddy_config_get_valid "screen_restore_policy" '^(marker_only|conservative|aggressive)$' "$LG_BUDDY_DEFAULT_SCREEN_RESTORE_POLICY" "$LG_BUDDY_CONFIG_FILE")"

--- a/configure.sh
+++ b/configure.sh
@@ -65,7 +65,7 @@ validate_system_sleep_wake_policy() {
 }
 
 validate_idle_timeout() {
-    [[ "$1" =~ ^[0-9]+$ ]] && [ "$1" -gt 0 ]
+    lg_buddy_validate_idle_timeout "$1"
 }
 
 normalize_restore_policy() {
@@ -135,6 +135,7 @@ if [ "${LG_BUDDY_NONINTERACTIVE:-0}" = "1" ]; then
         echo "LG_BUDDY_SCREEN_IDLE_TIMEOUT must be a positive integer."
         exit 1
     }
+    screen_idle_timeout="$(lg_buddy_normalize_idle_timeout "$screen_idle_timeout")"
     validate_system_sleep_wake_policy "$system_sleep_wake_policy" || {
         echo "LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY must be one of enabled or disabled."
         exit 1
@@ -253,6 +254,7 @@ else
     while true; do
         screen_idle_timeout="$(prompt_with_default "Enter idle timeout in seconds" "$current_screen_idle_timeout")"
         if validate_idle_timeout "$screen_idle_timeout"; then
+            screen_idle_timeout="$(lg_buddy_normalize_idle_timeout "$screen_idle_timeout")"
             break
         fi
         echo "  Please enter a positive number of seconds."

--- a/configure.sh
+++ b/configure.sh
@@ -307,9 +307,9 @@ chmod 700 "$CONFIG_DIR"
 
 cat >"$CONFIG_FILE" <<EOF
 # LG Buddy configuration
-tv_ip=$tv_ip
-tv_mac=$tv_mac
-input=$input
+tvs_primary_ip=$tv_ip
+tvs_primary_mac=$tv_mac
+tvs_primary_input=$input
 screen_backend=$screen_backend
 screen_idle_timeout=$screen_idle_timeout
 screen_restore_policy=$screen_restore_policy

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -1616,7 +1616,7 @@ mod tests {
 
     impl WakeOnLanSender for RecordingWakeOnLanSender {
         fn send_magic_packet(&self, mac: &MacAddress) -> Result<(), WakeOnLanError> {
-            self.calls.borrow_mut().push(mac.clone());
+            self.calls.borrow_mut().push(*mac);
             Ok(())
         }
     }

--- a/crates/lg-buddy/src/config.rs
+++ b/crates/lg-buddy/src/config.rs
@@ -11,6 +11,21 @@ const CONFIG_DIR_NAME: &str = "lg-buddy";
 const CONFIG_FILE_NAME: &str = "config.env";
 const INSTALL_CONFIG_POINTER_FILE: &str = "/usr/lib/lg-buddy/config-path";
 pub const DEFAULT_IDLE_TIMEOUT: u64 = 300;
+pub const MAX_IDLE_TIMEOUT: u64 = 86_400;
+
+pub fn parse_idle_timeout_secs(value: &str) -> Option<u64> {
+    value.parse::<u128>().ok().map(normalize_idle_timeout_secs)
+}
+
+pub fn normalize_idle_timeout_secs(idle_timeout_secs: u128) -> u64 {
+    if idle_timeout_secs == 0 {
+        DEFAULT_IDLE_TIMEOUT
+    } else if idle_timeout_secs > u128::from(MAX_IDLE_TIMEOUT) {
+        MAX_IDLE_TIMEOUT
+    } else {
+        idle_timeout_secs as u64
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct ConfigPathSources<'a> {
@@ -410,7 +425,7 @@ pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
 
     let screen_idle_timeout = entries
         .get("screen_idle_timeout")
-        .and_then(|value| value.parse::<u64>().ok())
+        .and_then(|value| parse_idle_timeout_secs(value))
         .unwrap_or(DEFAULT_IDLE_TIMEOUT);
 
     let screen_restore_policy = entries
@@ -479,7 +494,7 @@ mod tests {
     use super::{
         parse_config, parse_home_from_passwd_entries, resolve_config_path, Config, ConfigError,
         ConfigPathError, ConfigPathSources, HdmiInput, ScreenBackend, ScreenRestorePolicy,
-        SystemSleepWakePolicy, DEFAULT_IDLE_TIMEOUT,
+        SystemSleepWakePolicy, DEFAULT_IDLE_TIMEOUT, MAX_IDLE_TIMEOUT,
     };
     use std::path::Path;
 
@@ -598,6 +613,33 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
             config.system_sleep_wake_policy,
             SystemSleepWakePolicy::Disabled
         );
+    }
+
+    #[test]
+    fn parse_clamps_idle_timeout_to_max() {
+        let config = parse_config(
+            "\
+            tvs_primary_ip=192.168.1.42
+            tvs_primary_mac=aa:bb:cc:dd:ee:ff
+            tvs_primary_input=HDMI_2
+            screen_idle_timeout=86401
+            ",
+        )
+        .expect("parse config with capped timeout");
+
+        assert_eq!(config.screen_idle_timeout, MAX_IDLE_TIMEOUT);
+
+        let config = parse_config(
+            "\
+            tvs_primary_ip=192.168.1.42
+            tvs_primary_mac=aa:bb:cc:dd:ee:ff
+            tvs_primary_input=HDMI_2
+            screen_idle_timeout=18446744073709551615
+            ",
+        )
+        .expect("parse config with u64-max timeout");
+
+        assert_eq!(config.screen_idle_timeout, MAX_IDLE_TIMEOUT);
     }
 
     #[test]

--- a/crates/lg-buddy/src/config.rs
+++ b/crates/lg-buddy/src/config.rs
@@ -181,7 +181,7 @@ impl FromStr for HdmiInput {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MacAddress([u8; 6]);
 
 impl MacAddress {
@@ -367,40 +367,37 @@ pub fn load_config(path: &Path) -> Result<Config, ConfigError> {
 pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
     let entries = parse_config_entries(contents);
 
-    let tv_ip = entries
-        .get("tv_ip")
-        .ok_or(ConfigError::MissingRequiredKey("tv_ip"))
+    let tv_ip = required_config_value(&entries, "tvs_primary_ip", &["tv_ip"])
+        .ok_or(ConfigError::MissingRequiredKey("tvs_primary_ip"))
         .and_then(|value| {
             value
                 .parse::<Ipv4Addr>()
                 .map_err(|_| ConfigError::InvalidValue {
-                    key: "tv_ip",
+                    key: "tvs_primary_ip",
                     value: value.clone(),
                     expected: "an IPv4 address",
                 })
         })?;
 
-    let tv_mac = entries
-        .get("tv_mac")
-        .ok_or(ConfigError::MissingRequiredKey("tv_mac"))
+    let tv_mac = required_config_value(&entries, "tvs_primary_mac", &["tv_mac"])
+        .ok_or(ConfigError::MissingRequiredKey("tvs_primary_mac"))
         .and_then(|value| {
             value
                 .parse::<MacAddress>()
                 .map_err(|_| ConfigError::InvalidValue {
-                    key: "tv_mac",
+                    key: "tvs_primary_mac",
                     value: value.clone(),
                     expected: "a MAC address like aa:bb:cc:dd:ee:ff",
                 })
         })?;
 
-    let input = entries
-        .get("input")
-        .ok_or(ConfigError::MissingRequiredKey("input"))
+    let input = required_config_value(&entries, "tvs_primary_input", &["input"])
+        .ok_or(ConfigError::MissingRequiredKey("tvs_primary_input"))
         .and_then(|value| {
             value
                 .parse::<HdmiInput>()
                 .map_err(|_| ConfigError::InvalidValue {
-                    key: "input",
+                    key: "tvs_primary_input",
                     value: value.clone(),
                     expected: "one of HDMI_1, HDMI_2, HDMI_3, HDMI_4",
                 })
@@ -434,6 +431,18 @@ pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
         screen_idle_timeout,
         screen_restore_policy,
         system_sleep_wake_policy,
+    })
+}
+
+fn required_config_value<'a>(
+    entries: &'a HashMap<String, String>,
+    primary_key: &str,
+    fallback_keys: &[&str],
+) -> Option<&'a String> {
+    entries.get(primary_key).or_else(|| {
+        fallback_keys
+            .iter()
+            .find_map(|fallback_key| entries.get(*fallback_key))
     })
 }
 
@@ -565,9 +574,9 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
         let config = parse_config(
             "\
             # LG Buddy configuration
-            tv_ip=192.168.1.42
-            tv_mac=aa:bb:cc:dd:ee:ff
-            input=HDMI_2
+            tvs_primary_ip=192.168.1.42
+            tvs_primary_mac=aa:bb:cc:dd:ee:ff
+            tvs_primary_input=HDMI_2
             screen_backend=gnome
             screen_idle_timeout=450
             screen_restore_policy=aggressive
@@ -589,6 +598,22 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
             config.system_sleep_wake_policy,
             SystemSleepWakePolicy::Disabled
         );
+    }
+
+    #[test]
+    fn parse_accepts_legacy_single_tv_keys() {
+        let config = parse_config(
+            "\
+            tv_ip=192.168.1.42
+            tv_mac=aa:bb:cc:dd:ee:ff
+            input=HDMI_2
+            ",
+        )
+        .expect("parse legacy TV config");
+
+        assert_eq!(config.tv_ip.to_string(), "192.168.1.42");
+        assert_eq!(config.tv_mac.to_string(), "aa:bb:cc:dd:ee:ff");
+        assert_eq!(config.input, HdmiInput::Hdmi2);
     }
 
     #[test]
@@ -764,7 +789,10 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
         )
         .expect_err("missing tv_mac should fail");
 
-        assert_eq!(err.to_string(), "missing required config key `tv_mac`");
+        assert_eq!(
+            err.to_string(),
+            "missing required config key `tvs_primary_mac`"
+        );
     }
 
     #[test]
@@ -780,7 +808,10 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
 
         assert!(matches!(
             err,
-            ConfigError::InvalidValue { key: "tv_ip", .. }
+            ConfigError::InvalidValue {
+                key: "tvs_primary_ip",
+                ..
+            }
         ));
     }
 

--- a/crates/lg-buddy/src/config.rs
+++ b/crates/lg-buddy/src/config.rs
@@ -365,7 +365,7 @@ pub fn load_config(path: &Path) -> Result<Config, ConfigError> {
 }
 
 pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
-    let entries = parse_entries(contents);
+    let entries = parse_config_entries(contents);
 
     let tv_ip = entries
         .get("tv_ip")
@@ -437,7 +437,7 @@ pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
     })
 }
 
-fn parse_entries(contents: &str) -> HashMap<String, String> {
+pub(crate) fn parse_config_entries(contents: &str) -> HashMap<String, String> {
     let mut entries = HashMap::new();
 
     for line in contents.lines() {

--- a/crates/lg-buddy/src/events.rs
+++ b/crates/lg-buddy/src/events.rs
@@ -96,7 +96,10 @@ impl RuntimeEventKind {
             Command::Brightness => Some(Self::BrightnessRequested),
             Command::ScreenOff => Some(Self::ScreenBlankRequested),
             Command::ScreenOn => Some(Self::ScreenRestoreRequested),
-            Command::Monitor | Command::Lifecycle | Command::DetectBackend => None,
+            Command::Monitor
+            | Command::Lifecycle
+            | Command::DetectBackend
+            | Command::Settings(_) => None,
         }
     }
 }
@@ -176,6 +179,10 @@ mod tests {
         assert_eq!(RuntimeEvent::from_command(Command::Monitor), None);
         assert_eq!(RuntimeEvent::from_command(Command::Lifecycle), None);
         assert_eq!(RuntimeEvent::from_command(Command::DetectBackend), None);
+        assert_eq!(
+            RuntimeEvent::from_command(Command::Settings(crate::settings::SettingsCommand::List)),
+            None
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -223,7 +223,7 @@ Commands:
   monitor         Run the user-session monitor loop
   lifecycle       Run the system lifecycle monitor loop
   detect-backend  Detect the active screen backend
-  settings        Inspect structured LG Buddy settings
+  settings        Inspect and edit structured LG Buddy settings
 
 Startup modes:
   auto            Restore on wake when LG Buddy owns the system marker, otherwise boot
@@ -234,8 +234,8 @@ Settings:
   settings list
   settings describe [key]
   settings get <key>
-  settings set <key> <value>  Reserved for write support; currently fails without changes
-  settings unset <key>        Reserved for write support; currently fails without changes
+  settings set <key> <value>
+  settings unset <key>
 "
     )
 }
@@ -427,6 +427,21 @@ mod tests {
                 SettingsCommand::Get("screen.backend".to_string())
             )))
         );
+        assert_eq!(
+            parse_args(["settings", "set", "screen.backend", "gnome"]),
+            Ok(ParseOutcome::Command(Command::Settings(
+                SettingsCommand::Set {
+                    key: "screen.backend".to_string(),
+                    value: "gnome".to_string(),
+                }
+            )))
+        );
+        assert_eq!(
+            parse_args(["settings", "unset", "screen.backend"]),
+            Ok(ParseOutcome::Command(Command::Settings(
+                SettingsCommand::Unset("screen.backend".to_string())
+            )))
+        );
     }
 
     #[test]
@@ -511,5 +526,21 @@ mod tests {
         for mode in ["auto", "boot", "wake"] {
             assert!(help.contains(mode), "missing startup mode `{mode}`");
         }
+    }
+
+    #[test]
+    fn usage_mentions_settings_commands_without_reserved_notice() {
+        let help = usage("lg-buddy");
+
+        for command in [
+            "settings list",
+            "settings describe [key]",
+            "settings get <key>",
+            "settings set <key> <value>",
+            "settings unset <key>",
+        ] {
+            assert!(help.contains(command), "missing `{command}` from help");
+        }
+        assert!(!help.contains("Reserved for write support"));
     }
 }

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -29,11 +29,12 @@ use crate::commands::{
 };
 use crate::config::{ConfigError, ConfigPathError};
 use crate::session::runner::{run_lifecycle_monitor, run_monitor};
+use crate::settings::{run_settings_command, SettingsCommand, SettingsError, SettingsParseError};
 use crate::state::StateDirError;
 use std::fmt;
 use std::io::{self, Write};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
     Startup(StartupMode),
     Shutdown,
@@ -46,6 +47,7 @@ pub enum Command {
     Monitor,
     Lifecycle,
     DetectBackend,
+    Settings(SettingsCommand),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,6 +86,7 @@ pub enum ParseOutcome {
 pub enum ParseError {
     UnknownCommand(String),
     UnknownStartupMode(String),
+    Settings(SettingsParseError),
     UnexpectedArguments {
         command: Command,
         arguments: Vec<String>,
@@ -99,6 +102,7 @@ impl fmt::Display for ParseError {
             Self::UnknownStartupMode(mode) => {
                 write!(f, "unknown startup mode `{mode}`")
             }
+            Self::Settings(err) => write!(f, "{err}"),
             Self::UnexpectedArguments { command, arguments } => {
                 write!(
                     f,
@@ -121,6 +125,7 @@ pub enum RunError {
     StateDir(StateDirError),
     BackendSelection(BackendSelectionError),
     BackendDetection(BackendDetectionError),
+    Settings(SettingsError),
 }
 
 impl fmt::Display for RunError {
@@ -134,6 +139,7 @@ impl fmt::Display for RunError {
             Self::StateDir(err) => write!(f, "{err}"),
             Self::BackendSelection(err) => write!(f, "{err}"),
             Self::BackendDetection(err) => write!(f, "{err}"),
+            Self::Settings(err) => write!(f, "{err}"),
         }
     }
 }
@@ -149,6 +155,7 @@ impl std::error::Error for RunError {
             Self::StateDir(err) => Some(err),
             Self::BackendSelection(err) => Some(err),
             Self::BackendDetection(err) => Some(err),
+            Self::Settings(err) => Some(err),
         }
     }
 }
@@ -160,7 +167,7 @@ impl From<io::Error> for RunError {
 }
 
 impl Command {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::Startup(_) => "startup",
             Self::Shutdown => "shutdown",
@@ -173,10 +180,11 @@ impl Command {
             Self::Monitor => "monitor",
             Self::Lifecycle => "lifecycle",
             Self::DetectBackend => "detect-backend",
+            Self::Settings(_) => "settings",
         }
     }
 
-    pub fn placeholder_message(self) -> &'static str {
+    pub fn placeholder_message(&self) -> &'static str {
         match self {
             Self::Startup(_) => "TODO: implemented via command handler",
             Self::Shutdown => "TODO: implemented via command handler",
@@ -189,6 +197,7 @@ impl Command {
             Self::Monitor => "TODO: implemented via command handler",
             Self::Lifecycle => "TODO: implemented via command handler",
             Self::DetectBackend => "TODO: implement detect-backend command",
+            Self::Settings(_) => "TODO: implemented via command handler",
         }
     }
 }
@@ -214,11 +223,19 @@ Commands:
   monitor         Run the user-session monitor loop
   lifecycle       Run the system lifecycle monitor loop
   detect-backend  Detect the active screen backend
+  settings        Inspect structured LG Buddy settings
 
 Startup modes:
   auto            Restore on wake when LG Buddy owns the system marker, otherwise boot
   boot            Always treat startup as a cold boot
   wake            Only restore when LG Buddy owns the system marker
+
+Settings:
+  settings list
+  settings describe [key]
+  settings get <key>
+  settings set <key> <value>  Reserved for write support; currently fails without changes
+  settings unset <key>        Reserved for write support; currently fails without changes
 "
     )
 }
@@ -259,6 +276,11 @@ where
 
             return Ok(ParseOutcome::Command(Command::Startup(startup_mode)));
         }
+        "settings" => {
+            return SettingsCommand::parse(args)
+                .map(|command| ParseOutcome::Command(Command::Settings(command)))
+                .map_err(ParseError::Settings);
+        }
         "shutdown" => Command::Shutdown,
         "sleep-pre" => Command::SleepPre,
         "sleep" => Command::Sleep,
@@ -296,6 +318,9 @@ pub fn run_command<W: Write>(command: Command, writer: &mut W) -> Result<(), Run
         Command::ScreenOn => run_screen_on(writer),
         Command::Monitor => run_monitor(writer),
         Command::Lifecycle => run_lifecycle_monitor(writer),
+        Command::Settings(command) => {
+            run_settings_command(command, writer).map_err(RunError::Settings)
+        }
     }
 }
 
@@ -310,6 +335,7 @@ fn run_detect_backend<W: Write>(writer: &mut W) -> Result<(), RunError> {
 #[cfg(test)]
 mod tests {
     use super::{parse_args, usage, Command, ParseError, ParseOutcome, StartupMode};
+    use crate::settings::{SettingsCommand, SettingsParseError};
 
     #[test]
     fn no_args_prints_help() {
@@ -377,6 +403,30 @@ mod tests {
             parse_args(["detect-backend"]),
             Ok(ParseOutcome::Command(Command::DetectBackend))
         );
+        assert_eq!(
+            parse_args(["settings", "list"]),
+            Ok(ParseOutcome::Command(Command::Settings(
+                SettingsCommand::List
+            )))
+        );
+        assert_eq!(
+            parse_args(["settings", "describe"]),
+            Ok(ParseOutcome::Command(Command::Settings(
+                SettingsCommand::Describe(None)
+            )))
+        );
+        assert_eq!(
+            parse_args(["settings", "describe", "screen.backend"]),
+            Ok(ParseOutcome::Command(Command::Settings(
+                SettingsCommand::Describe(Some("screen.backend".to_string()))
+            )))
+        );
+        assert_eq!(
+            parse_args(["settings", "get", "screen.backend"]),
+            Ok(ParseOutcome::Command(Command::Settings(
+                SettingsCommand::Get("screen.backend".to_string())
+            )))
+        );
     }
 
     #[test]
@@ -407,6 +457,29 @@ mod tests {
     }
 
     #[test]
+    fn invalid_settings_command_is_rejected() {
+        assert_eq!(
+            parse_args(["settings"]),
+            Err(ParseError::Settings(SettingsParseError::MissingSubcommand))
+        );
+        assert_eq!(
+            parse_args(["settings", "get"]),
+            Err(ParseError::Settings(SettingsParseError::MissingKey {
+                subcommand: "get",
+            }))
+        );
+        assert_eq!(
+            parse_args(["settings", "list", "extra"]),
+            Err(ParseError::Settings(
+                SettingsParseError::UnexpectedArguments {
+                    subcommand: "list",
+                    arguments: vec!["extra".to_string()],
+                }
+            ))
+        );
+    }
+
+    #[test]
     fn usage_mentions_all_commands() {
         let help = usage("lg-buddy");
 
@@ -422,6 +495,7 @@ mod tests {
             "monitor",
             "lifecycle",
             "detect-backend",
+            "settings",
         ] {
             assert!(
                 help.contains(command),

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -9,6 +9,7 @@ pub mod runtime_phase;
 pub mod screen;
 pub mod session;
 pub mod session_bus;
+pub mod settings;
 pub mod sources;
 pub mod state;
 pub mod tv;

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -2382,7 +2382,7 @@ mod tests {
 
     impl WakeOnLanSender for RecordingWakeOnLanSender {
         fn send_magic_packet(&self, mac: &MacAddress) -> Result<(), WakeOnLanError> {
-            self.calls.borrow_mut().push(mac.clone());
+            self.calls.borrow_mut().push(*mac);
             Ok(())
         }
     }

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -1666,7 +1666,7 @@ mod tests {
 
     impl WakeOnLanSender for RecordingWakeOnLanSender {
         fn send_magic_packet(&self, mac: &MacAddress) -> Result<(), WakeOnLanError> {
-            self.calls.borrow_mut().push(mac.clone());
+            self.calls.borrow_mut().push(*mac);
             Ok(())
         }
     }

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -17,7 +17,8 @@ use crate::backend::{
 };
 use crate::commands::run_system_resume;
 use crate::config::{
-    load_config, resolve_config_path_from_env, ScreenBackend, DEFAULT_IDLE_TIMEOUT,
+    load_config, normalize_idle_timeout_secs, parse_idle_timeout_secs,
+    resolve_config_path_from_env, ScreenBackend, DEFAULT_IDLE_TIMEOUT,
 };
 use crate::events::{EventSource, RuntimeEvent};
 use crate::lifecycle::LifecycleEvent;
@@ -592,27 +593,20 @@ fn resolve_idle_timeout_secs() -> u64 {
     normalize_idle_timeout_secs(
         std::env::var("LG_BUDDY_IDLE_TIMEOUT")
             .ok()
-            .and_then(|value| value.parse::<u64>().ok())
+            .and_then(|value| parse_idle_timeout_secs(&value))
             .or_else(|| {
                 let path = resolve_config_path_from_env().ok()?;
                 load_config(&path)
                     .ok()
                     .map(|config| config.screen_idle_timeout)
             })
-            .unwrap_or(DEFAULT_IDLE_TIMEOUT),
+            .map(u128::from)
+            .unwrap_or(u128::from(DEFAULT_IDLE_TIMEOUT)),
     )
 }
 
 fn resolve_idle_timeout_ms() -> u64 {
     resolve_idle_timeout_secs().saturating_mul(1000)
-}
-
-fn normalize_idle_timeout_secs(idle_timeout_secs: u64) -> u64 {
-    if idle_timeout_secs == 0 {
-        DEFAULT_IDLE_TIMEOUT
-    } else {
-        idle_timeout_secs
-    }
 }
 
 fn resolve_gnome_monitor_test_timeout() -> Option<Duration> {
@@ -1741,6 +1735,10 @@ system_sleep_wake_policy={policy}
             crate::config::DEFAULT_IDLE_TIMEOUT
         );
         assert_eq!(normalize_idle_timeout_secs(180), 180);
+        assert_eq!(
+            normalize_idle_timeout_secs(u128::from(crate::config::MAX_IDLE_TIMEOUT) + 1),
+            crate::config::MAX_IDLE_TIMEOUT
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -52,6 +52,7 @@ const GAMEPAD_ACTIVITY_RECONCILE_INTERVAL: Duration = Duration::from_secs(300);
 const GAMEPAD_ACTIVITY_SEND_INTERVAL: Duration = Duration::from_millis(500);
 const LOGIND_LIFECYCLE_PROCESS_INTERVAL: Duration = Duration::from_secs(5);
 const GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV: &str = "LG_BUDDY_GNOME_MONITOR_TEST_TIMEOUT_SECS";
+const GAMEPAD_ACTIVITY_SOURCE_ENV: &str = "LG_BUDDY_GAMEPAD_ACTIVITY_SOURCE";
 const GAMEPAD_ACTIVITY_TEST_AFTER_SECS_ENV: &str = "LG_BUDDY_GAMEPAD_ACTIVITY_TEST_AFTER_SECS";
 
 pub trait SessionActionExecutor {
@@ -610,19 +611,44 @@ fn spawn_gnome_monitor_thread(
     })
 }
 
-fn spawn_gamepad_activity_thread(sender: mpsc::Sender<RunnerMessage>) -> GamepadActivityThread {
+fn spawn_gamepad_activity_thread(
+    sender: mpsc::Sender<RunnerMessage>,
+) -> Option<GamepadActivityThread> {
     let stop = Arc::new(AtomicBool::new(false));
     let thread_stop = Arc::clone(&stop);
-    let handle = match resolve_gamepad_activity_test_delay() {
-        Some(delay) => thread::spawn(move || {
+    let handle = match resolve_gamepad_activity_source_mode() {
+        GamepadActivitySourceMode::Disabled => return None,
+        GamepadActivitySourceMode::Synthetic(delay) => thread::spawn(move || {
             run_synthetic_gamepad_activity_process(sender, thread_stop, delay)
         }),
-        None => thread::spawn(move || run_gamepad_activity_process(sender, thread_stop)),
+        GamepadActivitySourceMode::System => {
+            thread::spawn(move || run_gamepad_activity_process(sender, thread_stop))
+        }
     };
 
-    GamepadActivityThread {
+    Some(GamepadActivityThread {
         stop,
         handle: Some(handle),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GamepadActivitySourceMode {
+    System,
+    Synthetic(Duration),
+    Disabled,
+}
+
+fn resolve_gamepad_activity_source_mode() -> GamepadActivitySourceMode {
+    match std::env::var(GAMEPAD_ACTIVITY_SOURCE_ENV).ok().as_deref() {
+        Some("disabled" | "none" | "off") => GamepadActivitySourceMode::Disabled,
+        Some("synthetic" | "test") => GamepadActivitySourceMode::Synthetic(
+            resolve_gamepad_activity_test_delay().unwrap_or(Duration::ZERO),
+        ),
+        Some("system" | "real") => GamepadActivitySourceMode::System,
+        Some(_) | None => resolve_gamepad_activity_test_delay()
+            .map(GamepadActivitySourceMode::Synthetic)
+            .unwrap_or(GamepadActivitySourceMode::System),
     }
 }
 
@@ -1666,6 +1692,47 @@ system_sleep_wake_policy={policy}
         assert_eq!(super::resolve_gnome_monitor_test_timeout(), None);
 
         std::env::remove_var(super::GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV);
+    }
+
+    #[test]
+    fn gamepad_activity_source_mode_is_explicitly_selectable() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV);
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_TEST_AFTER_SECS_ENV);
+        assert_eq!(
+            super::resolve_gamepad_activity_source_mode(),
+            super::GamepadActivitySourceMode::System
+        );
+
+        std::env::set_var(super::GAMEPAD_ACTIVITY_TEST_AFTER_SECS_ENV, "0.25");
+        assert_eq!(
+            super::resolve_gamepad_activity_source_mode(),
+            super::GamepadActivitySourceMode::Synthetic(Duration::from_millis(250))
+        );
+
+        std::env::set_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV, "disabled");
+        assert_eq!(
+            super::resolve_gamepad_activity_source_mode(),
+            super::GamepadActivitySourceMode::Disabled
+        );
+
+        std::env::set_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV, "synthetic");
+        assert_eq!(
+            super::resolve_gamepad_activity_source_mode(),
+            super::GamepadActivitySourceMode::Synthetic(Duration::from_millis(250))
+        );
+
+        std::env::set_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV, "system");
+        assert_eq!(
+            super::resolve_gamepad_activity_source_mode(),
+            super::GamepadActivitySourceMode::System
+        );
+
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV);
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_TEST_AFTER_SECS_ENV);
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -1495,9 +1495,9 @@ mod tests {
             path,
             format!(
                 "\
-tv_ip=192.168.1.42
-tv_mac=aa:bb:cc:dd:ee:ff
-input=HDMI_1
+tvs_primary_ip=192.168.1.42
+tvs_primary_mac=aa:bb:cc:dd:ee:ff
+tvs_primary_input=HDMI_1
 system_sleep_wake_policy={policy}
 "
             ),

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -51,7 +51,11 @@ const GAMEPAD_ACTIVITY_REFRESH_RETRY_INTERVAL: Duration = Duration::from_secs(2)
 const GAMEPAD_ACTIVITY_RECONCILE_INTERVAL: Duration = Duration::from_secs(300);
 const GAMEPAD_ACTIVITY_SEND_INTERVAL: Duration = Duration::from_millis(500);
 const LOGIND_LIFECYCLE_PROCESS_INTERVAL: Duration = Duration::from_secs(5);
+const LOGIND_LIFECYCLE_TEST_PROCESS_INTERVAL: Duration = Duration::from_millis(50);
 const GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV: &str = "LG_BUDDY_GNOME_MONITOR_TEST_TIMEOUT_SECS";
+const LIFECYCLE_MONITOR_TEST_TIMEOUT_SECS_ENV: &str =
+    "LG_BUDDY_LIFECYCLE_MONITOR_TEST_TIMEOUT_SECS";
+const LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV: &str = "LG_BUDDY_LIFECYCLE_MONITOR_TEST_EVENT_LIMIT";
 const GAMEPAD_ACTIVITY_SOURCE_ENV: &str = "LG_BUDDY_GAMEPAD_ACTIVITY_SOURCE";
 const GAMEPAD_ACTIVITY_TEST_AFTER_SECS_ENV: &str = "LG_BUDDY_GAMEPAD_ACTIVITY_TEST_AFTER_SECS";
 
@@ -294,15 +298,6 @@ pub fn run_monitor<W: Write>(writer: &mut W) -> Result<(), RunError> {
 
 pub fn run_lifecycle_monitor<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-    let config = load_config(&config_path).map_err(RunError::Config)?;
-    if !config.system_sleep_wake_policy.is_enabled() {
-        writeln!(
-            writer,
-            "LG Buddy Lifecycle: system sleep/wake handling is disabled by config."
-        )?;
-        return Ok(());
-    }
-
     run_lifecycle_monitor_with_executor(writer, RuntimeActionExecutor, &config_path).map_err(
         |err| match err {
             SessionRunnerError::BackendSelection(err) => RunError::BackendSelection(err),
@@ -341,44 +336,71 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
         "LG Buddy Lifecycle: Using logind system lifecycle source."
     )?;
 
+    let started = Instant::now();
+    let test_timeout = resolve_lifecycle_monitor_test_timeout();
+    let test_event_limit = resolve_lifecycle_monitor_test_event_limit();
+    let mut lifecycle_events_seen = 0usize;
+
     loop {
-        if !lifecycle_policy_enabled_from_config(config_path)? {
-            writeln!(
-                writer,
-                "LG Buddy Lifecycle: system sleep/wake handling is disabled by config; stopping lifecycle monitor."
-            )?;
-            return Ok(());
+        if let Some(timeout) = test_timeout {
+            if started.elapsed() >= timeout {
+                return Ok(());
+            }
         }
 
-        let Some(signal) = bus
-            .process(LOGIND_LIFECYCLE_PROCESS_INTERVAL)
-            .map_err(|err| SessionRunnerError::Failed {
-                backend: ScreenBackend::Auto,
-                message: format!("logind lifecycle bus processing failed: {err}"),
-            })?
+        let mut process_timeout = LOGIND_LIFECYCLE_PROCESS_INTERVAL;
+        if let Some(timeout) = test_timeout {
+            process_timeout = process_timeout
+                .min(LOGIND_LIFECYCLE_TEST_PROCESS_INTERVAL)
+                .min(timeout.saturating_sub(started.elapsed()));
+        }
+
+        let Some(signal) =
+            bus.process(process_timeout)
+                .map_err(|err| SessionRunnerError::Failed {
+                    backend: ScreenBackend::Auto,
+                    message: format!("logind lifecycle bus processing failed: {err}"),
+                })?
         else {
             continue;
         };
 
-        match map_prepare_for_sleep_signal(&signal) {
-            Some(event)
-                if LifecycleEvent::from_runtime_event(event)
-                    == Some(LifecycleEvent::MachineResumed) =>
-            {
-                if !lifecycle_policy_enabled_from_config(config_path)? {
+        let Some(event) = map_prepare_for_sleep_signal(&signal) else {
+            continue;
+        };
+
+        if !lifecycle_policy_enabled_from_config(config_path)? {
+            writeln!(
+                writer,
+                "LG Buddy Lifecycle: system sleep/wake handling is disabled by config; skipping lifecycle event."
+            )?;
+            lifecycle_events_seen += 1;
+            if test_event_limit.is_some_and(|limit| lifecycle_events_seen >= limit) {
+                return Ok(());
+            }
+            continue;
+        }
+
+        match LifecycleEvent::from_runtime_event(event) {
+            Some(LifecycleEvent::MachineResumed) => {
+                if lifecycle_policy_enabled_from_config(config_path)? {
+                    dispatcher.dispatch_lifecycle_event(writer, event)?;
+                } else {
                     writeln!(
                         writer,
-                        "LG Buddy Lifecycle: system sleep/wake handling is disabled by config; stopping lifecycle monitor."
+                        "LG Buddy Lifecycle: system sleep/wake handling is disabled by config; skipping lifecycle event."
                     )?;
-                    return Ok(());
                 }
-
-                dispatcher.dispatch_lifecycle_event(writer, event)?;
             }
-            Some(event) => {
+            Some(_) => {
                 dispatcher.dispatch_lifecycle_event(writer, event)?;
             }
             None => {}
+        }
+
+        lifecycle_events_seen += 1;
+        if test_event_limit.is_some_and(|limit| lifecycle_events_seen >= limit) {
+            return Ok(());
         }
     }
 }
@@ -599,6 +621,21 @@ fn resolve_gnome_monitor_test_timeout() -> Option<Duration> {
         .and_then(|value| value.parse::<f64>().ok())
         .filter(|value| value.is_finite() && *value > 0.0)
         .and_then(|value| Duration::try_from_secs_f64(value).ok())
+}
+
+fn resolve_lifecycle_monitor_test_timeout() -> Option<Duration> {
+    std::env::var(LIFECYCLE_MONITOR_TEST_TIMEOUT_SECS_ENV)
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .and_then(|value| Duration::try_from_secs_f64(value).ok())
+}
+
+fn resolve_lifecycle_monitor_test_event_limit() -> Option<usize> {
+    std::env::var(LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
 }
 
 fn spawn_gnome_monitor_thread(
@@ -1566,6 +1603,11 @@ system_sleep_wake_policy={policy}
 
     #[test]
     fn lifecycle_monitor_treats_logind_sleep_as_diagnostic_and_dispatches_resume() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::env::set_var(super::LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV, "2");
+
         let config_path = unique_config_path("lifecycle-monitor");
         write_lifecycle_config(&config_path, "enabled");
         let executor = FakeActionExecutor {
@@ -1584,7 +1626,7 @@ system_sleep_wake_policy={policy}
         let mut output = Vec::new();
 
         run_lifecycle_monitor_with_bus(&mut output, executor, &config_path, &mut bus)
-            .expect("lifecycle loop exits cleanly after config disables it");
+            .expect("lifecycle loop exits cleanly after test timeout");
 
         let output = String::from_utf8(output).expect("utf8");
         assert!(output.contains("Using logind system lifecycle source"));
@@ -1592,10 +1634,44 @@ system_sleep_wake_policy={policy}
         assert!(output.contains("diagnostic only"));
         assert!(output.contains("System resumed from sleep"));
         assert!(output.contains("after-resume output"));
-        assert!(output.contains("stopping lifecycle monitor"));
+        assert!(!output.contains("stopping lifecycle monitor"));
         assert_eq!(bus.signal_match_count, 1);
-        assert_eq!(bus.disable_config_after_signals, None);
+        assert!(bus.disable_config_after_signals.is_some());
         fs::remove_file(config_path).expect("remove lifecycle test config");
+        std::env::remove_var(super::LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV);
+    }
+
+    #[test]
+    fn lifecycle_monitor_skips_events_while_policy_is_disabled() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::env::set_var(super::LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV, "1");
+
+        let config_path = unique_config_path("lifecycle-disabled");
+        write_lifecycle_config(&config_path, "disabled");
+        let executor = FakeActionExecutor {
+            after_resume_output: "after-resume output\n".to_string(),
+            ..FakeActionExecutor::default()
+        };
+        let mut bus = FakeLifecycleBus {
+            signals: VecDeque::from([prepare_for_sleep_signal(false)]),
+            signal_match_count: 0,
+            disable_config_after_signals: None,
+        };
+        let mut output = Vec::new();
+
+        run_lifecycle_monitor_with_bus(&mut output, executor, &config_path, &mut bus)
+            .expect("lifecycle loop exits cleanly after test event limit");
+
+        let output = String::from_utf8(output).expect("utf8");
+        assert!(output.contains("Using logind system lifecycle source"));
+        assert!(output.contains("skipping lifecycle event"));
+        assert!(!output.contains("System resumed from sleep"));
+        assert!(!output.contains("after-resume output"));
+        assert_eq!(bus.signal_match_count, 1);
+        fs::remove_file(config_path).expect("remove lifecycle test config");
+        std::env::remove_var(super::LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV);
     }
 
     #[test]

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::Command as ProcessCommand;
+use std::process::{Command as ProcessCommand, Stdio};
 
 use crate::config::{
     parse_config_entries, resolve_config_path, resolve_config_path_from_env, ConfigPathError,
@@ -673,6 +673,8 @@ impl SystemdUserServiceController {
         ProcessCommand::new(&self.command_path)
             .arg("--user")
             .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status()
             .map(|status| status.success())
     }

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -324,7 +324,7 @@ impl SettingsFormatter {
                 writer,
                 "{}={} ({}, {}, ops: {})",
                 setting.key_name(),
-                format_effective_value(*setting),
+                format_effective_value(setting),
                 setting.source().as_str(),
                 setting.definition().mutability().as_str(),
                 format_operations(setting.definition().supported_operations(), ",")
@@ -345,7 +345,7 @@ impl SettingsFormatter {
                 writeln!(writer).map_err(output_error)?;
             }
 
-            self.write_single_description(writer, *setting)?;
+            self.write_single_description(writer, setting)?;
         }
 
         Ok(())
@@ -411,7 +411,7 @@ impl SettingsFormatter {
     fn write_single_description<W: io::Write>(
         &self,
         writer: &mut W,
-        setting: EffectiveSetting,
+        setting: &EffectiveSetting,
     ) -> Result<(), SettingsError> {
         let definition = setting.definition();
 
@@ -993,28 +993,36 @@ impl SettingsStore {
 
     pub fn effective_definition(&self, definition: &'static SettingDefinition) -> EffectiveSetting {
         let raw_value = self.reader.raw_setting_value(definition);
-        let parsed_value = raw_value.and_then(|(value, source)| {
-            definition
-                .parse_value(value)
-                .ok()
-                .map(|value| (value, source))
-        });
 
-        match (parsed_value, definition.default_value()) {
-            (Some((value, source)), _) => EffectiveSetting {
-                definition,
-                value: Some(value),
-                source,
-            },
-            (None, Some(value)) => EffectiveSetting {
+        if let Some((raw_value, source)) = raw_value {
+            return match definition.parse_value(raw_value) {
+                Ok(value) => EffectiveSetting {
+                    definition,
+                    value: Some(value),
+                    source,
+                    invalid_value: None,
+                },
+                Err(_) => EffectiveSetting {
+                    definition,
+                    value: None,
+                    source: source.invalid(),
+                    invalid_value: Some(raw_value.to_string()),
+                },
+            };
+        }
+
+        match definition.default_value() {
+            Some(value) => EffectiveSetting {
                 definition,
                 value: Some(value),
                 source: SettingSource::Default,
+                invalid_value: None,
             },
-            (None, None) => EffectiveSetting {
+            None => EffectiveSetting {
                 definition,
                 value: None,
                 source: SettingSource::Missing,
+                invalid_value: None,
             },
         }
     }
@@ -1105,43 +1113,56 @@ impl ConfigPathResolver {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct EffectiveSetting {
     definition: &'static SettingDefinition,
     value: Option<SettingValue>,
     source: SettingSource,
+    invalid_value: Option<String>,
 }
 
 impl EffectiveSetting {
-    pub fn definition(self) -> &'static SettingDefinition {
+    pub fn definition(&self) -> &'static SettingDefinition {
         self.definition
     }
 
-    pub fn key(self) -> SettingKey<'static> {
+    pub fn key(&self) -> SettingKey<'static> {
         self.definition.key()
     }
 
-    pub fn key_name(self) -> &'static str {
+    pub fn key_name(&self) -> &'static str {
         self.definition.key_name()
     }
 
-    pub fn storage_key(self) -> &'static str {
+    pub fn storage_key(&self) -> &'static str {
         self.definition.storage_key()
     }
 
-    pub fn value(self) -> Option<SettingValue> {
+    pub fn value(&self) -> Option<SettingValue> {
         self.value
     }
 
-    pub fn required_value(self) -> Result<SettingValue, SettingsError> {
+    pub fn required_value(&self) -> Result<SettingValue, SettingsError> {
+        if let Some(value) = self.invalid_value() {
+            return Err(SettingsError::InvalidValue {
+                key: self.key_name().to_string(),
+                value: value.to_string(),
+                expected: self.definition.value_type().expected(),
+            });
+        }
+
         self.value
             .ok_or_else(|| SettingsError::MissingRequiredSetting {
                 key: self.key_name().to_string(),
             })
     }
 
-    pub fn source(self) -> SettingSource {
+    pub fn source(&self) -> SettingSource {
         self.source
+    }
+
+    pub fn invalid_value(&self) -> Option<&str> {
+        self.invalid_value.as_deref()
     }
 }
 
@@ -1150,6 +1171,8 @@ pub enum SettingSource {
     Default,
     ConfigEnv,
     LegacyConfigEnv,
+    InvalidConfigEnv,
+    InvalidLegacyConfigEnv,
     Missing,
 }
 
@@ -1159,7 +1182,17 @@ impl SettingSource {
             Self::Default => "default",
             Self::ConfigEnv => "config.env",
             Self::LegacyConfigEnv => "legacy config.env",
+            Self::InvalidConfigEnv => "invalid config.env",
+            Self::InvalidLegacyConfigEnv => "invalid legacy config.env",
             Self::Missing => "missing",
+        }
+    }
+
+    fn invalid(self) -> Self {
+        match self {
+            Self::ConfigEnv => Self::InvalidConfigEnv,
+            Self::LegacyConfigEnv => Self::InvalidLegacyConfigEnv,
+            other => other,
         }
     }
 }
@@ -1894,7 +1927,11 @@ fn format_operations(operations: &[SettingOperation], separator: &str) -> String
         .join(separator)
 }
 
-fn format_effective_value(setting: EffectiveSetting) -> String {
+fn format_effective_value(setting: &EffectiveSetting) -> String {
+    if let Some(value) = setting.invalid_value() {
+        return format!("<invalid: {value}>");
+    }
+
     setting
         .value()
         .map(|value| value.to_string())
@@ -2279,6 +2316,41 @@ system.sleep_wake_policy=disabled (config.env, read-write, ops: get,describe,set
             }
         );
         assert!(output.is_empty());
+    }
+
+    #[test]
+    fn settings_runner_rejects_invalid_config_value_on_get() {
+        let store =
+            ConfigEnvReader::parse("/tmp/config.env", "tvs_primary_ip=not-an-ip\n").into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        let err = runner
+            .run(SettingsCommand::Get("tv.ip".to_string()), &mut output)
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            SettingsError::InvalidValue {
+                key: "tv.ip".to_string(),
+                value: "not-an-ip".to_string(),
+                expected: "an IPv4 address".to_string(),
+            }
+        );
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn settings_runner_lists_invalid_values_from_config() {
+        let store =
+            ConfigEnvReader::parse("/tmp/config.env", "tvs_primary_ip=not-an-ip\n").into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        runner.run(SettingsCommand::List, &mut output).unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("tv.ip=<invalid: not-an-ip> (invalid config.env"));
     }
 
     #[test]
@@ -2742,7 +2814,7 @@ tvs_primary_ip=192.0.2.43
     }
 
     #[test]
-    fn settings_store_uses_defaults_for_invalid_optional_values() {
+    fn settings_store_preserves_invalid_optional_values() {
         let store = ConfigEnvReader::parse(
             "/tmp/config.env",
             "\
@@ -2754,19 +2826,39 @@ tvs_primary_ip=192.0.2.43
         .into_store();
 
         let backend = store.effective_by_name("screen.backend").unwrap();
-        assert_eq!(backend.value(), Some(SettingValue::Enum("auto")));
-        assert_eq!(backend.source(), SettingSource::Default);
+        assert_eq!(backend.value(), None);
+        assert_eq!(backend.source(), SettingSource::InvalidConfigEnv);
+        assert_eq!(backend.invalid_value(), Some("not-a-backend"));
 
         let idle_timeout = store.effective_by_name("screen.idle_timeout").unwrap();
-        assert_eq!(idle_timeout.value(), Some(SettingValue::Integer(300)));
-        assert_eq!(idle_timeout.source(), SettingSource::Default);
+        assert_eq!(idle_timeout.value(), None);
+        assert_eq!(idle_timeout.source(), SettingSource::InvalidConfigEnv);
+        assert_eq!(idle_timeout.invalid_value(), Some("not-a-number"));
 
         let restore_policy = store.effective_by_name("screen.restore_policy").unwrap();
+        assert_eq!(restore_policy.value(), None);
+        assert_eq!(restore_policy.source(), SettingSource::InvalidConfigEnv);
+        assert_eq!(restore_policy.invalid_value(), Some("not-a-policy"));
+    }
+
+    #[test]
+    fn settings_store_preserves_invalid_required_values() {
+        let store =
+            ConfigEnvReader::parse("/tmp/config.env", "tvs_primary_ip=not-an-ip\n").into_store();
+
+        let tv_ip = store.effective_by_name("tv.ip").unwrap();
+
+        assert_eq!(tv_ip.value(), None);
+        assert_eq!(tv_ip.source(), SettingSource::InvalidConfigEnv);
+        assert_eq!(tv_ip.invalid_value(), Some("not-an-ip"));
         assert_eq!(
-            restore_policy.value(),
-            Some(SettingValue::Enum("conservative"))
+            tv_ip.required_value().unwrap_err(),
+            SettingsError::InvalidValue {
+                key: "tv.ip".to_string(),
+                value: "not-an-ip".to_string(),
+                expected: "an IPv4 address".to_string(),
+            }
         );
-        assert_eq!(restore_policy.source(), SettingSource::Default);
     }
 
     #[test]
@@ -2849,10 +2941,7 @@ tvs_primary_ip=192.0.2.43
 
         let settings = store.all_effective();
         let keys: Vec<&str> = settings.iter().map(|setting| setting.key_name()).collect();
-        let values: Vec<String> = settings
-            .iter()
-            .map(|setting| format_effective_value(*setting))
-            .collect();
+        let values: Vec<String> = settings.iter().map(format_effective_value).collect();
         let sources: Vec<SettingSource> = settings.iter().map(|setting| setting.source()).collect();
 
         assert_eq!(

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -9,6 +9,8 @@ use crate::config::{
     ConfigPathSources, DEFAULT_IDLE_TIMEOUT,
 };
 
+const SETTINGS_SUBCOMMANDS: &[&str] = &["list", "describe", "get", "set", "unset"];
+
 const READ_WRITE_OPERATIONS: &[SettingOperation] = &[
     SettingOperation::Get,
     SettingOperation::Describe,
@@ -86,6 +88,332 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
 pub static SETTINGS_REGISTRY: SettingsRegistry = SettingsRegistry {
     definitions: SETTING_DEFINITIONS,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsCommand {
+    List,
+    Describe(Option<String>),
+    Get(String),
+    Set { key: String, value: String },
+    Unset(String),
+}
+
+impl SettingsCommand {
+    pub fn parse<I, S>(args: I) -> Result<Self, SettingsParseError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut args = args.into_iter();
+        let Some(subcommand) = args.next() else {
+            return Err(SettingsParseError::MissingSubcommand);
+        };
+
+        match subcommand.as_ref() {
+            "list" => {
+                let extra_args = collect_args(args);
+                if extra_args.is_empty() {
+                    Ok(Self::List)
+                } else {
+                    Err(SettingsParseError::UnexpectedArguments {
+                        subcommand: "list",
+                        arguments: extra_args,
+                    })
+                }
+            }
+            "describe" => {
+                let key = args.next().map(|arg| arg.as_ref().to_string());
+                let extra_args = collect_args(args);
+                if extra_args.is_empty() {
+                    Ok(Self::Describe(key))
+                } else {
+                    Err(SettingsParseError::UnexpectedArguments {
+                        subcommand: "describe",
+                        arguments: extra_args,
+                    })
+                }
+            }
+            "get" => {
+                let key = args
+                    .next()
+                    .ok_or(SettingsParseError::MissingKey { subcommand: "get" })?;
+                let extra_args = collect_args(args);
+                if extra_args.is_empty() {
+                    Ok(Self::Get(key.as_ref().to_string()))
+                } else {
+                    Err(SettingsParseError::UnexpectedArguments {
+                        subcommand: "get",
+                        arguments: extra_args,
+                    })
+                }
+            }
+            "set" => {
+                let key = args
+                    .next()
+                    .ok_or(SettingsParseError::MissingKey { subcommand: "set" })?;
+                let value = args
+                    .next()
+                    .ok_or(SettingsParseError::MissingValue { subcommand: "set" })?;
+                let extra_args = collect_args(args);
+                if extra_args.is_empty() {
+                    Ok(Self::Set {
+                        key: key.as_ref().to_string(),
+                        value: value.as_ref().to_string(),
+                    })
+                } else {
+                    Err(SettingsParseError::UnexpectedArguments {
+                        subcommand: "set",
+                        arguments: extra_args,
+                    })
+                }
+            }
+            "unset" => {
+                let key = args.next().ok_or(SettingsParseError::MissingKey {
+                    subcommand: "unset",
+                })?;
+                let extra_args = collect_args(args);
+                if extra_args.is_empty() {
+                    Ok(Self::Unset(key.as_ref().to_string()))
+                } else {
+                    Err(SettingsParseError::UnexpectedArguments {
+                        subcommand: "unset",
+                        arguments: extra_args,
+                    })
+                }
+            }
+            other => Err(SettingsParseError::UnknownSubcommand(other.to_string())),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Describe(_) => "describe",
+            Self::Get(_) => "get",
+            Self::Set { .. } => "set",
+            Self::Unset(_) => "unset",
+        }
+    }
+
+    pub fn is_mutation(&self) -> bool {
+        matches!(self, Self::Set { .. } | Self::Unset(_))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsParseError {
+    MissingSubcommand,
+    UnknownSubcommand(String),
+    MissingKey {
+        subcommand: &'static str,
+    },
+    MissingValue {
+        subcommand: &'static str,
+    },
+    UnexpectedArguments {
+        subcommand: &'static str,
+        arguments: Vec<String>,
+    },
+}
+
+impl fmt::Display for SettingsParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingSubcommand => {
+                write!(
+                    f,
+                    "missing settings command; expected one of {}",
+                    SETTINGS_SUBCOMMANDS.join(", ")
+                )
+            }
+            Self::UnknownSubcommand(subcommand) => {
+                write!(f, "unknown settings command `{subcommand}`")
+            }
+            Self::MissingKey { subcommand } => {
+                write!(f, "missing setting key for `settings {subcommand}`")
+            }
+            Self::MissingValue { subcommand } => {
+                write!(f, "missing setting value for `settings {subcommand}`")
+            }
+            Self::UnexpectedArguments {
+                subcommand,
+                arguments,
+            } => {
+                write!(
+                    f,
+                    "unexpected arguments for `settings {subcommand}`: {}",
+                    arguments.join(" ")
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SettingsParseError {}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SettingsFormatter;
+
+impl SettingsFormatter {
+    pub fn write_get<W: io::Write>(
+        &self,
+        writer: &mut W,
+        setting: EffectiveSetting,
+    ) -> Result<(), SettingsError> {
+        writeln!(writer, "{}", setting.value()).map_err(output_error)
+    }
+
+    pub fn write_list<W: io::Write>(
+        &self,
+        writer: &mut W,
+        settings: &[EffectiveSetting],
+    ) -> Result<(), SettingsError> {
+        for setting in settings {
+            writeln!(
+                writer,
+                "{}={} ({}, {}, ops: {})",
+                setting.key_name(),
+                setting.value(),
+                setting.source().as_str(),
+                setting.definition().mutability().as_str(),
+                format_operations(setting.definition().supported_operations(), ",")
+            )
+            .map_err(output_error)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn write_describe<W: io::Write>(
+        &self,
+        writer: &mut W,
+        settings: &[EffectiveSetting],
+    ) -> Result<(), SettingsError> {
+        for (index, setting) in settings.iter().enumerate() {
+            if index > 0 {
+                writeln!(writer).map_err(output_error)?;
+            }
+
+            self.write_single_description(writer, *setting)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_single_description<W: io::Write>(
+        &self,
+        writer: &mut W,
+        setting: EffectiveSetting,
+    ) -> Result<(), SettingsError> {
+        let definition = setting.definition();
+
+        writeln!(writer, "{}", setting.key_name()).map_err(output_error)?;
+        writeln!(writer, "  storage key: {}", setting.storage_key()).map_err(output_error)?;
+        writeln!(writer, "  type: {}", definition.value_type().as_str()).map_err(output_error)?;
+        writeln!(writer, "  current: {}", setting.value()).map_err(output_error)?;
+        writeln!(writer, "  source: {}", setting.source().as_str()).map_err(output_error)?;
+        writeln!(writer, "  default: {}", definition.default_value()).map_err(output_error)?;
+        writeln!(writer, "  mutability: {}", definition.mutability().as_str())
+            .map_err(output_error)?;
+        writeln!(
+            writer,
+            "  supported operations: {}",
+            format_operations(definition.supported_operations(), ", ")
+        )
+        .map_err(output_error)?;
+
+        match definition.value_type() {
+            SettingType::Enum(enum_type) => {
+                writeln!(
+                    writer,
+                    "  allowed values: {}",
+                    enum_type.values().join(", ")
+                )
+                .map_err(output_error)?;
+                if !enum_type.aliases().is_empty() {
+                    writeln!(writer, "  aliases: {}", format_aliases(enum_type.aliases()))
+                        .map_err(output_error)?;
+                }
+            }
+            SettingType::Integer(integer_type) => {
+                writeln!(
+                    writer,
+                    "  range: {}..={}",
+                    integer_type.min(),
+                    integer_type.max()
+                )
+                .map_err(output_error)?;
+            }
+        }
+
+        writeln!(writer, "  apply: {}", definition.apply_strategy().as_str())
+            .map_err(output_error)?;
+        writeln!(writer, "  description: {}", definition.description()).map_err(output_error)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SettingsCommandRunner {
+    store: SettingsStore,
+    formatter: SettingsFormatter,
+}
+
+impl SettingsCommandRunner {
+    pub fn new(store: SettingsStore) -> Self {
+        Self {
+            store,
+            formatter: SettingsFormatter,
+        }
+    }
+
+    pub fn run<W: io::Write>(
+        &self,
+        command: SettingsCommand,
+        writer: &mut W,
+    ) -> Result<(), SettingsError> {
+        match command {
+            SettingsCommand::List => {
+                let settings = self.store.all_effective();
+                self.formatter.write_list(writer, &settings)
+            }
+            SettingsCommand::Describe(key) => match key {
+                Some(key) => {
+                    let setting = self.store.effective_by_name(&key)?;
+                    self.formatter.write_describe(writer, &[setting])
+                }
+                None => {
+                    let settings = self.store.all_effective();
+                    self.formatter.write_describe(writer, &settings)
+                }
+            },
+            SettingsCommand::Get(key) => {
+                let setting = self.store.effective_by_name(&key)?;
+                self.formatter.write_get(writer, setting)
+            }
+            SettingsCommand::Set { .. } => {
+                Err(SettingsError::WriteCommandUnavailable { command: "set" })
+            }
+            SettingsCommand::Unset(_) => {
+                Err(SettingsError::WriteCommandUnavailable { command: "unset" })
+            }
+        }
+    }
+}
+
+pub fn run_settings_command<W: io::Write>(
+    command: SettingsCommand,
+    writer: &mut W,
+) -> Result<(), SettingsError> {
+    if command.is_mutation() {
+        return Err(SettingsError::WriteCommandUnavailable {
+            command: command.as_str(),
+        });
+    }
+
+    let store = SettingsStore::load_from_env()?;
+    SettingsCommandRunner::new(store).run(command, writer)
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SettingsStore {
@@ -535,6 +863,13 @@ impl SettingType {
             Self::Integer(integer_type) => integer_type.expected(),
         }
     }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Enum(_) => "enum",
+            Self::Integer(_) => "integer",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -773,6 +1108,7 @@ pub enum SettingsError {
         kind: io::ErrorKind,
         message: String,
     },
+    WriteOutput(String),
     InvalidKey {
         key: String,
         reason: &'static str,
@@ -786,6 +1122,9 @@ pub enum SettingsError {
     UnsupportedOperation {
         key: String,
         operation: SettingOperation,
+    },
+    WriteCommandUnavailable {
+        command: &'static str,
     },
     RegistryInvariant(String),
 }
@@ -801,6 +1140,7 @@ impl fmt::Display for SettingsError {
                     path.display()
                 )
             }
+            Self::WriteOutput(message) => write!(f, "{message}"),
             Self::InvalidKey { key, reason } => {
                 write!(f, "invalid setting key `{key}`: {reason}")
             }
@@ -820,12 +1160,62 @@ impl fmt::Display for SettingsError {
                     operation.as_str()
                 )
             }
+            Self::WriteCommandUnavailable { command } => {
+                write!(
+                    f,
+                    "`settings {command}` is not implemented yet; no changes were made"
+                )
+            }
             Self::RegistryInvariant(message) => write!(f, "{message}"),
         }
     }
 }
 
-impl std::error::Error for SettingsError {}
+impl std::error::Error for SettingsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ConfigPath(err) => Some(err),
+            Self::ReadConfig { .. }
+            | Self::WriteOutput(_)
+            | Self::InvalidKey { .. }
+            | Self::UnknownKey(_)
+            | Self::InvalidValue { .. }
+            | Self::UnsupportedOperation { .. }
+            | Self::WriteCommandUnavailable { .. }
+            | Self::RegistryInvariant(_) => None,
+        }
+    }
+}
+
+fn collect_args<I, S>(args: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter()
+        .map(|arg| arg.as_ref().to_string())
+        .collect()
+}
+
+fn format_operations(operations: &[SettingOperation], separator: &str) -> String {
+    operations
+        .iter()
+        .map(|operation| operation.as_str())
+        .collect::<Vec<_>>()
+        .join(separator)
+}
+
+fn format_aliases(aliases: &[SettingAlias]) -> String {
+    aliases
+        .iter()
+        .map(|alias| format!("{} -> {}", alias.from(), alias.to()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn output_error(err: io::Error) -> SettingsError {
+    SettingsError::WriteOutput(err.to_string())
+}
 
 fn validate_setting_key(value: &str) -> Result<(), &'static str> {
     if value.is_empty() {
@@ -883,8 +1273,8 @@ fn validate_storage_key(value: &str) -> Result<(), &'static str> {
 mod tests {
     use super::{
         ApplyStrategy, ConfigEnvReader, ConfigPathResolver, SettingKey, SettingMutability,
-        SettingOperation, SettingSource, SettingType, SettingValue, SettingsError, SettingsStore,
-        SETTINGS_REGISTRY,
+        SettingOperation, SettingSource, SettingType, SettingValue, SettingsCommand,
+        SettingsCommandRunner, SettingsError, SettingsParseError, SettingsStore, SETTINGS_REGISTRY,
     };
     use crate::config::ConfigPathSources;
     use std::fs;
@@ -932,6 +1322,194 @@ mod tests {
                 ("system.sleep_wake_policy", "system_sleep_wake_policy"),
             ]
         );
+    }
+
+    #[test]
+    fn settings_command_parser_accepts_supported_commands() {
+        assert_eq!(SettingsCommand::parse(["list"]), Ok(SettingsCommand::List));
+        assert_eq!(
+            SettingsCommand::parse(["describe"]),
+            Ok(SettingsCommand::Describe(None))
+        );
+        assert_eq!(
+            SettingsCommand::parse(["describe", "screen.backend"]),
+            Ok(SettingsCommand::Describe(Some(
+                "screen.backend".to_string()
+            )))
+        );
+        assert_eq!(
+            SettingsCommand::parse(["get", "screen.backend"]),
+            Ok(SettingsCommand::Get("screen.backend".to_string()))
+        );
+        assert_eq!(
+            SettingsCommand::parse(["set", "screen.backend", "gnome"]),
+            Ok(SettingsCommand::Set {
+                key: "screen.backend".to_string(),
+                value: "gnome".to_string(),
+            })
+        );
+        assert_eq!(
+            SettingsCommand::parse(["unset", "screen.backend"]),
+            Ok(SettingsCommand::Unset("screen.backend".to_string()))
+        );
+    }
+
+    #[test]
+    fn settings_command_parser_rejects_invalid_shapes() {
+        assert_eq!(
+            SettingsCommand::parse(Vec::<String>::new()),
+            Err(SettingsParseError::MissingSubcommand)
+        );
+        assert_eq!(
+            SettingsCommand::parse(["show"]),
+            Err(SettingsParseError::UnknownSubcommand("show".to_string()))
+        );
+        assert_eq!(
+            SettingsCommand::parse(["get"]),
+            Err(SettingsParseError::MissingKey { subcommand: "get" })
+        );
+        assert_eq!(
+            SettingsCommand::parse(["set", "screen.backend"]),
+            Err(SettingsParseError::MissingValue { subcommand: "set" })
+        );
+        assert_eq!(
+            SettingsCommand::parse(["describe", "screen.backend", "extra"]),
+            Err(SettingsParseError::UnexpectedArguments {
+                subcommand: "describe",
+                arguments: vec!["extra".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn settings_runner_lists_values_sources_mutability_and_operations() {
+        let store = ConfigEnvReader::parse(
+            "/tmp/config.env",
+            "\
+            screen_backend=gnome
+            system_sleep_wake_policy=disabled
+            ",
+        )
+        .into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        runner.run(SettingsCommand::List, &mut output).unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert_eq!(
+            output,
+            "\
+screen.backend=gnome (config.env, read-write, ops: get,describe,set,unset)
+screen.idle_timeout=300 (default, read-write, ops: get,describe,set,unset)
+screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)
+system.sleep_wake_policy=disabled (config.env, read-only, ops: get,describe)
+"
+        );
+    }
+
+    #[test]
+    fn settings_runner_get_prints_value_only() {
+        let store =
+            ConfigEnvReader::parse("/tmp/config.env", "screen_idle_timeout=450\n").into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Get("screen.idle_timeout".to_string()),
+                &mut output,
+            )
+            .unwrap();
+
+        assert_eq!(String::from_utf8(output).unwrap(), "450\n");
+    }
+
+    #[test]
+    fn settings_runner_describe_includes_metadata_and_operations() {
+        let store =
+            ConfigEnvReader::parse("/tmp/config.env", "screen_restore_policy=marker_only\n")
+                .into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Describe(Some("screen.restore_policy".to_string())),
+                &mut output,
+            )
+            .unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("screen.restore_policy\n"));
+        assert!(output.contains("  storage key: screen_restore_policy\n"));
+        assert!(output.contains("  type: enum\n"));
+        assert!(output.contains("  current: conservative\n"));
+        assert!(output.contains("  source: config.env\n"));
+        assert!(output.contains("  default: conservative\n"));
+        assert!(output.contains("  mutability: read-write\n"));
+        assert!(output.contains("  supported operations: get, describe, set, unset\n"));
+        assert!(output.contains("  allowed values: conservative, aggressive\n"));
+        assert!(output.contains("  aliases: marker_only -> conservative\n"));
+        assert!(output.contains("  apply: restart-user-screen-service\n"));
+    }
+
+    #[test]
+    fn settings_runner_describe_without_key_describes_all_settings() {
+        let store = ConfigEnvReader::parse("/tmp/config.env", "").into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        runner
+            .run(SettingsCommand::Describe(None), &mut output)
+            .unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("screen.backend\n"));
+        assert!(output.contains("screen.idle_timeout\n"));
+        assert!(output.contains("  range: 1..=86400\n"));
+        assert!(output.contains("system.sleep_wake_policy\n"));
+        assert!(output.contains("  supported operations: get, describe\n"));
+    }
+
+    #[test]
+    fn settings_runner_rejects_unknown_keys() {
+        let store = ConfigEnvReader::parse("/tmp/config.env", "").into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        let err = runner
+            .run(
+                SettingsCommand::Get("screen.unknown".to_string()),
+                &mut output,
+            )
+            .unwrap_err();
+
+        assert_eq!(err, SettingsError::UnknownKey("screen.unknown".to_string()));
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn settings_runner_rejects_write_commands_without_changes() {
+        let store = ConfigEnvReader::parse("/tmp/config.env", "").into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        let err = runner
+            .run(
+                SettingsCommand::Set {
+                    key: "screen.backend".to_string(),
+                    value: "gnome".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            SettingsError::WriteCommandUnavailable { command: "set" }
+        );
+        assert!(output.is_empty());
     }
 
     #[test]

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -1,7 +1,13 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 
-use crate::config::DEFAULT_IDLE_TIMEOUT;
+use crate::config::{
+    parse_config_entries, resolve_config_path, resolve_config_path_from_env, ConfigPathError,
+    ConfigPathSources, DEFAULT_IDLE_TIMEOUT,
+};
 
 const READ_WRITE_OPERATIONS: &[SettingOperation] = &[
     SettingOperation::Get,
@@ -80,6 +86,177 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
 pub static SETTINGS_REGISTRY: SettingsRegistry = SettingsRegistry {
     definitions: SETTING_DEFINITIONS,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsStore {
+    reader: ConfigEnvReader,
+}
+
+impl SettingsStore {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, SettingsError> {
+        ConfigEnvReader::load(path).map(Self::from_reader)
+    }
+
+    pub fn load_from_env() -> Result<Self, SettingsError> {
+        let path = ConfigPathResolver::resolve_from_env()?;
+        Self::load(path)
+    }
+
+    pub fn from_reader(reader: ConfigEnvReader) -> Self {
+        Self { reader }
+    }
+
+    pub fn path(&self) -> &Path {
+        self.reader.path()
+    }
+
+    pub fn raw_storage_value(&self, storage_key: &str) -> Option<&str> {
+        self.reader.raw_value(storage_key)
+    }
+
+    pub fn effective_by_name(&self, key: &str) -> Result<EffectiveSetting, SettingsError> {
+        self.effective(SettingKey::parse(key)?)
+    }
+
+    pub fn effective(&self, key: SettingKey<'_>) -> Result<EffectiveSetting, SettingsError> {
+        let definition = SETTINGS_REGISTRY.get(key)?;
+        Ok(self.effective_definition(definition))
+    }
+
+    pub fn effective_definition(&self, definition: &'static SettingDefinition) -> EffectiveSetting {
+        let raw_value = self.reader.raw_value(definition.storage_key());
+        let parsed_value = raw_value.and_then(|value| definition.parse_value(value).ok());
+
+        match parsed_value {
+            Some(value) => EffectiveSetting {
+                definition,
+                value,
+                source: SettingSource::ConfigEnv,
+            },
+            None => EffectiveSetting {
+                definition,
+                value: definition.default_value(),
+                source: SettingSource::Default,
+            },
+        }
+    }
+
+    pub fn all_effective(&self) -> Vec<EffectiveSetting> {
+        SETTINGS_REGISTRY
+            .all()
+            .iter()
+            .map(|definition| self.effective_definition(definition))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigEnvReader {
+    path: PathBuf,
+    entries: HashMap<String, String>,
+}
+
+impl ConfigEnvReader {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, SettingsError> {
+        let path = path.as_ref().to_path_buf();
+        match fs::read_to_string(&path) {
+            Ok(contents) => Ok(Self::parse(path, &contents)),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(Self::empty(path)),
+            Err(err) => Err(SettingsError::ReadConfig {
+                path,
+                kind: err.kind(),
+                message: err.to_string(),
+            }),
+        }
+    }
+
+    pub fn parse(path: impl Into<PathBuf>, contents: &str) -> Self {
+        Self {
+            path: path.into(),
+            entries: parse_config_entries(contents),
+        }
+    }
+
+    pub fn empty(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn raw_value(&self, storage_key: &str) -> Option<&str> {
+        self.entries.get(storage_key).map(String::as_str)
+    }
+
+    pub fn into_store(self) -> SettingsStore {
+        SettingsStore::from_reader(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConfigPathResolver;
+
+impl ConfigPathResolver {
+    pub fn resolve(sources: ConfigPathSources<'_>) -> Result<PathBuf, SettingsError> {
+        resolve_config_path(sources).map_err(SettingsError::ConfigPath)
+    }
+
+    pub fn resolve_from_env() -> Result<PathBuf, SettingsError> {
+        resolve_config_path_from_env().map_err(SettingsError::ConfigPath)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EffectiveSetting {
+    definition: &'static SettingDefinition,
+    value: SettingValue,
+    source: SettingSource,
+}
+
+impl EffectiveSetting {
+    pub fn definition(self) -> &'static SettingDefinition {
+        self.definition
+    }
+
+    pub fn key(self) -> SettingKey<'static> {
+        self.definition.key()
+    }
+
+    pub fn key_name(self) -> &'static str {
+        self.definition.key_name()
+    }
+
+    pub fn storage_key(self) -> &'static str {
+        self.definition.storage_key()
+    }
+
+    pub fn value(self) -> SettingValue {
+        self.value
+    }
+
+    pub fn source(self) -> SettingSource {
+        self.source
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingSource {
+    Default,
+    ConfigEnv,
+}
+
+impl SettingSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::ConfigEnv => "config.env",
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct SettingsRegistry {
@@ -590,6 +767,12 @@ impl ApplyStrategy {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SettingsError {
+    ConfigPath(ConfigPathError),
+    ReadConfig {
+        path: PathBuf,
+        kind: io::ErrorKind,
+        message: String,
+    },
     InvalidKey {
         key: String,
         reason: &'static str,
@@ -610,6 +793,14 @@ pub enum SettingsError {
 impl fmt::Display for SettingsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::ConfigPath(err) => write!(f, "{err}"),
+            Self::ReadConfig { path, message, .. } => {
+                write!(
+                    f,
+                    "could not read settings config `{}`: {message}",
+                    path.display()
+                )
+            }
             Self::InvalidKey { key, reason } => {
                 write!(f, "invalid setting key `{key}`: {reason}")
             }
@@ -691,9 +882,14 @@ fn validate_storage_key(value: &str) -> Result<(), &'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApplyStrategy, SettingKey, SettingMutability, SettingOperation, SettingType, SettingValue,
-        SettingsError, SETTINGS_REGISTRY,
+        ApplyStrategy, ConfigEnvReader, ConfigPathResolver, SettingKey, SettingMutability,
+        SettingOperation, SettingSource, SettingType, SettingValue, SettingsError, SettingsStore,
+        SETTINGS_REGISTRY,
     };
+    use crate::config::ConfigPathSources;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn registry_metadata_is_internally_valid() {
@@ -734,6 +930,190 @@ mod tests {
                 ("screen.idle_timeout", "screen_idle_timeout"),
                 ("screen.restore_policy", "screen_restore_policy"),
                 ("system.sleep_wake_policy", "system_sleep_wake_policy"),
+            ]
+        );
+    }
+
+    #[test]
+    fn config_path_resolver_reuses_config_path_resolution() {
+        let resolved = ConfigPathResolver::resolve(ConfigPathSources {
+            explicit_config: Some(Path::new("/tmp/custom.env")),
+            install_pointer_config: Some(Path::new("/tmp/pointer.env")),
+            sudo_user_home: Some(Path::new("/tmp/sudo-home")),
+            xdg_config_home: Some(Path::new("/tmp/xdg")),
+            home: Some(Path::new("/tmp/home")),
+        });
+
+        assert_eq!(resolved, Ok(PathBuf::from("/tmp/custom.env")));
+    }
+
+    #[test]
+    fn config_env_reader_sanitizes_comments_and_uses_last_duplicate_value() {
+        let reader = ConfigEnvReader::parse(
+            "/tmp/config.env",
+            "\
+            screen_backend=swayidle
+            screen_backend=gnome # use GNOME when available
+            unused=value
+            ",
+        );
+
+        assert_eq!(reader.raw_value("screen_backend"), Some("gnome"));
+        assert_eq!(reader.raw_value("unused"), Some("value"));
+        assert_eq!(reader.raw_value("missing"), None);
+    }
+
+    #[test]
+    fn settings_store_reads_existing_values_without_required_tv_config() {
+        let store = ConfigEnvReader::parse(
+            "/tmp/config.env",
+            "\
+            screen_backend=gnome
+            screen_idle_timeout=450
+            screen_restore_policy=aggressive
+            system_sleep_wake_policy=disabled
+            ",
+        )
+        .into_store();
+
+        let backend = store.effective_by_name("screen.backend").unwrap();
+        assert_eq!(backend.value(), SettingValue::Enum("gnome"));
+        assert_eq!(backend.source(), SettingSource::ConfigEnv);
+
+        let idle_timeout = store.effective_by_name("screen.idle_timeout").unwrap();
+        assert_eq!(idle_timeout.value(), SettingValue::Integer(450));
+        assert_eq!(idle_timeout.source(), SettingSource::ConfigEnv);
+
+        let restore_policy = store.effective_by_name("screen.restore_policy").unwrap();
+        assert_eq!(restore_policy.value(), SettingValue::Enum("aggressive"));
+        assert_eq!(restore_policy.source(), SettingSource::ConfigEnv);
+
+        let sleep_policy = store.effective_by_name("system.sleep_wake_policy").unwrap();
+        assert_eq!(sleep_policy.value(), SettingValue::Enum("disabled"));
+        assert_eq!(sleep_policy.source(), SettingSource::ConfigEnv);
+    }
+
+    #[test]
+    fn settings_store_uses_defaults_for_missing_values() {
+        let store = ConfigEnvReader::parse("/tmp/config.env", "").into_store();
+
+        let effective = store.effective_by_name("screen.idle_timeout").unwrap();
+
+        assert_eq!(effective.value(), SettingValue::Integer(300));
+        assert_eq!(effective.source(), SettingSource::Default);
+    }
+
+    #[test]
+    fn settings_store_uses_defaults_for_invalid_optional_values() {
+        let store = ConfigEnvReader::parse(
+            "/tmp/config.env",
+            "\
+            screen_backend=not-a-backend
+            screen_idle_timeout=not-a-number
+            screen_restore_policy=not-a-policy
+            ",
+        )
+        .into_store();
+
+        let backend = store.effective_by_name("screen.backend").unwrap();
+        assert_eq!(backend.value(), SettingValue::Enum("auto"));
+        assert_eq!(backend.source(), SettingSource::Default);
+
+        let idle_timeout = store.effective_by_name("screen.idle_timeout").unwrap();
+        assert_eq!(idle_timeout.value(), SettingValue::Integer(300));
+        assert_eq!(idle_timeout.source(), SettingSource::Default);
+
+        let restore_policy = store.effective_by_name("screen.restore_policy").unwrap();
+        assert_eq!(restore_policy.value(), SettingValue::Enum("conservative"));
+        assert_eq!(restore_policy.source(), SettingSource::Default);
+    }
+
+    #[test]
+    fn settings_store_canonicalizes_valid_alias_values_from_config_env() {
+        let store =
+            ConfigEnvReader::parse("/tmp/config.env", "screen_restore_policy=marker_only\n")
+                .into_store();
+
+        let restore_policy = store.effective_by_name("screen.restore_policy").unwrap();
+
+        assert_eq!(restore_policy.value(), SettingValue::Enum("conservative"));
+        assert_eq!(restore_policy.source(), SettingSource::ConfigEnv);
+    }
+
+    #[test]
+    fn settings_store_loads_existing_config_file() {
+        let path = unique_test_path("existing");
+        fs::write(&path, "screen_idle_timeout=123\n").unwrap();
+
+        let store = SettingsStore::load(&path).unwrap();
+
+        assert_eq!(store.path(), path.as_path());
+        assert_eq!(store.raw_storage_value("screen_idle_timeout"), Some("123"));
+        assert_eq!(
+            store
+                .effective_by_name("screen.idle_timeout")
+                .unwrap()
+                .value(),
+            SettingValue::Integer(123)
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn settings_store_loads_missing_config_file_as_empty_defaults() {
+        let path = unique_test_path("missing");
+        let _ = fs::remove_file(&path);
+
+        let store = SettingsStore::load(&path).unwrap();
+
+        assert_eq!(store.path(), path.as_path());
+        assert_eq!(
+            store.effective_by_name("screen.backend").unwrap().value(),
+            SettingValue::Enum("auto")
+        );
+        assert_eq!(
+            store.effective_by_name("screen.backend").unwrap().source(),
+            SettingSource::Default
+        );
+    }
+
+    #[test]
+    fn all_effective_returns_registry_order() {
+        let store = ConfigEnvReader::parse(
+            "/tmp/config.env",
+            "\
+            screen_backend=gnome
+            system_sleep_wake_policy=disabled
+            ",
+        )
+        .into_store();
+
+        let settings = store.all_effective();
+        let keys: Vec<&str> = settings.iter().map(|setting| setting.key_name()).collect();
+        let values: Vec<String> = settings
+            .iter()
+            .map(|setting| setting.value().to_string())
+            .collect();
+        let sources: Vec<SettingSource> = settings.iter().map(|setting| setting.source()).collect();
+
+        assert_eq!(
+            keys,
+            vec![
+                "screen.backend",
+                "screen.idle_timeout",
+                "screen.restore_policy",
+                "system.sleep_wake_policy",
+            ]
+        );
+        assert_eq!(values, vec!["gnome", "300", "conservative", "disabled"]);
+        assert_eq!(
+            sources,
+            vec![
+                SettingSource::ConfigEnv,
+                SettingSource::Default,
+                SettingSource::Default,
+                SettingSource::ConfigEnv,
             ]
         );
     }
@@ -900,5 +1280,17 @@ mod tests {
             sleep_policy.apply_strategy(),
             ApplyStrategy::PendingLifecycleService
         );
+    }
+
+    fn unique_test_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        std::env::temp_dir().join(format!(
+            "lg-buddy-settings-{name}-{}-{nanos}.env",
+            std::process::id()
+        ))
     }
 }

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -3,12 +3,13 @@ use std::env;
 use std::fmt;
 use std::fs;
 use std::io;
+use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
 
 use crate::config::{
     parse_config_entries, resolve_config_path, resolve_config_path_from_env, ConfigPathError,
-    ConfigPathSources, DEFAULT_IDLE_TIMEOUT,
+    ConfigPathSources, MacAddress, DEFAULT_IDLE_TIMEOUT,
 };
 
 const SETTINGS_SUBCOMMANDS: &[&str] = &["list", "describe", "get", "set", "unset"];
@@ -20,25 +21,72 @@ const READ_WRITE_OPERATIONS: &[SettingOperation] = &[
     SettingOperation::Set,
     SettingOperation::Unset,
 ];
+const READ_SET_OPERATIONS: &[SettingOperation] = &[
+    SettingOperation::Get,
+    SettingOperation::Describe,
+    SettingOperation::Set,
+];
 const EMPTY_ALIASES: &[SettingAlias] = &[];
+const EMPTY_STORAGE_KEYS: &[&str] = &[];
+const TV_IP_FALLBACK_STORAGE_KEYS: &[&str] = &["tv_ip"];
+const TV_MAC_FALLBACK_STORAGE_KEYS: &[&str] = &["tv_mac"];
+const TV_INPUT_FALLBACK_STORAGE_KEYS: &[&str] = &["input"];
 const SCREEN_RESTORE_POLICY_ALIASES: &[SettingAlias] = &[SettingAlias {
     from: "marker_only",
     to: "conservative",
 }];
 
+const TV_INPUT_VALUES: &[&str] = &["HDMI_1", "HDMI_2", "HDMI_3", "HDMI_4"];
 const SCREEN_BACKEND_VALUES: &[&str] = &["auto", "gnome", "swayidle"];
 const SCREEN_RESTORE_POLICY_VALUES: &[&str] = &["conservative", "aggressive"];
 const SYSTEM_SLEEP_WAKE_POLICY_VALUES: &[&str] = &["enabled", "disabled"];
 
 const SETTING_DEFINITIONS: &[SettingDefinition] = &[
     SettingDefinition {
+        key: "tv.ip",
+        storage_key: "tvs_primary_ip",
+        fallback_storage_keys: TV_IP_FALLBACK_STORAGE_KEYS,
+        value_type: SettingType::Ipv4,
+        default_value: None,
+        mutability: SettingMutability::ReadWrite,
+        operations: READ_SET_OPERATIONS,
+        apply_strategy: ApplyStrategy::NoRuntimeApplyRequired,
+        description: "IPv4 address of the primary configured TV.",
+    },
+    SettingDefinition {
+        key: "tv.mac",
+        storage_key: "tvs_primary_mac",
+        fallback_storage_keys: TV_MAC_FALLBACK_STORAGE_KEYS,
+        value_type: SettingType::MacAddress,
+        default_value: None,
+        mutability: SettingMutability::ReadWrite,
+        operations: READ_SET_OPERATIONS,
+        apply_strategy: ApplyStrategy::NoRuntimeApplyRequired,
+        description: "MAC address of the primary configured TV for Wake-on-LAN.",
+    },
+    SettingDefinition {
+        key: "tv.input",
+        storage_key: "tvs_primary_input",
+        fallback_storage_keys: TV_INPUT_FALLBACK_STORAGE_KEYS,
+        value_type: SettingType::Enum(EnumSettingType {
+            values: TV_INPUT_VALUES,
+            aliases: EMPTY_ALIASES,
+        }),
+        default_value: None,
+        mutability: SettingMutability::ReadWrite,
+        operations: READ_SET_OPERATIONS,
+        apply_strategy: ApplyStrategy::NoRuntimeApplyRequired,
+        description: "HDMI input used by the primary configured TV.",
+    },
+    SettingDefinition {
         key: "screen.backend",
         storage_key: "screen_backend",
+        fallback_storage_keys: EMPTY_STORAGE_KEYS,
         value_type: SettingType::Enum(EnumSettingType {
             values: SCREEN_BACKEND_VALUES,
             aliases: EMPTY_ALIASES,
         }),
-        default_value: SettingValue::Enum("auto"),
+        default_value: Some(SettingValue::Enum("auto")),
         mutability: SettingMutability::ReadWrite,
         operations: READ_WRITE_OPERATIONS,
         apply_strategy: ApplyStrategy::RestartUserScreenService,
@@ -47,11 +95,12 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
     SettingDefinition {
         key: "screen.idle_timeout",
         storage_key: "screen_idle_timeout",
+        fallback_storage_keys: EMPTY_STORAGE_KEYS,
         value_type: SettingType::Integer(IntegerSettingType {
             min: 1,
             max: 86_400,
         }),
-        default_value: SettingValue::Integer(DEFAULT_IDLE_TIMEOUT as i64),
+        default_value: Some(SettingValue::Integer(DEFAULT_IDLE_TIMEOUT as i64)),
         mutability: SettingMutability::ReadWrite,
         operations: READ_WRITE_OPERATIONS,
         apply_strategy: ApplyStrategy::RestartUserScreenService,
@@ -60,11 +109,12 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
     SettingDefinition {
         key: "screen.restore_policy",
         storage_key: "screen_restore_policy",
+        fallback_storage_keys: EMPTY_STORAGE_KEYS,
         value_type: SettingType::Enum(EnumSettingType {
             values: SCREEN_RESTORE_POLICY_VALUES,
             aliases: SCREEN_RESTORE_POLICY_ALIASES,
         }),
-        default_value: SettingValue::Enum("conservative"),
+        default_value: Some(SettingValue::Enum("conservative")),
         mutability: SettingMutability::ReadWrite,
         operations: READ_WRITE_OPERATIONS,
         apply_strategy: ApplyStrategy::RestartUserScreenService,
@@ -73,11 +123,12 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
     SettingDefinition {
         key: "system.sleep_wake_policy",
         storage_key: "system_sleep_wake_policy",
+        fallback_storage_keys: EMPTY_STORAGE_KEYS,
         value_type: SettingType::Enum(EnumSettingType {
             values: SYSTEM_SLEEP_WAKE_POLICY_VALUES,
             aliases: EMPTY_ALIASES,
         }),
-        default_value: SettingValue::Enum("enabled"),
+        default_value: Some(SettingValue::Enum("enabled")),
         mutability: SettingMutability::ReadWrite,
         operations: READ_WRITE_OPERATIONS,
         apply_strategy: ApplyStrategy::RuntimePolicyOnly,
@@ -260,7 +311,7 @@ impl SettingsFormatter {
         writer: &mut W,
         setting: EffectiveSetting,
     ) -> Result<(), SettingsError> {
-        writeln!(writer, "{}", setting.value()).map_err(output_error)
+        writeln!(writer, "{}", setting.required_value()?).map_err(output_error)
     }
 
     pub fn write_list<W: io::Write>(
@@ -273,7 +324,7 @@ impl SettingsFormatter {
                 writer,
                 "{}={} ({}, {}, ops: {})",
                 setting.key_name(),
-                setting.value(),
+                format_effective_value(*setting),
                 setting.source().as_str(),
                 setting.definition().mutability().as_str(),
                 format_operations(setting.definition().supported_operations(), ",")
@@ -314,7 +365,7 @@ impl SettingsFormatter {
                     writer,
                     "{}={} (saved to {})",
                     mutation.key_name(),
-                    mutation.new_value(),
+                    mutation.new_value()?,
                     change.path().display()
                 )
                 .map_err(output_error)?;
@@ -324,7 +375,7 @@ impl SettingsFormatter {
                     writer,
                     "{} already set to {} ({})",
                     mutation.key_name(),
-                    mutation.new_value(),
+                    mutation.new_value()?,
                     change.path().display()
                 )
                 .map_err(output_error)?;
@@ -367,9 +418,10 @@ impl SettingsFormatter {
         writeln!(writer, "{}", setting.key_name()).map_err(output_error)?;
         writeln!(writer, "  storage key: {}", setting.storage_key()).map_err(output_error)?;
         writeln!(writer, "  type: {}", definition.value_type().as_str()).map_err(output_error)?;
-        writeln!(writer, "  current: {}", setting.value()).map_err(output_error)?;
+        writeln!(writer, "  current: {}", format_effective_value(setting)).map_err(output_error)?;
         writeln!(writer, "  source: {}", setting.source().as_str()).map_err(output_error)?;
-        writeln!(writer, "  default: {}", definition.default_value()).map_err(output_error)?;
+        writeln!(writer, "  default: {}", definition.default_value_label())
+            .map_err(output_error)?;
         writeln!(writer, "  mutability: {}", definition.mutability().as_str())
             .map_err(output_error)?;
         writeln!(
@@ -401,6 +453,7 @@ impl SettingsFormatter {
                 )
                 .map_err(output_error)?;
             }
+            SettingType::Ipv4 | SettingType::MacAddress => {}
         }
 
         writeln!(writer, "  apply: {}", definition.apply_strategy().as_str())
@@ -512,9 +565,9 @@ pub enum SettingsMutationAction {
 #[derive(Debug, Clone, Copy)]
 pub struct SettingsMutation {
     definition: &'static SettingDefinition,
-    old_value: SettingValue,
+    old_value: Option<SettingValue>,
     old_source: SettingSource,
-    new_value: SettingValue,
+    new_value: Option<SettingValue>,
     action: SettingsMutationAction,
 }
 
@@ -529,7 +582,7 @@ impl SettingsMutation {
             definition,
             old_value: old.value(),
             old_source: old.source(),
-            new_value,
+            new_value: Some(new_value),
             action: SettingsMutationAction::Set,
         })
     }
@@ -560,7 +613,7 @@ impl SettingsMutation {
         self.definition.storage_key()
     }
 
-    pub fn old_value(self) -> SettingValue {
+    pub fn old_value(self) -> Option<SettingValue> {
         self.old_value
     }
 
@@ -568,8 +621,11 @@ impl SettingsMutation {
         self.old_source
     }
 
-    pub fn new_value(self) -> SettingValue {
+    pub fn new_value(self) -> Result<SettingValue, SettingsError> {
         self.new_value
+            .ok_or_else(|| SettingsError::MissingRequiredSetting {
+                key: self.key_name().to_string(),
+            })
     }
 
     pub fn action(self) -> SettingsMutationAction {
@@ -749,7 +805,9 @@ impl<C: ServiceController> SettingsApplier<C> {
     pub fn apply(&self, change: &SettingsChange) -> Result<SettingsApplyOutcome, SettingsError> {
         match change.mutation().definition().apply_strategy() {
             ApplyStrategy::RestartUserScreenService => self.apply_screen_service_restart(),
-            ApplyStrategy::RuntimePolicyOnly => Ok(SettingsApplyOutcome::NoActionRequired),
+            ApplyStrategy::RuntimePolicyOnly | ApplyStrategy::NoRuntimeApplyRequired => {
+                Ok(SettingsApplyOutcome::NoActionRequired)
+            }
         }
     }
 
@@ -870,8 +928,20 @@ fn persist_settings_mutation(
 ) -> Result<SettingsChange, SettingsError> {
     let mut editor = ConfigEnvEditor::load(path)?;
     let file_changed = match mutation.action() {
-        SettingsMutationAction::Set => editor.set(mutation.storage_key(), mutation.new_value()),
-        SettingsMutationAction::Unset => editor.unset(mutation.storage_key()),
+        SettingsMutationAction::Set => {
+            let mut changed = editor.set(mutation.storage_key(), mutation.new_value()?);
+            for fallback_key in mutation.definition().fallback_storage_keys() {
+                changed |= editor.unset(fallback_key);
+            }
+            changed
+        }
+        SettingsMutationAction::Unset => {
+            let mut changed = editor.unset(mutation.storage_key());
+            for fallback_key in mutation.definition().fallback_storage_keys() {
+                changed |= editor.unset(fallback_key);
+            }
+            changed
+        }
     };
 
     if file_changed {
@@ -922,19 +992,29 @@ impl SettingsStore {
     }
 
     pub fn effective_definition(&self, definition: &'static SettingDefinition) -> EffectiveSetting {
-        let raw_value = self.reader.raw_value(definition.storage_key());
-        let parsed_value = raw_value.and_then(|value| definition.parse_value(value).ok());
+        let raw_value = self.reader.raw_setting_value(definition);
+        let parsed_value = raw_value.and_then(|(value, source)| {
+            definition
+                .parse_value(value)
+                .ok()
+                .map(|value| (value, source))
+        });
 
-        match parsed_value {
-            Some(value) => EffectiveSetting {
+        match (parsed_value, definition.default_value()) {
+            (Some((value, source)), _) => EffectiveSetting {
                 definition,
-                value,
-                source: SettingSource::ConfigEnv,
+                value: Some(value),
+                source,
             },
-            None => EffectiveSetting {
+            (None, Some(value)) => EffectiveSetting {
                 definition,
-                value: definition.default_value(),
+                value: Some(value),
                 source: SettingSource::Default,
+            },
+            (None, None) => EffectiveSetting {
+                definition,
+                value: None,
+                source: SettingSource::Missing,
             },
         }
     }
@@ -990,6 +1070,23 @@ impl ConfigEnvReader {
         self.entries.get(storage_key).map(String::as_str)
     }
 
+    pub fn raw_setting_value(
+        &self,
+        definition: &'static SettingDefinition,
+    ) -> Option<(&str, SettingSource)> {
+        self.raw_value(definition.storage_key())
+            .map(|value| (value, SettingSource::ConfigEnv))
+            .or_else(|| {
+                definition
+                    .fallback_storage_keys()
+                    .iter()
+                    .find_map(|storage_key| {
+                        self.raw_value(storage_key)
+                            .map(|value| (value, SettingSource::LegacyConfigEnv))
+                    })
+            })
+    }
+
     pub fn into_store(self) -> SettingsStore {
         SettingsStore::from_reader(self)
     }
@@ -1011,7 +1108,7 @@ impl ConfigPathResolver {
 #[derive(Debug, Clone, Copy)]
 pub struct EffectiveSetting {
     definition: &'static SettingDefinition,
-    value: SettingValue,
+    value: Option<SettingValue>,
     source: SettingSource,
 }
 
@@ -1032,8 +1129,15 @@ impl EffectiveSetting {
         self.definition.storage_key()
     }
 
-    pub fn value(self) -> SettingValue {
+    pub fn value(self) -> Option<SettingValue> {
         self.value
+    }
+
+    pub fn required_value(self) -> Result<SettingValue, SettingsError> {
+        self.value
+            .ok_or_else(|| SettingsError::MissingRequiredSetting {
+                key: self.key_name().to_string(),
+            })
     }
 
     pub fn source(self) -> SettingSource {
@@ -1045,6 +1149,8 @@ impl EffectiveSetting {
 pub enum SettingSource {
     Default,
     ConfigEnv,
+    LegacyConfigEnv,
+    Missing,
 }
 
 impl SettingSource {
@@ -1052,6 +1158,8 @@ impl SettingSource {
         match self {
             Self::Default => "default",
             Self::ConfigEnv => "config.env",
+            Self::LegacyConfigEnv => "legacy config.env",
+            Self::Missing => "missing",
         }
     }
 }
@@ -1104,6 +1212,21 @@ impl SettingsRegistry {
                 )));
             }
 
+            for fallback_storage_key in definition.fallback_storage_keys {
+                validate_storage_key(fallback_storage_key).map_err(|reason| {
+                    SettingsError::RegistryInvariant(format!(
+                        "invalid fallback storage key `{fallback_storage_key}` for `{}`: {reason}",
+                        definition.key
+                    ))
+                })?;
+
+                if !storage_keys.insert(*fallback_storage_key) {
+                    return Err(SettingsError::RegistryInvariant(format!(
+                        "duplicate storage key `{fallback_storage_key}`"
+                    )));
+                }
+            }
+
             definition.validate_type_metadata()?;
             definition.validate_default()?;
             definition.validate_operation_metadata()?;
@@ -1141,8 +1264,9 @@ impl fmt::Display for SettingKey<'_> {
 pub struct SettingDefinition {
     key: &'static str,
     storage_key: &'static str,
+    fallback_storage_keys: &'static [&'static str],
     value_type: SettingType,
-    default_value: SettingValue,
+    default_value: Option<SettingValue>,
     mutability: SettingMutability,
     operations: &'static [SettingOperation],
     apply_strategy: ApplyStrategy,
@@ -1162,12 +1286,22 @@ impl SettingDefinition {
         self.storage_key
     }
 
+    pub fn fallback_storage_keys(&self) -> &'static [&'static str] {
+        self.fallback_storage_keys
+    }
+
     pub fn value_type(&self) -> SettingType {
         self.value_type
     }
 
-    pub fn default_value(&self) -> SettingValue {
+    pub fn default_value(&self) -> Option<SettingValue> {
         self.default_value
+    }
+
+    pub fn default_value_label(&self) -> String {
+        self.default_value
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "required".to_string())
     }
 
     pub fn mutability(&self) -> SettingMutability {
@@ -1212,22 +1346,27 @@ impl SettingDefinition {
         match self.value_type {
             SettingType::Enum(enum_type) => enum_type.validate(self.key),
             SettingType::Integer(integer_type) => integer_type.validate(self.key),
+            SettingType::Ipv4 | SettingType::MacAddress => Ok(()),
         }
     }
 
     fn validate_default(&self) -> Result<(), SettingsError> {
-        self.value_type
-            .validate_value(self.key, self.default_value)
-            .map_err(|err| match err {
-                SettingsError::InvalidValue {
-                    key,
-                    value,
-                    expected,
-                } => SettingsError::RegistryInvariant(format!(
-                    "invalid default value `{value}` for `{key}`: expected {expected}"
-                )),
-                other => other,
-            })
+        if let Some(default_value) = self.default_value {
+            self.value_type
+                .validate_value(self.key, default_value)
+                .map_err(|err| match err {
+                    SettingsError::InvalidValue {
+                        key,
+                        value,
+                        expected,
+                    } => SettingsError::RegistryInvariant(format!(
+                        "invalid default value `{value}` for `{key}`: expected {expected}"
+                    )),
+                    other => other,
+                })
+        } else {
+            Ok(())
+        }
     }
 
     fn validate_operation_metadata(&self) -> Result<(), SettingsError> {
@@ -1240,8 +1379,12 @@ impl SettingDefinition {
 
         match self.mutability {
             SettingMutability::ReadWrite => {
-                for operation in READ_WRITE_OPERATIONS {
-                    if !self.operations.contains(operation) {
+                for operation in [
+                    SettingOperation::Get,
+                    SettingOperation::Describe,
+                    SettingOperation::Set,
+                ] {
+                    if !self.operations.contains(&operation) {
                         return Err(SettingsError::RegistryInvariant(format!(
                             "`{}` is read-write but does not support `{}`",
                             self.key,
@@ -1263,6 +1406,13 @@ impl SettingDefinition {
             }
         }
 
+        if self.default_value.is_none() && self.operations.contains(&SettingOperation::Unset) {
+            return Err(SettingsError::RegistryInvariant(format!(
+                "`{}` is required but supports `unset`",
+                self.key
+            )));
+        }
+
         Ok(())
     }
 }
@@ -1271,6 +1421,8 @@ impl SettingDefinition {
 pub enum SettingType {
     Enum(EnumSettingType),
     Integer(IntegerSettingType),
+    Ipv4,
+    MacAddress,
 }
 
 impl SettingType {
@@ -1292,6 +1444,22 @@ impl SettingType {
                     expected: integer_type.expected(),
                 }),
             },
+            Self::Ipv4 => value
+                .parse::<Ipv4Addr>()
+                .map(SettingValue::Ipv4)
+                .map_err(|_| SettingsError::InvalidValue {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                    expected: Self::Ipv4.expected(),
+                }),
+            Self::MacAddress => value
+                .parse::<MacAddress>()
+                .map(SettingValue::MacAddress)
+                .map_err(|_| SettingsError::InvalidValue {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                    expected: Self::MacAddress.expected(),
+                }),
         }
     }
 
@@ -1319,6 +1487,8 @@ impl SettingType {
                     expected: integer_type.expected(),
                 })
             }
+            (Self::Ipv4, SettingValue::Ipv4(_))
+            | (Self::MacAddress, SettingValue::MacAddress(_)) => Ok(()),
             (expected_type, actual_value) => Err(SettingsError::InvalidValue {
                 key: key.to_string(),
                 value: actual_value.to_string(),
@@ -1331,6 +1501,8 @@ impl SettingType {
         match self {
             Self::Enum(enum_type) => enum_type.expected(),
             Self::Integer(integer_type) => integer_type.expected(),
+            Self::Ipv4 => "an IPv4 address".to_string(),
+            Self::MacAddress => "a MAC address like aa:bb:cc:dd:ee:ff".to_string(),
         }
     }
 
@@ -1338,6 +1510,8 @@ impl SettingType {
         match self {
             Self::Enum(_) => "enum",
             Self::Integer(_) => "integer",
+            Self::Ipv4 => "ipv4",
+            Self::MacAddress => "mac-address",
         }
     }
 }
@@ -1488,19 +1662,21 @@ impl IntegerSettingType {
 pub enum SettingValue {
     Enum(&'static str),
     Integer(i64),
+    Ipv4(Ipv4Addr),
+    MacAddress(MacAddress),
 }
 
 impl SettingValue {
     pub fn as_enum(self) -> Option<&'static str> {
         match self {
             Self::Enum(value) => Some(value),
-            Self::Integer(_) => None,
+            Self::Integer(_) | Self::Ipv4(_) | Self::MacAddress(_) => None,
         }
     }
 
     pub fn as_integer(self) -> Option<i64> {
         match self {
-            Self::Enum(_) => None,
+            Self::Enum(_) | Self::Ipv4(_) | Self::MacAddress(_) => None,
             Self::Integer(value) => Some(value),
         }
     }
@@ -1511,6 +1687,8 @@ impl fmt::Display for SettingValue {
         match self {
             Self::Enum(value) => write!(f, "{value}"),
             Self::Integer(value) => write!(f, "{value}"),
+            Self::Ipv4(value) => write!(f, "{value}"),
+            Self::MacAddress(value) => write!(f, "{value}"),
         }
     }
 }
@@ -1559,6 +1737,7 @@ impl fmt::Display for SettingOperation {
 pub enum ApplyStrategy {
     RestartUserScreenService,
     RuntimePolicyOnly,
+    NoRuntimeApplyRequired,
 }
 
 impl ApplyStrategy {
@@ -1566,6 +1745,7 @@ impl ApplyStrategy {
         match self {
             Self::RestartUserScreenService => "restart-user-screen-service",
             Self::RuntimePolicyOnly => "runtime-policy-only",
+            Self::NoRuntimeApplyRequired => "no-runtime-apply-required",
         }
     }
 }
@@ -1600,6 +1780,9 @@ pub enum SettingsError {
         key: String,
         value: String,
         expected: String,
+    },
+    MissingRequiredSetting {
+        key: String,
     },
     UnsupportedOperation {
         key: String,
@@ -1645,6 +1828,9 @@ impl fmt::Display for SettingsError {
                 f,
                 "invalid value for setting `{key}`: `{value}`; expected {expected}"
             ),
+            Self::MissingRequiredSetting { key } => {
+                write!(f, "required setting `{key}` is not configured")
+            }
             Self::UnsupportedOperation { key, operation } => {
                 write!(
                     f,
@@ -1669,6 +1855,7 @@ impl std::error::Error for SettingsError {
             | Self::InvalidKey { .. }
             | Self::UnknownKey(_)
             | Self::InvalidValue { .. }
+            | Self::MissingRequiredSetting { .. }
             | Self::UnsupportedOperation { .. }
             | Self::RegistryInvariant(_) => None,
         }
@@ -1691,6 +1878,13 @@ fn format_operations(operations: &[SettingOperation], separator: &str) -> String
         .map(|operation| operation.as_str())
         .collect::<Vec<_>>()
         .join(separator)
+}
+
+fn format_effective_value(setting: EffectiveSetting) -> String {
+    setting
+        .value()
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "<missing>".to_string())
 }
 
 fn format_aliases(aliases: &[SettingAlias]) -> String {
@@ -1825,10 +2019,10 @@ fn validate_storage_key(value: &str) -> Result<(), &'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApplyStrategy, ConfigEnvReader, ConfigPathResolver, ServiceController, SettingKey,
-        SettingMutability, SettingOperation, SettingSource, SettingType, SettingValue,
-        SettingsApplier, SettingsCommand, SettingsCommandRunner, SettingsError, SettingsParseError,
-        SettingsStore, UserServiceState, SETTINGS_REGISTRY,
+        format_effective_value, ApplyStrategy, ConfigEnvReader, ConfigPathResolver,
+        ServiceController, SettingKey, SettingMutability, SettingOperation, SettingSource,
+        SettingType, SettingValue, SettingsApplier, SettingsCommand, SettingsCommandRunner,
+        SettingsError, SettingsParseError, SettingsStore, UserServiceState, SETTINGS_REGISTRY,
     };
     use crate::config::ConfigPathSources;
     use std::cell::Cell;
@@ -1853,6 +2047,9 @@ mod tests {
         assert_eq!(
             keys,
             vec![
+                "tv.ip",
+                "tv.mac",
+                "tv.input",
                 "screen.backend",
                 "screen.idle_timeout",
                 "screen.restore_policy",
@@ -1872,6 +2069,9 @@ mod tests {
         assert_eq!(
             mappings,
             vec![
+                ("tv.ip", "tvs_primary_ip"),
+                ("tv.mac", "tvs_primary_mac"),
+                ("tv.input", "tvs_primary_input"),
                 ("screen.backend", "screen_backend"),
                 ("screen.idle_timeout", "screen_idle_timeout"),
                 ("screen.restore_policy", "screen_restore_policy"),
@@ -1956,6 +2156,9 @@ mod tests {
         assert_eq!(
             output,
             "\
+tv.ip=<missing> (missing, read-write, ops: get,describe,set)
+tv.mac=<missing> (missing, read-write, ops: get,describe,set)
+tv.input=<missing> (missing, read-write, ops: get,describe,set)
 screen.backend=gnome (config.env, read-write, ops: get,describe,set,unset)
 screen.idle_timeout=300 (default, read-write, ops: get,describe,set,unset)
 screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)
@@ -2042,6 +2245,25 @@ system.sleep_wake_policy=disabled (config.env, read-write, ops: get,describe,set
             .unwrap_err();
 
         assert_eq!(err, SettingsError::UnknownKey("screen.unknown".to_string()));
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn settings_runner_rejects_missing_required_value_on_get() {
+        let store = ConfigEnvReader::parse("/tmp/config.env", "").into_store();
+        let runner = SettingsCommandRunner::new(store);
+        let mut output = Vec::new();
+
+        let err = runner
+            .run(SettingsCommand::Get("tv.ip".to_string()), &mut output)
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            SettingsError::MissingRequiredSetting {
+                key: "tv.ip".to_string()
+            }
+        );
         assert!(output.is_empty());
     }
 
@@ -2250,6 +2472,50 @@ screen_restore_policy=aggressive
     }
 
     #[test]
+    fn settings_runner_sets_tv_value_to_canonical_storage_without_restart() {
+        let path = unique_test_path("tv-set");
+        fs::write(
+            &path,
+            "\
+tv_ip=192.0.2.42
+tv_mac=aa:bb:cc:dd:ee:ff
+input=HDMI_2
+",
+        )
+        .unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let fake_service = FakeServiceController::active_or_enabled();
+        let restarts = fake_service.restarts.clone();
+        let runner = SettingsCommandRunner::with_applier(store, SettingsApplier::new(fake_service));
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Set {
+                    key: "tv.ip".to_string(),
+                    value: "192.0.2.43".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "\
+tv_mac=aa:bb:cc:dd:ee:ff
+input=HDMI_2
+tvs_primary_ip=192.0.2.43
+"
+        );
+        assert_eq!(restarts.get(), 0);
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("tv.ip=192.0.2.43 (saved to "));
+        assert!(output.contains("apply: no runtime apply action required\n"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
     fn settings_runner_creates_parent_directory_for_valid_write() {
         let root = unique_test_path("parent").with_extension("");
         let path = root.join("nested").join("config.env");
@@ -2354,20 +2620,70 @@ screen_restore_policy=aggressive
         .into_store();
 
         let backend = store.effective_by_name("screen.backend").unwrap();
-        assert_eq!(backend.value(), SettingValue::Enum("gnome"));
+        assert_eq!(backend.value(), Some(SettingValue::Enum("gnome")));
         assert_eq!(backend.source(), SettingSource::ConfigEnv);
 
         let idle_timeout = store.effective_by_name("screen.idle_timeout").unwrap();
-        assert_eq!(idle_timeout.value(), SettingValue::Integer(450));
+        assert_eq!(idle_timeout.value(), Some(SettingValue::Integer(450)));
         assert_eq!(idle_timeout.source(), SettingSource::ConfigEnv);
 
         let restore_policy = store.effective_by_name("screen.restore_policy").unwrap();
-        assert_eq!(restore_policy.value(), SettingValue::Enum("aggressive"));
+        assert_eq!(
+            restore_policy.value(),
+            Some(SettingValue::Enum("aggressive"))
+        );
         assert_eq!(restore_policy.source(), SettingSource::ConfigEnv);
 
         let sleep_policy = store.effective_by_name("system.sleep_wake_policy").unwrap();
-        assert_eq!(sleep_policy.value(), SettingValue::Enum("disabled"));
+        assert_eq!(sleep_policy.value(), Some(SettingValue::Enum("disabled")));
         assert_eq!(sleep_policy.source(), SettingSource::ConfigEnv);
+    }
+
+    #[test]
+    fn settings_store_reads_tv_values_from_canonical_and_legacy_storage() {
+        let canonical = ConfigEnvReader::parse(
+            "/tmp/config.env",
+            "\
+            tvs_primary_ip=192.0.2.43
+            tvs_primary_mac=11:22:33:44:55:66
+            tvs_primary_input=HDMI_3
+            ",
+        )
+        .into_store();
+
+        assert_eq!(
+            canonical.effective_by_name("tv.ip").unwrap().value(),
+            Some(SettingValue::Ipv4("192.0.2.43".parse().unwrap()))
+        );
+        assert_eq!(
+            canonical.effective_by_name("tv.mac").unwrap().value(),
+            Some(SettingValue::MacAddress(
+                "11:22:33:44:55:66".parse().unwrap()
+            ))
+        );
+        assert_eq!(
+            canonical.effective_by_name("tv.input").unwrap().value(),
+            Some(SettingValue::Enum("HDMI_3"))
+        );
+
+        let legacy = ConfigEnvReader::parse(
+            "/tmp/config.env",
+            "\
+            tv_ip=192.0.2.42
+            tv_mac=aa:bb:cc:dd:ee:ff
+            input=HDMI_2
+            ",
+        )
+        .into_store();
+
+        assert_eq!(
+            legacy.effective_by_name("tv.ip").unwrap().value(),
+            Some(SettingValue::Ipv4("192.0.2.42".parse().unwrap()))
+        );
+        assert_eq!(
+            legacy.effective_by_name("tv.ip").unwrap().source(),
+            SettingSource::LegacyConfigEnv
+        );
     }
 
     #[test]
@@ -2376,7 +2692,7 @@ screen_restore_policy=aggressive
 
         let effective = store.effective_by_name("screen.idle_timeout").unwrap();
 
-        assert_eq!(effective.value(), SettingValue::Integer(300));
+        assert_eq!(effective.value(), Some(SettingValue::Integer(300)));
         assert_eq!(effective.source(), SettingSource::Default);
     }
 
@@ -2393,15 +2709,18 @@ screen_restore_policy=aggressive
         .into_store();
 
         let backend = store.effective_by_name("screen.backend").unwrap();
-        assert_eq!(backend.value(), SettingValue::Enum("auto"));
+        assert_eq!(backend.value(), Some(SettingValue::Enum("auto")));
         assert_eq!(backend.source(), SettingSource::Default);
 
         let idle_timeout = store.effective_by_name("screen.idle_timeout").unwrap();
-        assert_eq!(idle_timeout.value(), SettingValue::Integer(300));
+        assert_eq!(idle_timeout.value(), Some(SettingValue::Integer(300)));
         assert_eq!(idle_timeout.source(), SettingSource::Default);
 
         let restore_policy = store.effective_by_name("screen.restore_policy").unwrap();
-        assert_eq!(restore_policy.value(), SettingValue::Enum("conservative"));
+        assert_eq!(
+            restore_policy.value(),
+            Some(SettingValue::Enum("conservative"))
+        );
         assert_eq!(restore_policy.source(), SettingSource::Default);
     }
 
@@ -2413,7 +2732,10 @@ screen_restore_policy=aggressive
 
         let restore_policy = store.effective_by_name("screen.restore_policy").unwrap();
 
-        assert_eq!(restore_policy.value(), SettingValue::Enum("conservative"));
+        assert_eq!(
+            restore_policy.value(),
+            Some(SettingValue::Enum("conservative"))
+        );
         assert_eq!(restore_policy.source(), SettingSource::ConfigEnv);
     }
 
@@ -2431,7 +2753,7 @@ screen_restore_policy=aggressive
                 .effective_by_name("screen.idle_timeout")
                 .unwrap()
                 .value(),
-            SettingValue::Integer(123)
+            Some(SettingValue::Integer(123))
         );
 
         let _ = fs::remove_file(path);
@@ -2447,7 +2769,7 @@ screen_restore_policy=aggressive
         assert_eq!(store.path(), path.as_path());
         assert_eq!(
             store.effective_by_name("screen.backend").unwrap().value(),
-            SettingValue::Enum("auto")
+            Some(SettingValue::Enum("auto"))
         );
         assert_eq!(
             store.effective_by_name("screen.backend").unwrap().source(),
@@ -2470,23 +2792,40 @@ screen_restore_policy=aggressive
         let keys: Vec<&str> = settings.iter().map(|setting| setting.key_name()).collect();
         let values: Vec<String> = settings
             .iter()
-            .map(|setting| setting.value().to_string())
+            .map(|setting| format_effective_value(*setting))
             .collect();
         let sources: Vec<SettingSource> = settings.iter().map(|setting| setting.source()).collect();
 
         assert_eq!(
             keys,
             vec![
+                "tv.ip",
+                "tv.mac",
+                "tv.input",
                 "screen.backend",
                 "screen.idle_timeout",
                 "screen.restore_policy",
                 "system.sleep_wake_policy",
             ]
         );
-        assert_eq!(values, vec!["gnome", "300", "conservative", "disabled"]);
+        assert_eq!(
+            values,
+            vec![
+                "<missing>",
+                "<missing>",
+                "<missing>",
+                "gnome",
+                "300",
+                "conservative",
+                "disabled",
+            ]
+        );
         assert_eq!(
             sources,
             vec![
+                SettingSource::Missing,
+                SettingSource::Missing,
+                SettingSource::Missing,
                 SettingSource::ConfigEnv,
                 SettingSource::Default,
                 SettingSource::Default,
@@ -2536,7 +2875,7 @@ screen_restore_policy=aggressive
 
         assert_eq!(definition.key_name(), "screen.idle_timeout");
         assert_eq!(definition.storage_key(), "screen_idle_timeout");
-        assert_eq!(definition.default_value(), SettingValue::Integer(300));
+        assert_eq!(definition.default_value(), Some(SettingValue::Integer(300)));
         assert_eq!(definition.mutability(), SettingMutability::ReadWrite);
     }
 
@@ -2558,6 +2897,41 @@ screen_restore_policy=aggressive
 
         assert!(matches!(
             definition.parse_value("kde"),
+            Err(SettingsError::InvalidValue { .. })
+        ));
+    }
+
+    #[test]
+    fn tv_values_are_validated() {
+        let ip = SETTINGS_REGISTRY.get_by_name("tv.ip").unwrap();
+        assert_eq!(
+            ip.parse_value("192.0.2.42"),
+            Ok(SettingValue::Ipv4("192.0.2.42".parse().unwrap()))
+        );
+        assert!(matches!(
+            ip.parse_value("not-an-ip"),
+            Err(SettingsError::InvalidValue { .. })
+        ));
+
+        let mac = SETTINGS_REGISTRY.get_by_name("tv.mac").unwrap();
+        assert_eq!(
+            mac.parse_value("AA:BB:CC:DD:EE:FF"),
+            Ok(SettingValue::MacAddress(
+                "AA:BB:CC:DD:EE:FF".parse().unwrap()
+            ))
+        );
+        assert!(matches!(
+            mac.parse_value("not-a-mac"),
+            Err(SettingsError::InvalidValue { .. })
+        ));
+
+        let input = SETTINGS_REGISTRY.get_by_name("tv.input").unwrap();
+        assert_eq!(
+            input.parse_value("HDMI_1"),
+            Ok(SettingValue::Enum("HDMI_1"))
+        );
+        assert!(matches!(
+            input.parse_value("AV_1"),
             Err(SettingsError::InvalidValue { .. })
         ));
     }

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -9,7 +9,7 @@ use std::process::{Command as ProcessCommand, Stdio};
 
 use crate::config::{
     parse_config_entries, resolve_config_path, resolve_config_path_from_env, ConfigPathError,
-    ConfigPathSources, MacAddress, DEFAULT_IDLE_TIMEOUT,
+    ConfigPathSources, MacAddress, DEFAULT_IDLE_TIMEOUT, MAX_IDLE_TIMEOUT,
 };
 
 const SETTINGS_SUBCOMMANDS: &[&str] = &["list", "describe", "get", "set", "unset"];
@@ -98,7 +98,7 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
         fallback_storage_keys: EMPTY_STORAGE_KEYS,
         value_type: SettingType::Integer(IntegerSettingType {
             min: 1,
-            max: 86_400,
+            max: MAX_IDLE_TIMEOUT as i64,
         }),
         default_value: Some(SettingValue::Integer(DEFAULT_IDLE_TIMEOUT as i64)),
         mutability: SettingMutability::ReadWrite,
@@ -1436,8 +1436,10 @@ impl SettingType {
                     value: value.to_string(),
                     expected: enum_type.expected(),
                 }),
-            Self::Integer(integer_type) => match value.parse::<i64>() {
-                Ok(parsed) if integer_type.contains(parsed) => Ok(SettingValue::Integer(parsed)),
+            Self::Integer(integer_type) => match value.parse::<i128>() {
+                Ok(parsed) if integer_type.accepts(parsed) => {
+                    Ok(SettingValue::Integer(integer_type.coerce(parsed)))
+                }
                 _ => Err(SettingsError::InvalidValue {
                     key: key.to_string(),
                     value: value.to_string(),
@@ -1640,6 +1642,18 @@ impl IntegerSettingType {
 
     pub fn contains(self, value: i64) -> bool {
         value >= self.min && value <= self.max
+    }
+
+    fn accepts(self, value: i128) -> bool {
+        value >= i128::from(self.min)
+    }
+
+    fn coerce(self, value: i128) -> i64 {
+        if value > i128::from(self.max) {
+            self.max
+        } else {
+            value as i64
+        }
     }
 
     fn expected(self) -> String {
@@ -2024,7 +2038,7 @@ mod tests {
         SettingType, SettingValue, SettingsApplier, SettingsCommand, SettingsCommandRunner,
         SettingsError, SettingsParseError, SettingsStore, UserServiceState, SETTINGS_REGISTRY,
     };
-    use crate::config::ConfigPathSources;
+    use crate::config::{ConfigPathSources, MAX_IDLE_TIMEOUT};
     use std::cell::Cell;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -2307,6 +2321,37 @@ screen_idle_timeout=300
         let output = String::from_utf8(output).unwrap();
         assert!(output.contains("screen.backend=gnome (saved to "));
         assert!(output.contains("apply: restarted LG_Buddy_screen.service\n"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn settings_runner_clamps_idle_timeout_above_max_when_setting() {
+        let path = unique_test_path("set-clamped-idle-timeout");
+        fs::write(&path, "screen_idle_timeout=300\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let runner = SettingsCommandRunner::with_applier(
+            store,
+            SettingsApplier::new(FakeServiceController::missing()),
+        );
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Set {
+                    key: "screen.idle_timeout".to_string(),
+                    value: "86401".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            format!("screen_idle_timeout={MAX_IDLE_TIMEOUT}\n")
+        );
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains(&format!("screen.idle_timeout={MAX_IDLE_TIMEOUT} ")));
 
         let _ = fs::remove_file(path);
     }
@@ -2725,6 +2770,20 @@ tvs_primary_ip=192.0.2.43
     }
 
     #[test]
+    fn settings_store_clamps_idle_timeout_above_max() {
+        let store =
+            ConfigEnvReader::parse("/tmp/config.env", "screen_idle_timeout=86401\n").into_store();
+
+        let idle_timeout = store.effective_by_name("screen.idle_timeout").unwrap();
+
+        assert_eq!(
+            idle_timeout.value(),
+            Some(SettingValue::Integer(MAX_IDLE_TIMEOUT as i64))
+        );
+        assert_eq!(idle_timeout.source(), SettingSource::ConfigEnv);
+    }
+
+    #[test]
     fn settings_store_canonicalizes_valid_alias_values_from_config_env() {
         let store =
             ConfigEnvReader::parse("/tmp/config.env", "screen_restore_policy=marker_only\n")
@@ -2967,8 +3026,16 @@ tvs_primary_ip=192.0.2.43
             definition.parse_value("86400"),
             Ok(SettingValue::Integer(86_400))
         );
+        assert_eq!(
+            definition.parse_value("86401"),
+            Ok(SettingValue::Integer(86_400))
+        );
+        assert_eq!(
+            definition.parse_value("18446744073709551615"),
+            Ok(SettingValue::Integer(86_400))
+        );
 
-        for value in ["0", "86401", "-1", "abc"] {
+        for value in ["0", "-1", "abc"] {
             assert!(
                 matches!(
                     definition.parse_value(value),

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -20,9 +20,6 @@ const READ_WRITE_OPERATIONS: &[SettingOperation] = &[
     SettingOperation::Set,
     SettingOperation::Unset,
 ];
-const READ_ONLY_OPERATIONS: &[SettingOperation] =
-    &[SettingOperation::Get, SettingOperation::Describe];
-
 const EMPTY_ALIASES: &[SettingAlias] = &[];
 const SCREEN_RESTORE_POLICY_ALIASES: &[SettingAlias] = &[SettingAlias {
     from: "marker_only",
@@ -81,9 +78,9 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
             aliases: EMPTY_ALIASES,
         }),
         default_value: SettingValue::Enum("enabled"),
-        mutability: SettingMutability::ReadOnly,
-        operations: READ_ONLY_OPERATIONS,
-        apply_strategy: ApplyStrategy::PendingLifecycleService,
+        mutability: SettingMutability::ReadWrite,
+        operations: READ_WRITE_OPERATIONS,
+        apply_strategy: ApplyStrategy::RuntimePolicyOnly,
         description: "System sleep and wake policy for lifecycle hooks.",
     },
 ];
@@ -752,7 +749,7 @@ impl<C: ServiceController> SettingsApplier<C> {
     pub fn apply(&self, change: &SettingsChange) -> Result<SettingsApplyOutcome, SettingsError> {
         match change.mutation().definition().apply_strategy() {
             ApplyStrategy::RestartUserScreenService => self.apply_screen_service_restart(),
-            ApplyStrategy::PendingLifecycleService => Ok(SettingsApplyOutcome::NoActionRequired),
+            ApplyStrategy::RuntimePolicyOnly => Ok(SettingsApplyOutcome::NoActionRequired),
         }
     }
 
@@ -1561,14 +1558,14 @@ impl fmt::Display for SettingOperation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApplyStrategy {
     RestartUserScreenService,
-    PendingLifecycleService,
+    RuntimePolicyOnly,
 }
 
 impl ApplyStrategy {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::RestartUserScreenService => "restart-user-screen-service",
-            Self::PendingLifecycleService => "pending-lifecycle-service",
+            Self::RuntimePolicyOnly => "runtime-policy-only",
         }
     }
 }
@@ -1962,7 +1959,7 @@ mod tests {
 screen.backend=gnome (config.env, read-write, ops: get,describe,set,unset)
 screen.idle_timeout=300 (default, read-write, ops: get,describe,set,unset)
 screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)
-system.sleep_wake_policy=disabled (config.env, read-only, ops: get,describe)
+system.sleep_wake_policy=disabled (config.env, read-write, ops: get,describe,set,unset)
 "
         );
     }
@@ -2028,7 +2025,7 @@ system.sleep_wake_policy=disabled (config.env, read-only, ops: get,describe)
         assert!(output.contains("screen.idle_timeout\n"));
         assert!(output.contains("  range: 1..=86400\n"));
         assert!(output.contains("system.sleep_wake_policy\n"));
-        assert!(output.contains("  supported operations: get, describe\n"));
+        assert!(output.contains("  supported operations: get, describe, set, unset\n"));
     }
 
     #[test]
@@ -2221,17 +2218,16 @@ screen_restore_policy=aggressive
     }
 
     #[test]
-    fn settings_runner_rejects_read_only_write_without_touching_config() {
-        let path = unique_test_path("readonly");
+    fn settings_runner_sets_lifecycle_policy_without_service_restart() {
+        let path = unique_test_path("lifecycle-policy");
         fs::write(&path, "system_sleep_wake_policy=disabled\n").unwrap();
         let store = SettingsStore::load(&path).unwrap();
-        let runner = SettingsCommandRunner::with_applier(
-            store,
-            SettingsApplier::new(FakeServiceController::active_or_enabled()),
-        );
+        let fake_service = FakeServiceController::active_or_enabled();
+        let restarts = fake_service.restarts.clone();
+        let runner = SettingsCommandRunner::with_applier(store, SettingsApplier::new(fake_service));
         let mut output = Vec::new();
 
-        let err = runner
+        runner
             .run(
                 SettingsCommand::Set {
                     key: "system.sleep_wake_policy".to_string(),
@@ -2239,20 +2235,16 @@ screen_restore_policy=aggressive
                 },
                 &mut output,
             )
-            .unwrap_err();
+            .unwrap();
 
         assert_eq!(
-            err,
-            SettingsError::UnsupportedOperation {
-                key: "system.sleep_wake_policy".to_string(),
-                operation: SettingOperation::Set,
-            }
-        );
-        assert_eq!(
             fs::read_to_string(&path).unwrap(),
-            "system_sleep_wake_policy=disabled\n"
+            "system_sleep_wake_policy=enabled\n"
         );
-        assert!(output.is_empty());
+        assert_eq!(restarts.get(), 0);
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("system.sleep_wake_policy=enabled (saved to "));
+        assert!(output.contains("apply: no runtime apply action required\n"));
 
         let _ = fs::remove_file(path);
     }
@@ -2632,18 +2624,19 @@ screen_restore_policy=aggressive
         let sleep_definition = SETTINGS_REGISTRY
             .get_by_name("system.sleep_wake_policy")
             .unwrap();
-        assert_eq!(sleep_definition.mutability(), SettingMutability::ReadOnly);
+        assert_eq!(sleep_definition.mutability(), SettingMutability::ReadWrite);
         assert_eq!(
             sleep_definition.supported_operations(),
-            &[SettingOperation::Get, SettingOperation::Describe]
+            &[
+                SettingOperation::Get,
+                SettingOperation::Describe,
+                SettingOperation::Set,
+                SettingOperation::Unset,
+            ]
         );
-        assert_eq!(
-            sleep_definition.ensure_operation_supported(SettingOperation::Set),
-            Err(SettingsError::UnsupportedOperation {
-                key: "system.sleep_wake_policy".to_string(),
-                operation: SettingOperation::Set,
-            })
-        );
+        sleep_definition
+            .ensure_operation_supported(SettingOperation::Set)
+            .unwrap();
     }
 
     #[test]
@@ -2663,7 +2656,7 @@ screen_restore_policy=aggressive
         assert!(matches!(sleep_policy.value_type(), SettingType::Enum(_)));
         assert_eq!(
             sleep_policy.apply_strategy(),
-            ApplyStrategy::PendingLifecycleService
+            ApplyStrategy::RuntimePolicyOnly
         );
     }
 

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -1,0 +1,904 @@
+use std::collections::HashSet;
+use std::fmt;
+
+use crate::config::DEFAULT_IDLE_TIMEOUT;
+
+const READ_WRITE_OPERATIONS: &[SettingOperation] = &[
+    SettingOperation::Get,
+    SettingOperation::Describe,
+    SettingOperation::Set,
+    SettingOperation::Unset,
+];
+const READ_ONLY_OPERATIONS: &[SettingOperation] =
+    &[SettingOperation::Get, SettingOperation::Describe];
+
+const EMPTY_ALIASES: &[SettingAlias] = &[];
+const SCREEN_RESTORE_POLICY_ALIASES: &[SettingAlias] = &[SettingAlias {
+    from: "marker_only",
+    to: "conservative",
+}];
+
+const SCREEN_BACKEND_VALUES: &[&str] = &["auto", "gnome", "swayidle"];
+const SCREEN_RESTORE_POLICY_VALUES: &[&str] = &["conservative", "aggressive"];
+const SYSTEM_SLEEP_WAKE_POLICY_VALUES: &[&str] = &["enabled", "disabled"];
+
+const SETTING_DEFINITIONS: &[SettingDefinition] = &[
+    SettingDefinition {
+        key: "screen.backend",
+        storage_key: "screen_backend",
+        value_type: SettingType::Enum(EnumSettingType {
+            values: SCREEN_BACKEND_VALUES,
+            aliases: EMPTY_ALIASES,
+        }),
+        default_value: SettingValue::Enum("auto"),
+        mutability: SettingMutability::ReadWrite,
+        operations: READ_WRITE_OPERATIONS,
+        apply_strategy: ApplyStrategy::RestartUserScreenService,
+        description: "Screen backend selection for user-session blanking and restore behavior.",
+    },
+    SettingDefinition {
+        key: "screen.idle_timeout",
+        storage_key: "screen_idle_timeout",
+        value_type: SettingType::Integer(IntegerSettingType {
+            min: 1,
+            max: 86_400,
+        }),
+        default_value: SettingValue::Integer(DEFAULT_IDLE_TIMEOUT as i64),
+        mutability: SettingMutability::ReadWrite,
+        operations: READ_WRITE_OPERATIONS,
+        apply_strategy: ApplyStrategy::RestartUserScreenService,
+        description: "Idle timeout in seconds before LG Buddy blanks the configured screen.",
+    },
+    SettingDefinition {
+        key: "screen.restore_policy",
+        storage_key: "screen_restore_policy",
+        value_type: SettingType::Enum(EnumSettingType {
+            values: SCREEN_RESTORE_POLICY_VALUES,
+            aliases: SCREEN_RESTORE_POLICY_ALIASES,
+        }),
+        default_value: SettingValue::Enum("conservative"),
+        mutability: SettingMutability::ReadWrite,
+        operations: READ_WRITE_OPERATIONS,
+        apply_strategy: ApplyStrategy::RestartUserScreenService,
+        description: "Screen restore policy after LG Buddy blanks the configured screen.",
+    },
+    SettingDefinition {
+        key: "system.sleep_wake_policy",
+        storage_key: "system_sleep_wake_policy",
+        value_type: SettingType::Enum(EnumSettingType {
+            values: SYSTEM_SLEEP_WAKE_POLICY_VALUES,
+            aliases: EMPTY_ALIASES,
+        }),
+        default_value: SettingValue::Enum("enabled"),
+        mutability: SettingMutability::ReadOnly,
+        operations: READ_ONLY_OPERATIONS,
+        apply_strategy: ApplyStrategy::PendingLifecycleService,
+        description: "System sleep and wake policy for lifecycle hooks.",
+    },
+];
+
+pub static SETTINGS_REGISTRY: SettingsRegistry = SettingsRegistry {
+    definitions: SETTING_DEFINITIONS,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct SettingsRegistry {
+    definitions: &'static [SettingDefinition],
+}
+
+impl SettingsRegistry {
+    pub fn all(&self) -> &'static [SettingDefinition] {
+        self.definitions
+    }
+
+    pub fn get(&self, key: SettingKey<'_>) -> Result<&'static SettingDefinition, SettingsError> {
+        self.definitions
+            .iter()
+            .find(|definition| definition.key == key.as_str())
+            .ok_or_else(|| SettingsError::UnknownKey(key.as_str().to_string()))
+    }
+
+    pub fn get_by_name(&self, key: &str) -> Result<&'static SettingDefinition, SettingsError> {
+        self.get(SettingKey::parse(key)?)
+    }
+
+    pub fn validate(&self) -> Result<(), SettingsError> {
+        let mut public_keys = HashSet::new();
+        let mut storage_keys = HashSet::new();
+
+        for definition in self.definitions {
+            SettingKey::parse(definition.key)?;
+            validate_storage_key(definition.storage_key).map_err(|reason| {
+                SettingsError::RegistryInvariant(format!(
+                    "invalid storage key `{}` for `{}`: {reason}",
+                    definition.storage_key, definition.key
+                ))
+            })?;
+
+            if !public_keys.insert(definition.key) {
+                return Err(SettingsError::RegistryInvariant(format!(
+                    "duplicate setting key `{}`",
+                    definition.key
+                )));
+            }
+
+            if !storage_keys.insert(definition.storage_key) {
+                return Err(SettingsError::RegistryInvariant(format!(
+                    "duplicate storage key `{}`",
+                    definition.storage_key
+                )));
+            }
+
+            definition.validate_type_metadata()?;
+            definition.validate_default()?;
+            definition.validate_operation_metadata()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SettingKey<'a>(&'a str);
+
+impl<'a> SettingKey<'a> {
+    pub fn parse(value: &'a str) -> Result<Self, SettingsError> {
+        validate_setting_key(value)
+            .map_err(|reason| SettingsError::InvalidKey {
+                key: value.to_string(),
+                reason,
+            })
+            .map(|()| Self(value))
+    }
+
+    pub fn as_str(self) -> &'a str {
+        self.0
+    }
+}
+
+impl fmt::Display for SettingKey<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SettingDefinition {
+    key: &'static str,
+    storage_key: &'static str,
+    value_type: SettingType,
+    default_value: SettingValue,
+    mutability: SettingMutability,
+    operations: &'static [SettingOperation],
+    apply_strategy: ApplyStrategy,
+    description: &'static str,
+}
+
+impl SettingDefinition {
+    pub fn key(&self) -> SettingKey<'static> {
+        SettingKey(self.key)
+    }
+
+    pub fn key_name(&self) -> &'static str {
+        self.key
+    }
+
+    pub fn storage_key(&self) -> &'static str {
+        self.storage_key
+    }
+
+    pub fn value_type(&self) -> SettingType {
+        self.value_type
+    }
+
+    pub fn default_value(&self) -> SettingValue {
+        self.default_value
+    }
+
+    pub fn mutability(&self) -> SettingMutability {
+        self.mutability
+    }
+
+    pub fn supported_operations(&self) -> &'static [SettingOperation] {
+        self.operations
+    }
+
+    pub fn apply_strategy(&self) -> ApplyStrategy {
+        self.apply_strategy
+    }
+
+    pub fn description(&self) -> &'static str {
+        self.description
+    }
+
+    pub fn supports_operation(&self, operation: SettingOperation) -> bool {
+        self.operations.contains(&operation)
+    }
+
+    pub fn ensure_operation_supported(
+        &self,
+        operation: SettingOperation,
+    ) -> Result<(), SettingsError> {
+        if self.supports_operation(operation) {
+            Ok(())
+        } else {
+            Err(SettingsError::UnsupportedOperation {
+                key: self.key.to_string(),
+                operation,
+            })
+        }
+    }
+
+    pub fn parse_value(&self, value: &str) -> Result<SettingValue, SettingsError> {
+        self.value_type.parse_value(self.key, value)
+    }
+
+    fn validate_type_metadata(&self) -> Result<(), SettingsError> {
+        match self.value_type {
+            SettingType::Enum(enum_type) => enum_type.validate(self.key),
+            SettingType::Integer(integer_type) => integer_type.validate(self.key),
+        }
+    }
+
+    fn validate_default(&self) -> Result<(), SettingsError> {
+        self.value_type
+            .validate_value(self.key, self.default_value)
+            .map_err(|err| match err {
+                SettingsError::InvalidValue {
+                    key,
+                    value,
+                    expected,
+                } => SettingsError::RegistryInvariant(format!(
+                    "invalid default value `{value}` for `{key}`: expected {expected}"
+                )),
+                other => other,
+            })
+    }
+
+    fn validate_operation_metadata(&self) -> Result<(), SettingsError> {
+        if self.operations.is_empty() {
+            return Err(SettingsError::RegistryInvariant(format!(
+                "`{}` must support at least one operation",
+                self.key
+            )));
+        }
+
+        match self.mutability {
+            SettingMutability::ReadWrite => {
+                for operation in READ_WRITE_OPERATIONS {
+                    if !self.operations.contains(operation) {
+                        return Err(SettingsError::RegistryInvariant(format!(
+                            "`{}` is read-write but does not support `{}`",
+                            self.key,
+                            operation.as_str()
+                        )));
+                    }
+                }
+            }
+            SettingMutability::ReadOnly => {
+                for operation in [SettingOperation::Set, SettingOperation::Unset] {
+                    if self.operations.contains(&operation) {
+                        return Err(SettingsError::RegistryInvariant(format!(
+                            "`{}` is read-only but supports `{}`",
+                            self.key,
+                            operation.as_str()
+                        )));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingType {
+    Enum(EnumSettingType),
+    Integer(IntegerSettingType),
+}
+
+impl SettingType {
+    pub fn parse_value(self, key: &str, value: &str) -> Result<SettingValue, SettingsError> {
+        match self {
+            Self::Enum(enum_type) => enum_type
+                .canonicalize(value)
+                .map(SettingValue::Enum)
+                .ok_or_else(|| SettingsError::InvalidValue {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                    expected: enum_type.expected(),
+                }),
+            Self::Integer(integer_type) => match value.parse::<i64>() {
+                Ok(parsed) if integer_type.contains(parsed) => Ok(SettingValue::Integer(parsed)),
+                _ => Err(SettingsError::InvalidValue {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                    expected: integer_type.expected(),
+                }),
+            },
+        }
+    }
+
+    pub fn validate_value(self, key: &str, value: SettingValue) -> Result<(), SettingsError> {
+        match (self, value) {
+            (Self::Enum(enum_type), SettingValue::Enum(value)) => {
+                match enum_type.canonicalize(value) {
+                    Some(canonical) if canonical == value => Ok(()),
+                    _ => Err(SettingsError::InvalidValue {
+                        key: key.to_string(),
+                        value: value.to_string(),
+                        expected: enum_type.expected(),
+                    }),
+                }
+            }
+            (Self::Integer(integer_type), SettingValue::Integer(value))
+                if integer_type.contains(value) =>
+            {
+                Ok(())
+            }
+            (Self::Integer(integer_type), SettingValue::Integer(value)) => {
+                Err(SettingsError::InvalidValue {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                    expected: integer_type.expected(),
+                })
+            }
+            (expected_type, actual_value) => Err(SettingsError::InvalidValue {
+                key: key.to_string(),
+                value: actual_value.to_string(),
+                expected: expected_type.expected(),
+            }),
+        }
+    }
+
+    pub fn expected(self) -> String {
+        match self {
+            Self::Enum(enum_type) => enum_type.expected(),
+            Self::Integer(integer_type) => integer_type.expected(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnumSettingType {
+    values: &'static [&'static str],
+    aliases: &'static [SettingAlias],
+}
+
+impl EnumSettingType {
+    pub fn values(self) -> &'static [&'static str] {
+        self.values
+    }
+
+    pub fn aliases(self) -> &'static [SettingAlias] {
+        self.aliases
+    }
+
+    pub fn canonicalize(self, value: &str) -> Option<&'static str> {
+        if let Some(canonical) = self
+            .values
+            .iter()
+            .copied()
+            .find(|allowed| *allowed == value)
+        {
+            return Some(canonical);
+        }
+
+        self.aliases
+            .iter()
+            .find(|alias| alias.from == value)
+            .map(|alias| alias.to)
+    }
+
+    fn expected(self) -> String {
+        format!("one of {}", self.values.join(", "))
+    }
+
+    fn validate(self, key: &str) -> Result<(), SettingsError> {
+        if self.values.is_empty() {
+            return Err(SettingsError::RegistryInvariant(format!(
+                "`{key}` enum settings must define at least one value"
+            )));
+        }
+
+        let mut values = HashSet::new();
+        for value in self.values {
+            if value.is_empty() {
+                return Err(SettingsError::RegistryInvariant(format!(
+                    "`{key}` enum settings must not define empty values"
+                )));
+            }
+
+            if !values.insert(*value) {
+                return Err(SettingsError::RegistryInvariant(format!(
+                    "`{key}` enum setting has duplicate value `{value}`"
+                )));
+            }
+        }
+
+        let mut aliases = HashSet::new();
+        for alias in self.aliases {
+            if alias.from.is_empty() || alias.to.is_empty() {
+                return Err(SettingsError::RegistryInvariant(format!(
+                    "`{key}` enum settings must not define empty aliases"
+                )));
+            }
+
+            if values.contains(alias.from) {
+                return Err(SettingsError::RegistryInvariant(format!(
+                    "`{key}` enum alias `{}` duplicates a canonical value",
+                    alias.from
+                )));
+            }
+
+            if !values.contains(alias.to) {
+                return Err(SettingsError::RegistryInvariant(format!(
+                    "`{key}` enum alias `{}` points to unknown value `{}`",
+                    alias.from, alias.to
+                )));
+            }
+
+            if !aliases.insert(alias.from) {
+                return Err(SettingsError::RegistryInvariant(format!(
+                    "`{key}` enum setting has duplicate alias `{}`",
+                    alias.from
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SettingAlias {
+    from: &'static str,
+    to: &'static str,
+}
+
+impl SettingAlias {
+    pub fn from(self) -> &'static str {
+        self.from
+    }
+
+    pub fn to(self) -> &'static str {
+        self.to
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IntegerSettingType {
+    min: i64,
+    max: i64,
+}
+
+impl IntegerSettingType {
+    pub fn min(self) -> i64 {
+        self.min
+    }
+
+    pub fn max(self) -> i64 {
+        self.max
+    }
+
+    pub fn contains(self, value: i64) -> bool {
+        value >= self.min && value <= self.max
+    }
+
+    fn expected(self) -> String {
+        format!("an integer from {} to {}", self.min, self.max)
+    }
+
+    fn validate(self, key: &str) -> Result<(), SettingsError> {
+        if self.min <= self.max {
+            Ok(())
+        } else {
+            Err(SettingsError::RegistryInvariant(format!(
+                "`{key}` integer setting has an invalid range {}..{}",
+                self.min, self.max
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingValue {
+    Enum(&'static str),
+    Integer(i64),
+}
+
+impl SettingValue {
+    pub fn as_enum(self) -> Option<&'static str> {
+        match self {
+            Self::Enum(value) => Some(value),
+            Self::Integer(_) => None,
+        }
+    }
+
+    pub fn as_integer(self) -> Option<i64> {
+        match self {
+            Self::Enum(_) => None,
+            Self::Integer(value) => Some(value),
+        }
+    }
+}
+
+impl fmt::Display for SettingValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Enum(value) => write!(f, "{value}"),
+            Self::Integer(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingMutability {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl SettingMutability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read-only",
+            Self::ReadWrite => "read-write",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SettingOperation {
+    Get,
+    Describe,
+    Set,
+    Unset,
+}
+
+impl SettingOperation {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Get => "get",
+            Self::Describe => "describe",
+            Self::Set => "set",
+            Self::Unset => "unset",
+        }
+    }
+}
+
+impl fmt::Display for SettingOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyStrategy {
+    RestartUserScreenService,
+    PendingLifecycleService,
+}
+
+impl ApplyStrategy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RestartUserScreenService => "restart-user-screen-service",
+            Self::PendingLifecycleService => "pending-lifecycle-service",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsError {
+    InvalidKey {
+        key: String,
+        reason: &'static str,
+    },
+    UnknownKey(String),
+    InvalidValue {
+        key: String,
+        value: String,
+        expected: String,
+    },
+    UnsupportedOperation {
+        key: String,
+        operation: SettingOperation,
+    },
+    RegistryInvariant(String),
+}
+
+impl fmt::Display for SettingsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidKey { key, reason } => {
+                write!(f, "invalid setting key `{key}`: {reason}")
+            }
+            Self::UnknownKey(key) => write!(f, "unknown setting `{key}`"),
+            Self::InvalidValue {
+                key,
+                value,
+                expected,
+            } => write!(
+                f,
+                "invalid value for setting `{key}`: `{value}`; expected {expected}"
+            ),
+            Self::UnsupportedOperation { key, operation } => {
+                write!(
+                    f,
+                    "setting `{key}` does not support `{}`",
+                    operation.as_str()
+                )
+            }
+            Self::RegistryInvariant(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for SettingsError {}
+
+fn validate_setting_key(value: &str) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("must not be empty");
+    }
+
+    let mut last_was_dot = true;
+    let mut has_dot = false;
+
+    for byte in value.bytes() {
+        match byte {
+            b'a'..=b'z' | b'0'..=b'9' | b'_' => {
+                last_was_dot = false;
+            }
+            b'.' if !last_was_dot => {
+                last_was_dot = true;
+                has_dot = true;
+            }
+            b'.' => return Err("must not contain empty segments"),
+            _ => {
+                return Err(
+                    "must contain only ASCII lowercase letters, digits, underscores, and dots",
+                )
+            }
+        }
+    }
+
+    if last_was_dot {
+        return Err("must not end with a dot");
+    }
+
+    if !has_dot {
+        return Err("must contain at least one dot");
+    }
+
+    Ok(())
+}
+
+fn validate_storage_key(value: &str) -> Result<(), &'static str> {
+    if value.is_empty() {
+        return Err("must not be empty");
+    }
+
+    if value
+        .bytes()
+        .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'_'))
+    {
+        Ok(())
+    } else {
+        Err("must contain only ASCII lowercase letters, digits, and underscores")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ApplyStrategy, SettingKey, SettingMutability, SettingOperation, SettingType, SettingValue,
+        SettingsError, SETTINGS_REGISTRY,
+    };
+
+    #[test]
+    fn registry_metadata_is_internally_valid() {
+        SETTINGS_REGISTRY.validate().unwrap();
+    }
+
+    #[test]
+    fn registry_contains_initial_settings() {
+        let keys: Vec<&str> = SETTINGS_REGISTRY
+            .all()
+            .iter()
+            .map(|definition| definition.key_name())
+            .collect();
+
+        assert_eq!(
+            keys,
+            vec![
+                "screen.backend",
+                "screen.idle_timeout",
+                "screen.restore_policy",
+                "system.sleep_wake_policy",
+            ]
+        );
+    }
+
+    #[test]
+    fn registry_maps_public_keys_to_storage_keys() {
+        let mappings: Vec<(&str, &str)> = SETTINGS_REGISTRY
+            .all()
+            .iter()
+            .map(|definition| (definition.key_name(), definition.storage_key()))
+            .collect();
+
+        assert_eq!(
+            mappings,
+            vec![
+                ("screen.backend", "screen_backend"),
+                ("screen.idle_timeout", "screen_idle_timeout"),
+                ("screen.restore_policy", "screen_restore_policy"),
+                ("system.sleep_wake_policy", "system_sleep_wake_policy"),
+            ]
+        );
+    }
+
+    #[test]
+    fn key_parser_accepts_supported_dotted_names() {
+        for key in [
+            "screen.backend",
+            "screen.idle_timeout",
+            "system.sleep_wake_policy",
+        ] {
+            assert_eq!(SettingKey::parse(key).unwrap().as_str(), key);
+        }
+    }
+
+    #[test]
+    fn key_parser_rejects_invalid_names() {
+        for key in [
+            "",
+            "screen",
+            ".screen.backend",
+            "screen.",
+            "screen..backend",
+            "Screen.backend",
+            "screen-backend",
+            "screen backend",
+        ] {
+            assert!(
+                matches!(
+                    SettingKey::parse(key),
+                    Err(SettingsError::InvalidKey { .. })
+                ),
+                "expected invalid key for `{key}`"
+            );
+        }
+    }
+
+    #[test]
+    fn lookup_returns_definitions_by_key() {
+        let definition = SETTINGS_REGISTRY
+            .get_by_name("screen.idle_timeout")
+            .unwrap();
+
+        assert_eq!(definition.key_name(), "screen.idle_timeout");
+        assert_eq!(definition.storage_key(), "screen_idle_timeout");
+        assert_eq!(definition.default_value(), SettingValue::Integer(300));
+        assert_eq!(definition.mutability(), SettingMutability::ReadWrite);
+    }
+
+    #[test]
+    fn lookup_rejects_unknown_keys() {
+        assert!(matches!(
+            SETTINGS_REGISTRY.get_by_name("screen.unknown"),
+            Err(SettingsError::UnknownKey(key)) if key == "screen.unknown"
+        ));
+    }
+
+    #[test]
+    fn screen_backend_values_are_validated() {
+        let definition = SETTINGS_REGISTRY.get_by_name("screen.backend").unwrap();
+
+        for value in ["auto", "gnome", "swayidle"] {
+            assert_eq!(definition.parse_value(value), Ok(SettingValue::Enum(value)));
+        }
+
+        assert!(matches!(
+            definition.parse_value("kde"),
+            Err(SettingsError::InvalidValue { .. })
+        ));
+    }
+
+    #[test]
+    fn screen_restore_policy_accepts_legacy_alias() {
+        let definition = SETTINGS_REGISTRY
+            .get_by_name("screen.restore_policy")
+            .unwrap();
+
+        assert_eq!(
+            definition.parse_value("conservative"),
+            Ok(SettingValue::Enum("conservative"))
+        );
+        assert_eq!(
+            definition.parse_value("marker_only"),
+            Ok(SettingValue::Enum("conservative"))
+        );
+        assert_eq!(
+            definition.parse_value("aggressive"),
+            Ok(SettingValue::Enum("aggressive"))
+        );
+    }
+
+    #[test]
+    fn integer_values_are_range_checked() {
+        let definition = SETTINGS_REGISTRY
+            .get_by_name("screen.idle_timeout")
+            .unwrap();
+
+        assert_eq!(definition.parse_value("1"), Ok(SettingValue::Integer(1)));
+        assert_eq!(
+            definition.parse_value("86400"),
+            Ok(SettingValue::Integer(86_400))
+        );
+
+        for value in ["0", "86401", "-1", "abc"] {
+            assert!(
+                matches!(
+                    definition.parse_value(value),
+                    Err(SettingsError::InvalidValue { .. })
+                ),
+                "expected invalid idle timeout for `{value}`"
+            );
+        }
+    }
+
+    #[test]
+    fn mutability_controls_supported_operations() {
+        let screen_definition = SETTINGS_REGISTRY.get_by_name("screen.backend").unwrap();
+        assert_eq!(
+            screen_definition.supported_operations(),
+            &[
+                SettingOperation::Get,
+                SettingOperation::Describe,
+                SettingOperation::Set,
+                SettingOperation::Unset,
+            ]
+        );
+        screen_definition
+            .ensure_operation_supported(SettingOperation::Set)
+            .unwrap();
+
+        let sleep_definition = SETTINGS_REGISTRY
+            .get_by_name("system.sleep_wake_policy")
+            .unwrap();
+        assert_eq!(sleep_definition.mutability(), SettingMutability::ReadOnly);
+        assert_eq!(
+            sleep_definition.supported_operations(),
+            &[SettingOperation::Get, SettingOperation::Describe]
+        );
+        assert_eq!(
+            sleep_definition.ensure_operation_supported(SettingOperation::Set),
+            Err(SettingsError::UnsupportedOperation {
+                key: "system.sleep_wake_policy".to_string(),
+                operation: SettingOperation::Set,
+            })
+        );
+    }
+
+    #[test]
+    fn definitions_expose_type_and_apply_metadata() {
+        let idle_timeout = SETTINGS_REGISTRY
+            .get_by_name("screen.idle_timeout")
+            .unwrap();
+        assert!(matches!(idle_timeout.value_type(), SettingType::Integer(_)));
+        assert_eq!(
+            idle_timeout.apply_strategy(),
+            ApplyStrategy::RestartUserScreenService
+        );
+
+        let sleep_policy = SETTINGS_REGISTRY
+            .get_by_name("system.sleep_wake_policy")
+            .unwrap();
+        assert!(matches!(sleep_policy.value_type(), SettingType::Enum(_)));
+        assert_eq!(
+            sleep_policy.apply_strategy(),
+            ApplyStrategy::PendingLifecycleService
+        );
+    }
+}

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
 
 use crate::config::{
     parse_config_entries, resolve_config_path, resolve_config_path_from_env, ConfigPathError,
@@ -10,6 +12,7 @@ use crate::config::{
 };
 
 const SETTINGS_SUBCOMMANDS: &[&str] = &["list", "describe", "get", "set", "unset"];
+const SCREEN_SERVICE_NAME: &str = "LG_Buddy_screen.service";
 
 const READ_WRITE_OPERATIONS: &[SettingOperation] = &[
     SettingOperation::Get,
@@ -300,6 +303,63 @@ impl SettingsFormatter {
         Ok(())
     }
 
+    pub fn write_change<W: io::Write>(
+        &self,
+        writer: &mut W,
+        change: &SettingsChange,
+        apply: &SettingsApplyOutcome,
+    ) -> Result<(), SettingsError> {
+        let mutation = change.mutation();
+
+        match (mutation.action(), change.file_changed()) {
+            (SettingsMutationAction::Set, true) => {
+                writeln!(
+                    writer,
+                    "{}={} (saved to {})",
+                    mutation.key_name(),
+                    mutation.new_value(),
+                    change.path().display()
+                )
+                .map_err(output_error)?;
+            }
+            (SettingsMutationAction::Set, false) => {
+                writeln!(
+                    writer,
+                    "{} already set to {} ({})",
+                    mutation.key_name(),
+                    mutation.new_value(),
+                    change.path().display()
+                )
+                .map_err(output_error)?;
+            }
+            (SettingsMutationAction::Unset, true) => {
+                writeln!(
+                    writer,
+                    "{} unset (saved to {})",
+                    mutation.key_name(),
+                    change.path().display()
+                )
+                .map_err(output_error)?;
+            }
+            (SettingsMutationAction::Unset, false) => {
+                writeln!(
+                    writer,
+                    "{} already unset ({})",
+                    mutation.key_name(),
+                    change.path().display()
+                )
+                .map_err(output_error)?;
+            }
+        }
+
+        if !change.file_changed() {
+            writeln!(writer, "config: unchanged").map_err(output_error)?;
+        }
+
+        writeln!(writer, "apply: {apply}").map_err(output_error)?;
+        Ok(())
+    }
+
     fn write_single_description<W: io::Write>(
         &self,
         writer: &mut W,
@@ -354,16 +414,393 @@ impl SettingsFormatter {
 }
 
 #[derive(Debug, Clone)]
-pub struct SettingsCommandRunner {
-    store: SettingsStore,
-    formatter: SettingsFormatter,
+pub struct ConfigEnvEditor {
+    path: PathBuf,
+    lines: Vec<String>,
 }
 
-impl SettingsCommandRunner {
+impl ConfigEnvEditor {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, SettingsError> {
+        let path = path.as_ref().to_path_buf();
+        match fs::read_to_string(&path) {
+            Ok(contents) => Ok(Self::parse(path, &contents)),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(Self::empty(path)),
+            Err(err) => Err(SettingsError::ReadConfig {
+                path,
+                kind: err.kind(),
+                message: err.to_string(),
+            }),
+        }
+    }
+
+    pub fn parse(path: impl Into<PathBuf>, contents: &str) -> Self {
+        Self {
+            path: path.into(),
+            lines: contents.lines().map(str::to_string).collect(),
+        }
+    }
+
+    pub fn empty(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            lines: Vec::new(),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn set(&mut self, storage_key: &str, value: SettingValue) -> bool {
+        let value = value.to_string();
+
+        if let Some(index) = self.last_key_index(storage_key) {
+            let replacement = replace_config_line_value(&self.lines[index], storage_key, &value);
+            let changed = self.lines[index] != replacement;
+            self.lines[index] = replacement;
+            changed
+        } else {
+            self.lines.push(format!("{storage_key}={value}"));
+            true
+        }
+    }
+
+    pub fn unset(&mut self, storage_key: &str) -> bool {
+        let original_len = self.lines.len();
+        self.lines
+            .retain(|line| config_line_key(line) != Some(storage_key));
+        self.lines.len() != original_len
+    }
+
+    pub fn save(&self) -> Result<(), SettingsError> {
+        if let Some(parent) = self.path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).map_err(|err| SettingsError::WriteConfig {
+                    path: parent.to_path_buf(),
+                    message: err.to_string(),
+                })?;
+            }
+        }
+
+        fs::write(&self.path, self.render()).map_err(|err| SettingsError::WriteConfig {
+            path: self.path.clone(),
+            message: err.to_string(),
+        })
+    }
+
+    pub fn render(&self) -> String {
+        if self.lines.is_empty() {
+            String::new()
+        } else {
+            format!("{}\n", self.lines.join("\n"))
+        }
+    }
+
+    fn last_key_index(&self, storage_key: &str) -> Option<usize> {
+        self.lines
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, line)| config_line_key(line) == Some(storage_key))
+            .map(|(index, _)| index)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsMutationAction {
+    Set,
+    Unset,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SettingsMutation {
+    definition: &'static SettingDefinition,
+    old_value: SettingValue,
+    old_source: SettingSource,
+    new_value: SettingValue,
+    action: SettingsMutationAction,
+}
+
+impl SettingsMutation {
+    pub fn set(store: &SettingsStore, key: &str, value: &str) -> Result<Self, SettingsError> {
+        let definition = SETTINGS_REGISTRY.get_by_name(key)?;
+        definition.ensure_operation_supported(SettingOperation::Set)?;
+        let old = store.effective_definition(definition);
+        let new_value = definition.parse_value(value)?;
+
+        Ok(Self {
+            definition,
+            old_value: old.value(),
+            old_source: old.source(),
+            new_value,
+            action: SettingsMutationAction::Set,
+        })
+    }
+
+    pub fn unset(store: &SettingsStore, key: &str) -> Result<Self, SettingsError> {
+        let definition = SETTINGS_REGISTRY.get_by_name(key)?;
+        definition.ensure_operation_supported(SettingOperation::Unset)?;
+        let old = store.effective_definition(definition);
+
+        Ok(Self {
+            definition,
+            old_value: old.value(),
+            old_source: old.source(),
+            new_value: definition.default_value(),
+            action: SettingsMutationAction::Unset,
+        })
+    }
+
+    pub fn definition(self) -> &'static SettingDefinition {
+        self.definition
+    }
+
+    pub fn key_name(self) -> &'static str {
+        self.definition.key_name()
+    }
+
+    pub fn storage_key(self) -> &'static str {
+        self.definition.storage_key()
+    }
+
+    pub fn old_value(self) -> SettingValue {
+        self.old_value
+    }
+
+    pub fn old_source(self) -> SettingSource {
+        self.old_source
+    }
+
+    pub fn new_value(self) -> SettingValue {
+        self.new_value
+    }
+
+    pub fn action(self) -> SettingsMutationAction {
+        self.action
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SettingsChange {
+    mutation: SettingsMutation,
+    path: PathBuf,
+    file_changed: bool,
+}
+
+impl SettingsChange {
+    pub fn mutation(&self) -> SettingsMutation {
+        self.mutation
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn file_changed(&self) -> bool {
+        self.file_changed
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsApplyOutcome {
+    Restarted { service: &'static str },
+    NotInstalled { service: &'static str },
+    InactiveDisabled { service: &'static str },
+    Skipped { reason: String },
+    NoActionRequired,
+}
+
+impl fmt::Display for SettingsApplyOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Restarted { service } => write!(f, "restarted {service}"),
+            Self::NotInstalled { service } => {
+                write!(
+                    f,
+                    "{service} is not installed; change applies when it is installed"
+                )
+            }
+            Self::InactiveDisabled { service } => write!(
+                f,
+                "{service} is inactive and disabled; change applies when it is started"
+            ),
+            Self::Skipped { reason } => write!(f, "{reason}"),
+            Self::NoActionRequired => write!(f, "no runtime apply action required"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserServiceState {
+    Missing,
+    InactiveDisabled,
+    ActiveOrEnabled,
+}
+
+pub trait ServiceController {
+    fn systemd_actions_disabled(&self) -> bool {
+        false
+    }
+
+    fn user_service_state(&self, service: &str) -> Result<UserServiceState, SettingsError>;
+
+    fn restart_user_service(&self, service: &str) -> Result<(), SettingsError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct SystemdUserServiceController {
+    command_path: PathBuf,
+    skip_systemd_actions: bool,
+}
+
+impl Default for SystemdUserServiceController {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+impl SystemdUserServiceController {
+    pub fn from_env() -> Self {
+        Self {
+            command_path: env::var_os("LG_BUDDY_SYSTEMCTL")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("systemctl")),
+            skip_systemd_actions: env_truthy("LG_BUDDY_SKIP_SYSTEMD_ACTIONS"),
+        }
+    }
+
+    fn user_systemctl_status(&self, args: &[&str]) -> io::Result<bool> {
+        ProcessCommand::new(&self.command_path)
+            .arg("--user")
+            .args(args)
+            .status()
+            .map(|status| status.success())
+    }
+}
+
+impl ServiceController for SystemdUserServiceController {
+    fn systemd_actions_disabled(&self) -> bool {
+        self.skip_systemd_actions
+    }
+
+    fn user_service_state(&self, service: &str) -> Result<UserServiceState, SettingsError> {
+        if !self
+            .user_systemctl_status(&["cat", service])
+            .unwrap_or(false)
+        {
+            return Ok(UserServiceState::Missing);
+        }
+
+        let active = self
+            .user_systemctl_status(&["is-active", "--quiet", service])
+            .unwrap_or(false);
+        let enabled = self
+            .user_systemctl_status(&["is-enabled", "--quiet", service])
+            .unwrap_or(false);
+
+        if active || enabled {
+            Ok(UserServiceState::ActiveOrEnabled)
+        } else {
+            Ok(UserServiceState::InactiveDisabled)
+        }
+    }
+
+    fn restart_user_service(&self, service: &str) -> Result<(), SettingsError> {
+        let output = ProcessCommand::new(&self.command_path)
+            .arg("--user")
+            .arg("restart")
+            .arg(service)
+            .output()
+            .map_err(|err| SettingsError::Apply {
+                message: format!("could not run systemctl: {err}"),
+            })?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(SettingsError::Apply {
+                message: format_command_failure(
+                    output.status.code(),
+                    &output.stdout,
+                    &output.stderr,
+                ),
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SettingsApplier<C = SystemdUserServiceController> {
+    service_controller: C,
+}
+
+impl SettingsApplier<SystemdUserServiceController> {
+    pub fn from_env() -> Self {
+        Self {
+            service_controller: SystemdUserServiceController::from_env(),
+        }
+    }
+}
+
+impl<C: ServiceController> SettingsApplier<C> {
+    pub fn new(service_controller: C) -> Self {
+        Self { service_controller }
+    }
+
+    pub fn apply(&self, change: &SettingsChange) -> Result<SettingsApplyOutcome, SettingsError> {
+        match change.mutation().definition().apply_strategy() {
+            ApplyStrategy::RestartUserScreenService => self.apply_screen_service_restart(),
+            ApplyStrategy::PendingLifecycleService => Ok(SettingsApplyOutcome::NoActionRequired),
+        }
+    }
+
+    fn apply_screen_service_restart(&self) -> Result<SettingsApplyOutcome, SettingsError> {
+        if self.service_controller.systemd_actions_disabled() {
+            return Ok(SettingsApplyOutcome::Skipped {
+                reason: "skipped systemd apply because LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1".to_string(),
+            });
+        }
+
+        match self
+            .service_controller
+            .user_service_state(SCREEN_SERVICE_NAME)?
+        {
+            UserServiceState::Missing => Ok(SettingsApplyOutcome::NotInstalled {
+                service: SCREEN_SERVICE_NAME,
+            }),
+            UserServiceState::InactiveDisabled => Ok(SettingsApplyOutcome::InactiveDisabled {
+                service: SCREEN_SERVICE_NAME,
+            }),
+            UserServiceState::ActiveOrEnabled => {
+                self.service_controller
+                    .restart_user_service(SCREEN_SERVICE_NAME)?;
+                Ok(SettingsApplyOutcome::Restarted {
+                    service: SCREEN_SERVICE_NAME,
+                })
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SettingsCommandRunner<C = SystemdUserServiceController> {
+    store: SettingsStore,
+    formatter: SettingsFormatter,
+    applier: SettingsApplier<C>,
+}
+
+impl SettingsCommandRunner<SystemdUserServiceController> {
     pub fn new(store: SettingsStore) -> Self {
+        Self::with_applier(store, SettingsApplier::from_env())
+    }
+}
+
+impl<C: ServiceController> SettingsCommandRunner<C> {
+    pub fn with_applier(store: SettingsStore, applier: SettingsApplier<C>) -> Self {
         Self {
             store,
             formatter: SettingsFormatter,
+            applier,
         }
     }
 
@@ -391,13 +828,32 @@ impl SettingsCommandRunner {
                 let setting = self.store.effective_by_name(&key)?;
                 self.formatter.write_get(writer, setting)
             }
-            SettingsCommand::Set { .. } => {
-                Err(SettingsError::WriteCommandUnavailable { command: "set" })
+            SettingsCommand::Set { key, value } => {
+                let mutation = SettingsMutation::set(&self.store, &key, &value)?;
+                let change = persist_settings_mutation(self.store.path(), mutation)?;
+                let apply = self.apply_after_persist(&change)?;
+                self.formatter.write_change(writer, &change, &apply)
             }
-            SettingsCommand::Unset(_) => {
-                Err(SettingsError::WriteCommandUnavailable { command: "unset" })
+            SettingsCommand::Unset(key) => {
+                let mutation = SettingsMutation::unset(&self.store, &key)?;
+                let change = persist_settings_mutation(self.store.path(), mutation)?;
+                let apply = self.apply_after_persist(&change)?;
+                self.formatter.write_change(writer, &change, &apply)
             }
         }
+    }
+
+    fn apply_after_persist(
+        &self,
+        change: &SettingsChange,
+    ) -> Result<SettingsApplyOutcome, SettingsError> {
+        self.applier
+            .apply(change)
+            .map_err(|err| SettingsError::ApplyAfterPersist {
+                key: change.mutation().key_name().to_string(),
+                path: change.path().to_path_buf(),
+                message: err.to_string(),
+            })
     }
 }
 
@@ -405,14 +861,29 @@ pub fn run_settings_command<W: io::Write>(
     command: SettingsCommand,
     writer: &mut W,
 ) -> Result<(), SettingsError> {
-    if command.is_mutation() {
-        return Err(SettingsError::WriteCommandUnavailable {
-            command: command.as_str(),
-        });
-    }
-
     let store = SettingsStore::load_from_env()?;
     SettingsCommandRunner::new(store).run(command, writer)
+}
+
+fn persist_settings_mutation(
+    path: &Path,
+    mutation: SettingsMutation,
+) -> Result<SettingsChange, SettingsError> {
+    let mut editor = ConfigEnvEditor::load(path)?;
+    let file_changed = match mutation.action() {
+        SettingsMutationAction::Set => editor.set(mutation.storage_key(), mutation.new_value()),
+        SettingsMutationAction::Unset => editor.unset(mutation.storage_key()),
+    };
+
+    if file_changed {
+        editor.save()?;
+    }
+
+    Ok(SettingsChange {
+        mutation,
+        path: editor.path().to_path_buf(),
+        file_changed,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1108,6 +1579,18 @@ pub enum SettingsError {
         kind: io::ErrorKind,
         message: String,
     },
+    WriteConfig {
+        path: PathBuf,
+        message: String,
+    },
+    Apply {
+        message: String,
+    },
+    ApplyAfterPersist {
+        key: String,
+        path: PathBuf,
+        message: String,
+    },
     WriteOutput(String),
     InvalidKey {
         key: String,
@@ -1123,9 +1606,6 @@ pub enum SettingsError {
         key: String,
         operation: SettingOperation,
     },
-    WriteCommandUnavailable {
-        command: &'static str,
-    },
     RegistryInvariant(String),
 }
 
@@ -1140,6 +1620,19 @@ impl fmt::Display for SettingsError {
                     path.display()
                 )
             }
+            Self::WriteConfig { path, message } => {
+                write!(
+                    f,
+                    "could not write settings config `{}`: {message}",
+                    path.display()
+                )
+            }
+            Self::Apply { message } => write!(f, "{message}"),
+            Self::ApplyAfterPersist { key, path, message } => write!(
+                f,
+                "setting `{key}` was saved to `{}` but could not be applied: {message}. Restart LG Buddy or rerun the command after fixing the apply error.",
+                path.display()
+            ),
             Self::WriteOutput(message) => write!(f, "{message}"),
             Self::InvalidKey { key, reason } => {
                 write!(f, "invalid setting key `{key}`: {reason}")
@@ -1160,12 +1653,6 @@ impl fmt::Display for SettingsError {
                     operation.as_str()
                 )
             }
-            Self::WriteCommandUnavailable { command } => {
-                write!(
-                    f,
-                    "`settings {command}` is not implemented yet; no changes were made"
-                )
-            }
             Self::RegistryInvariant(message) => write!(f, "{message}"),
         }
     }
@@ -1176,12 +1663,14 @@ impl std::error::Error for SettingsError {
         match self {
             Self::ConfigPath(err) => Some(err),
             Self::ReadConfig { .. }
+            | Self::WriteConfig { .. }
+            | Self::Apply { .. }
+            | Self::ApplyAfterPersist { .. }
             | Self::WriteOutput(_)
             | Self::InvalidKey { .. }
             | Self::UnknownKey(_)
             | Self::InvalidValue { .. }
             | Self::UnsupportedOperation { .. }
-            | Self::WriteCommandUnavailable { .. }
             | Self::RegistryInvariant(_) => None,
         }
     }
@@ -1215,6 +1704,71 @@ fn format_aliases(aliases: &[SettingAlias]) -> String {
 
 fn output_error(err: io::Error) -> SettingsError {
     SettingsError::WriteOutput(err.to_string())
+}
+
+fn config_line_key(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    let (key, _) = trimmed.split_once('=')?;
+    Some(key.trim())
+}
+
+fn replace_config_line_value(line: &str, storage_key: &str, value: &str) -> String {
+    let indentation: String = line
+        .chars()
+        .take_while(|character| character.is_whitespace())
+        .collect();
+    let suffix = line
+        .split_once('=')
+        .map(|(_, existing_value)| config_value_suffix(existing_value))
+        .unwrap_or_default();
+
+    format!("{indentation}{storage_key}={value}{suffix}")
+}
+
+fn config_value_suffix(value: &str) -> &str {
+    let Some(comment_start) = value.find('#') else {
+        return "";
+    };
+
+    let before_comment = &value[..comment_start];
+    let suffix_start = before_comment
+        .char_indices()
+        .rev()
+        .find(|(_, character)| !character.is_whitespace())
+        .map(|(index, character)| index + character.len_utf8())
+        .unwrap_or(0);
+
+    &value[suffix_start..]
+}
+
+fn env_truthy(name: &str) -> bool {
+    env::var(name)
+        .map(|value| {
+            matches!(
+                value.as_str(),
+                "1" | "true" | "TRUE" | "True" | "yes" | "YES" | "Yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn format_command_failure(status_code: Option<i32>, stdout: &[u8], stderr: &[u8]) -> String {
+    let status = status_code
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "signal".to_string());
+    let stdout = String::from_utf8_lossy(stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => format!("systemctl exited with status {status}"),
+        (false, true) => format!("systemctl exited with status {status}: {stdout}"),
+        (true, false) => format!("systemctl exited with status {status}: {stderr}"),
+        (false, false) => format!("systemctl exited with status {status}: {stderr}; {stdout}"),
+    }
 }
 
 fn validate_setting_key(value: &str) -> Result<(), &'static str> {
@@ -1272,13 +1826,16 @@ fn validate_storage_key(value: &str) -> Result<(), &'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApplyStrategy, ConfigEnvReader, ConfigPathResolver, SettingKey, SettingMutability,
-        SettingOperation, SettingSource, SettingType, SettingValue, SettingsCommand,
-        SettingsCommandRunner, SettingsError, SettingsParseError, SettingsStore, SETTINGS_REGISTRY,
+        ApplyStrategy, ConfigEnvReader, ConfigPathResolver, ServiceController, SettingKey,
+        SettingMutability, SettingOperation, SettingSource, SettingType, SettingValue,
+        SettingsApplier, SettingsCommand, SettingsCommandRunner, SettingsError, SettingsParseError,
+        SettingsStore, UserServiceState, SETTINGS_REGISTRY,
     };
     use crate::config::ConfigPathSources;
+    use std::cell::Cell;
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::rc::Rc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -1490,9 +2047,256 @@ system.sleep_wake_policy=disabled (config.env, read-only, ops: get,describe)
     }
 
     #[test]
-    fn settings_runner_rejects_write_commands_without_changes() {
-        let store = ConfigEnvReader::parse("/tmp/config.env", "").into_store();
-        let runner = SettingsCommandRunner::new(store);
+    fn settings_runner_sets_value_and_restarts_active_screen_service() {
+        let path = unique_test_path("set");
+        fs::write(
+            &path,
+            "\
+tv_ip=192.168.1.42
+screen_backend=swayidle # keep backend comment
+screen_idle_timeout=300
+",
+        )
+        .unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let fake_service = FakeServiceController::active_or_enabled();
+        let restarts = fake_service.restarts.clone();
+        let runner = SettingsCommandRunner::with_applier(store, SettingsApplier::new(fake_service));
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Set {
+                    key: "screen.backend".to_string(),
+                    value: "gnome".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap();
+
+        assert_eq!(restarts.get(), 1);
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "\
+tv_ip=192.168.1.42
+screen_backend=gnome # keep backend comment
+screen_idle_timeout=300
+"
+        );
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("screen.backend=gnome (saved to "));
+        assert!(output.contains("apply: restarted LG_Buddy_screen.service\n"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn settings_runner_unsets_value_and_removes_all_duplicate_keys() {
+        let path = unique_test_path("unset");
+        fs::write(
+            &path,
+            "\
+screen_backend=swayidle
+screen_idle_timeout=120
+screen_idle_timeout=450
+screen_restore_policy=aggressive
+",
+        )
+        .unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let runner = SettingsCommandRunner::with_applier(
+            store,
+            SettingsApplier::new(FakeServiceController::missing()),
+        );
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Unset("screen.idle_timeout".to_string()),
+                &mut output,
+            )
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "\
+screen_backend=swayidle
+screen_restore_policy=aggressive
+"
+        );
+        assert!(String::from_utf8(output)
+            .unwrap()
+            .contains("apply: LG_Buddy_screen.service is not installed"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn settings_runner_unsets_absent_key_without_creating_config() {
+        let path = unique_test_path("unset-absent");
+        let _ = fs::remove_file(&path);
+        let store = ConfigEnvReader::empty(&path).into_store();
+        let runner = SettingsCommandRunner::with_applier(
+            store,
+            SettingsApplier::new(FakeServiceController::missing()),
+        );
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Unset("screen.backend".to_string()),
+                &mut output,
+            )
+            .unwrap();
+
+        assert!(!path.exists());
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("screen.backend already unset"));
+        assert!(output.contains("config: unchanged\n"));
+        assert!(output.contains("apply: LG_Buddy_screen.service is not installed"));
+    }
+
+    #[test]
+    fn settings_runner_rejects_invalid_write_without_touching_config() {
+        let path = unique_test_path("invalid");
+        fs::write(&path, "screen_backend=swayidle\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let runner = SettingsCommandRunner::with_applier(
+            store,
+            SettingsApplier::new(FakeServiceController::active_or_enabled()),
+        );
+        let mut output = Vec::new();
+
+        let err = runner
+            .run(
+                SettingsCommand::Set {
+                    key: "screen.backend".to_string(),
+                    value: "kde".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, SettingsError::InvalidValue { .. }));
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "screen_backend=swayidle\n"
+        );
+        assert!(output.is_empty());
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn settings_runner_rejects_unknown_write_without_touching_config() {
+        let path = unique_test_path("unknown");
+        fs::write(&path, "screen_backend=swayidle\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let runner = SettingsCommandRunner::with_applier(
+            store,
+            SettingsApplier::new(FakeServiceController::active_or_enabled()),
+        );
+        let mut output = Vec::new();
+
+        let err = runner
+            .run(
+                SettingsCommand::Set {
+                    key: "screen.unknown".to_string(),
+                    value: "gnome".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap_err();
+
+        assert_eq!(err, SettingsError::UnknownKey("screen.unknown".to_string()));
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "screen_backend=swayidle\n"
+        );
+        assert!(output.is_empty());
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn settings_runner_rejects_read_only_write_without_touching_config() {
+        let path = unique_test_path("readonly");
+        fs::write(&path, "system_sleep_wake_policy=disabled\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let runner = SettingsCommandRunner::with_applier(
+            store,
+            SettingsApplier::new(FakeServiceController::active_or_enabled()),
+        );
+        let mut output = Vec::new();
+
+        let err = runner
+            .run(
+                SettingsCommand::Set {
+                    key: "system.sleep_wake_policy".to_string(),
+                    value: "enabled".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            SettingsError::UnsupportedOperation {
+                key: "system.sleep_wake_policy".to_string(),
+                operation: SettingOperation::Set,
+            }
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "system_sleep_wake_policy=disabled\n"
+        );
+        assert!(output.is_empty());
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn settings_runner_creates_parent_directory_for_valid_write() {
+        let root = unique_test_path("parent").with_extension("");
+        let path = root.join("nested").join("config.env");
+        let _ = fs::remove_dir_all(&root);
+        let store = ConfigEnvReader::empty(&path).into_store();
+        let runner = SettingsCommandRunner::with_applier(
+            store,
+            SettingsApplier::new(FakeServiceController::inactive_disabled()),
+        );
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Set {
+                    key: "screen.idle_timeout".to_string(),
+                    value: "600".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "screen_idle_timeout=600\n"
+        );
+        assert!(String::from_utf8(output)
+            .unwrap()
+            .contains("apply: LG_Buddy_screen.service is inactive and disabled"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn settings_runner_reports_apply_failure_after_persisting_value() {
+        let path = unique_test_path("apply-fail");
+        fs::write(&path, "screen_backend=swayidle\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let runner = SettingsCommandRunner::with_applier(
+            store,
+            SettingsApplier::new(FakeServiceController::failing_restart()),
+        );
         let mut output = Vec::new();
 
         let err = runner
@@ -1505,11 +2309,12 @@ system.sleep_wake_policy=disabled (config.env, read-only, ops: get,describe)
             )
             .unwrap_err();
 
-        assert_eq!(
-            err,
-            SettingsError::WriteCommandUnavailable { command: "set" }
-        );
+        assert_eq!(fs::read_to_string(&path).unwrap(), "screen_backend=gnome\n");
+        assert!(matches!(err, SettingsError::ApplyAfterPersist { .. }));
+        assert!(err.to_string().contains("was saved"));
         assert!(output.is_empty());
+
+        let _ = fs::remove_file(path);
     }
 
     #[test]
@@ -1870,5 +2675,73 @@ system.sleep_wake_policy=disabled (config.env, read-only, ops: get,describe)
             "lg-buddy-settings-{name}-{}-{nanos}.env",
             std::process::id()
         ))
+    }
+
+    #[derive(Debug, Clone)]
+    struct FakeServiceController {
+        state: UserServiceState,
+        restarts: Rc<Cell<usize>>,
+        restart_error: Option<&'static str>,
+        skip_actions: bool,
+    }
+
+    impl FakeServiceController {
+        fn active_or_enabled() -> Self {
+            Self {
+                state: UserServiceState::ActiveOrEnabled,
+                restarts: Rc::new(Cell::new(0)),
+                restart_error: None,
+                skip_actions: false,
+            }
+        }
+
+        fn inactive_disabled() -> Self {
+            Self {
+                state: UserServiceState::InactiveDisabled,
+                restarts: Rc::new(Cell::new(0)),
+                restart_error: None,
+                skip_actions: false,
+            }
+        }
+
+        fn missing() -> Self {
+            Self {
+                state: UserServiceState::Missing,
+                restarts: Rc::new(Cell::new(0)),
+                restart_error: None,
+                skip_actions: false,
+            }
+        }
+
+        fn failing_restart() -> Self {
+            Self {
+                state: UserServiceState::ActiveOrEnabled,
+                restarts: Rc::new(Cell::new(0)),
+                restart_error: Some("restart failed"),
+                skip_actions: false,
+            }
+        }
+    }
+
+    impl ServiceController for FakeServiceController {
+        fn systemd_actions_disabled(&self) -> bool {
+            self.skip_actions
+        }
+
+        fn user_service_state(&self, _service: &str) -> Result<UserServiceState, SettingsError> {
+            Ok(self.state)
+        }
+
+        fn restart_user_service(&self, _service: &str) -> Result<(), SettingsError> {
+            self.restarts.set(self.restarts.get() + 1);
+
+            if let Some(message) = self.restart_error {
+                Err(SettingsError::Apply {
+                    message: message.to_string(),
+                })
+            } else {
+                Ok(())
+            }
+        }
     }
 }

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -1380,7 +1380,7 @@ mod tests {
 
     impl WakeOnLanSender for RecordingWakeOnLanSender {
         fn send_magic_packet(&self, mac: &MacAddress) -> Result<(), WakeOnLanError> {
-            self.calls.borrow_mut().push((mac.clone(), None));
+            self.calls.borrow_mut().push((*mac, None));
             Ok(())
         }
 
@@ -1389,7 +1389,7 @@ mod tests {
             mac: &MacAddress,
             target_ip: Ipv4Addr,
         ) -> Result<(), WakeOnLanError> {
-            self.calls.borrow_mut().push((mac.clone(), Some(target_ip)));
+            self.calls.borrow_mut().push((*mac, Some(target_ip)));
             Ok(())
         }
     }

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -301,6 +301,15 @@ fn stdout_contains(world: &mut LgBuddyWorld, expected: String) {
     );
 }
 
+#[then(regex = r#"stdout does not contain "([^"]+)""#)]
+fn stdout_does_not_contain(world: &mut LgBuddyWorld, unexpected: String) {
+    assert!(
+        !world.command_result().stdout.contains(&unexpected),
+        "stdout was: {}",
+        world.command_result().stdout
+    );
+}
+
 #[then(regex = r#"stderr contains "([^"]+)""#)]
 fn stderr_contains(world: &mut LgBuddyWorld, expected: String) {
     assert!(

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -16,6 +16,21 @@ fn idle_timeout_seconds(world: &mut LgBuddyWorld, seconds: u64) {
     world.set_idle_timeout_secs(seconds);
 }
 
+#[given("the current config is remembered")]
+fn current_config_is_remembered(world: &mut LgBuddyWorld) {
+    world.remember_config_contents();
+}
+
+#[given("systemd apply actions are skipped")]
+fn systemd_apply_actions_are_skipped(world: &mut LgBuddyWorld) {
+    world.skip_systemd_apply_actions();
+}
+
+#[given("the user screen service is active")]
+fn user_screen_service_is_active(world: &mut LgBuddyWorld) {
+    world.install_active_user_screen_service_stub();
+}
+
 #[given("LG Buddy session runtime is isolated")]
 fn isolated_runtime(world: &mut LgBuddyWorld) {
     world.create_runtime();
@@ -293,6 +308,26 @@ fn stderr_contains(world: &mut LgBuddyWorld, expected: String) {
         "stderr was: {}",
         world.command_result().stderr
     );
+}
+
+#[then(regex = r#"config\.env contains "([^"]+)""#)]
+fn config_env_contains(world: &mut LgBuddyWorld, expected: String) {
+    world.assert_config_contains(&expected);
+}
+
+#[then(regex = r#"config\.env does not contain "([^"]+)""#)]
+fn config_env_does_not_contain(world: &mut LgBuddyWorld, unexpected: String) {
+    world.assert_config_does_not_contain(&unexpected);
+}
+
+#[then("config.env is unchanged")]
+fn config_env_is_unchanged(world: &mut LgBuddyWorld) {
+    world.assert_config_unchanged();
+}
+
+#[then(regex = r#"systemctl was invoked with "([^"]+)""#)]
+fn systemctl_was_invoked_with(world: &mut LgBuddyWorld, expected: String) {
+    world.assert_systemctl_invoked_with(&expected);
 }
 
 #[then(regex = r#"nm-online was invoked with "([^"]+)""#)]

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -56,6 +56,8 @@ impl LgBuddyWorld {
         let config = TestConfigFile::new("cucumber-config");
         config.write_sample(input);
         self.ensure_env().set("LG_BUDDY_CONFIG", config.path());
+        self.ensure_env()
+            .set("LG_BUDDY_GAMEPAD_ACTIVITY_SOURCE", "disabled");
         self.config = Some(config);
     }
 
@@ -113,7 +115,15 @@ log_path={}\n\
 printf '%s\\n' \"$*\" >> \"$log_path\"\n\
 if [ \"$1\" = \"--user\" ]; then\n\
   case \"$2\" in\n\
-    cat|is-active|is-enabled|restart) exit 0 ;;\n\
+    cat)\n\
+      cat <<'EOF'\n\
+# /home/test/.config/systemd/user/LG_Buddy_screen.service\n\
+[Unit]\n\
+Description=LG Buddy Screen Monitor Service\n\
+EOF\n\
+      exit 0\n\
+      ;;\n\
+    is-active|is-enabled|restart) exit 0 ;;\n\
   esac\n\
 fi\n\
 exit 1\n",
@@ -339,6 +349,8 @@ exit 1\n",
     }
 
     pub fn gamepad_activity_occurs_after_secs(&mut self, seconds: f64) {
+        self.ensure_env()
+            .set("LG_BUDDY_GAMEPAD_ACTIVITY_SOURCE", "synthetic");
         self.ensure_env().set(
             "LG_BUDDY_GAMEPAD_ACTIVITY_TEST_AFTER_SECS",
             seconds.to_string(),

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -5,7 +5,8 @@ use crate::support::{
 use cucumber::World;
 use lg_buddy::auth::resolve_bscpylgtv_auth_context_from_env;
 use std::fmt;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
 #[derive(World, Default)]
@@ -18,6 +19,8 @@ pub struct LgBuddyWorld {
     nm_online: Option<MockNmOnline>,
     swayidle: Option<MockSwayidle>,
     path_scripts: Vec<ExecutableScript>,
+    config_snapshot: Option<String>,
+    systemctl_log_path: Option<PathBuf>,
     command_result: Option<CommandExecution>,
 }
 
@@ -41,6 +44,8 @@ impl fmt::Debug for LgBuddyWorld {
             .field("nm_online", &self.nm_online.is_some())
             .field("swayidle", &self.swayidle.is_some())
             .field("path_scripts", &self.path_scripts.len())
+            .field("config_snapshot", &self.config_snapshot.is_some())
+            .field("systemctl_log_path", &self.systemctl_log_path)
             .field("command_result", &self.command_result)
             .finish()
     }
@@ -64,6 +69,77 @@ impl LgBuddyWorld {
     pub fn set_idle_timeout_secs(&mut self, seconds: u64) {
         self.ensure_env()
             .set("LG_BUDDY_IDLE_TIMEOUT", seconds.to_string());
+    }
+
+    pub fn remember_config_contents(&mut self) {
+        self.config_snapshot = Some(self.read_config_contents());
+    }
+
+    pub fn assert_config_unchanged(&self) {
+        assert_eq!(
+            self.read_config_contents(),
+            self.config_snapshot
+                .as_ref()
+                .expect("config contents should be remembered")
+                .as_str()
+        );
+    }
+
+    pub fn assert_config_contains(&self, expected: &str) {
+        let contents = self.read_config_contents();
+        assert!(
+            contents.contains(expected),
+            "expected config to contain `{expected}`\nconfig was:\n{contents}"
+        );
+    }
+
+    pub fn assert_config_does_not_contain(&self, unexpected: &str) {
+        let contents = self.read_config_contents();
+        assert!(
+            !contents.contains(unexpected),
+            "expected config not to contain `{unexpected}`\nconfig was:\n{contents}"
+        );
+    }
+
+    pub fn skip_systemd_apply_actions(&mut self) {
+        self.ensure_env().set("LG_BUDDY_SKIP_SYSTEMD_ACTIONS", "1");
+    }
+
+    pub fn install_active_user_screen_service_stub(&mut self) {
+        let log_path = self.config().path().with_file_name("systemctl.log");
+        let body = format!(
+            "#!/bin/sh\n\
+log_path={}\n\
+printf '%s\\n' \"$*\" >> \"$log_path\"\n\
+if [ \"$1\" = \"--user\" ]; then\n\
+  case \"$2\" in\n\
+    cat|is-active|is-enabled|restart) exit 0 ;;\n\
+  esac\n\
+fi\n\
+exit 1\n",
+            shell_quote_path(&log_path)
+        );
+        let script = ExecutableScript::new(
+            "cucumber-settings-systemctl",
+            "mock-settings-systemctl",
+            &body,
+        );
+        self.ensure_env().set("LG_BUDDY_SYSTEMCTL", script.path());
+        self.ensure_env().remove("LG_BUDDY_SKIP_SYSTEMD_ACTIONS");
+        self.systemctl_log_path = Some(log_path);
+        self.path_scripts.push(script);
+    }
+
+    pub fn assert_systemctl_invoked_with(&self, expected: &str) {
+        let log_path = self
+            .systemctl_log_path
+            .as_ref()
+            .expect("settings systemctl log should be configured");
+        let contents = fs::read_to_string(log_path).unwrap_or_default();
+        assert!(
+            contents.lines().any(|line| line == expected),
+            "expected systemctl invocation `{expected}`\nsystemctl log was:\n{contents}"
+        );
     }
 
     pub fn create_runtime(&mut self) {
@@ -420,4 +496,13 @@ impl LgBuddyWorld {
             .as_mut()
             .expect("mock session-bus idle monitor configured")
     }
+
+    fn read_config_contents(&self) -> String {
+        fs::read_to_string(self.config().path()).expect("read temporary config")
+    }
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    format!("'{}'", value.replace('\'', "'\\''"))
 }

--- a/crates/lg-buddy/tests/features/settings.feature
+++ b/crates/lg-buddy/tests/features/settings.feature
@@ -60,6 +60,7 @@ Feature: Settings CLI
     When I run the command "settings set screen.backend gnome"
     Then the command succeeds
     And stdout contains "apply: restarted LG_Buddy_screen.service"
+    And stdout does not contain "Description=LG Buddy Screen Monitor Service"
     And config.env contains "screen_backend=gnome"
     And systemctl was invoked with "--user restart LG_Buddy_screen.service"
 

--- a/crates/lg-buddy/tests/features/settings.feature
+++ b/crates/lg-buddy/tests/features/settings.feature
@@ -5,9 +5,21 @@ Feature: Settings CLI
     Given a temporary LG Buddy config using input HDMI_2
     When I run the command "settings list"
     Then the command succeeds
+    And stdout contains "tv.ip=192.0.2.42 (config.env, read-write, ops: get,describe,set)"
+    And stdout contains "tv.mac=aa:bb:cc:dd:ee:ff (config.env, read-write, ops: get,describe,set)"
+    And stdout contains "tv.input=HDMI_2 (config.env, read-write, ops: get,describe,set)"
     And stdout contains "screen.backend=auto (config.env, read-write, ops: get,describe,set,unset)"
     And stdout contains "screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)"
     And stdout contains "system.sleep_wake_policy=enabled (default, read-write, ops: get,describe,set,unset)"
+
+  Scenario: settings describe shows required TV operations
+    Given a temporary LG Buddy config using input HDMI_2
+    When I run the command "settings describe tv.input"
+    Then the command succeeds
+    And stdout contains "tv.input"
+    And stdout contains "storage key: tvs_primary_input"
+    And stdout contains "default: required"
+    And stdout contains "supported operations: get, describe, set"
 
   Scenario: settings describe shows lifecycle policy operations
     Given a temporary LG Buddy config using input HDMI_2
@@ -25,6 +37,21 @@ Feature: Settings CLI
     And stdout contains "screen.idle_timeout=600"
     And stdout contains "apply: skipped systemd apply"
     And config.env contains "screen_idle_timeout=600"
+
+  Scenario: settings set writes TV settings to profile-shaped storage
+    Given a temporary LG Buddy config using input HDMI_2
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_3
+    When I run the command "settings set tv.input HDMI_3"
+    Then the command succeeds
+    And stdout contains "tv.input=HDMI_3"
+    And stdout contains "apply: no runtime apply action required"
+    And config.env contains "tvs_primary_input=HDMI_3"
+    And config.env does not contain "input=HDMI_2"
+    When I run the command "screen-off"
+    Then the command succeeds
+    And the TV client received "turn_screen_off"
 
   Scenario: settings set writes a restore policy consumed by screen runtime
     Given a temporary LG Buddy config using input HDMI_3

--- a/crates/lg-buddy/tests/features/settings.feature
+++ b/crates/lg-buddy/tests/features/settings.feature
@@ -1,0 +1,72 @@
+Feature: Settings CLI
+  LG Buddy should expose structured settings over the existing config.env file.
+
+  Scenario: settings list shows values and supported operations
+    Given a temporary LG Buddy config using input HDMI_2
+    When I run the command "settings list"
+    Then the command succeeds
+    And stdout contains "screen.backend=auto (config.env, read-write, ops: get,describe,set,unset)"
+    And stdout contains "screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)"
+    And stdout contains "system.sleep_wake_policy=enabled (default, read-only, ops: get,describe)"
+
+  Scenario: settings describe shows read-only lifecycle operations
+    Given a temporary LG Buddy config using input HDMI_2
+    When I run the command "settings describe system.sleep_wake_policy"
+    Then the command succeeds
+    And stdout contains "system.sleep_wake_policy"
+    And stdout contains "mutability: read-only"
+    And stdout contains "supported operations: get, describe"
+
+  Scenario: settings set writes config.env and reports skipped apply
+    Given a temporary LG Buddy config using input HDMI_2
+    And systemd apply actions are skipped
+    When I run the command "settings set screen.idle_timeout 600"
+    Then the command succeeds
+    And stdout contains "screen.idle_timeout=600"
+    And stdout contains "apply: skipped systemd apply"
+    And config.env contains "screen_idle_timeout=600"
+
+  Scenario: settings set writes a restore policy consumed by screen runtime
+    Given a temporary LG Buddy config using input HDMI_3
+    And systemd apply actions are skipped
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_3
+    And the TV screen is blanked
+    When I run the command "settings set screen.restore_policy aggressive"
+    Then the command succeeds
+    And config.env contains "screen_restore_policy=aggressive"
+    When I run the command "screen-on"
+    Then the command succeeds
+    And stdout contains "Aggressive restore policy is enabled"
+    And the TV client received "turn_screen_on"
+    And the session marker is absent
+
+  Scenario: settings unset removes an override and restores the default
+    Given a temporary LG Buddy config using input HDMI_2
+    And the screen restore policy is "aggressive"
+    And systemd apply actions are skipped
+    When I run the command "settings unset screen.restore_policy"
+    Then the command succeeds
+    And stdout contains "screen.restore_policy unset"
+    And config.env does not contain "screen_restore_policy="
+    When I run the command "settings get screen.restore_policy"
+    Then the command succeeds
+    And stdout is "conservative"
+
+  Scenario: settings set restarts an active user screen service
+    Given a temporary LG Buddy config using input HDMI_2
+    And the user screen service is active
+    When I run the command "settings set screen.backend gnome"
+    Then the command succeeds
+    And stdout contains "apply: restarted LG_Buddy_screen.service"
+    And config.env contains "screen_backend=gnome"
+    And systemctl was invoked with "--user restart LG_Buddy_screen.service"
+
+  Scenario: read-only lifecycle settings are rejected without changing config.env
+    Given a temporary LG Buddy config using input HDMI_2
+    And the current config is remembered
+    When I run the command "settings set system.sleep_wake_policy disabled"
+    Then the command fails
+    And stderr contains "setting `system.sleep_wake_policy` does not support `set`"
+    And config.env is unchanged

--- a/crates/lg-buddy/tests/features/settings.feature
+++ b/crates/lg-buddy/tests/features/settings.feature
@@ -7,15 +7,15 @@ Feature: Settings CLI
     Then the command succeeds
     And stdout contains "screen.backend=auto (config.env, read-write, ops: get,describe,set,unset)"
     And stdout contains "screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)"
-    And stdout contains "system.sleep_wake_policy=enabled (default, read-only, ops: get,describe)"
+    And stdout contains "system.sleep_wake_policy=enabled (default, read-write, ops: get,describe,set,unset)"
 
-  Scenario: settings describe shows read-only lifecycle operations
+  Scenario: settings describe shows lifecycle policy operations
     Given a temporary LG Buddy config using input HDMI_2
     When I run the command "settings describe system.sleep_wake_policy"
     Then the command succeeds
     And stdout contains "system.sleep_wake_policy"
-    And stdout contains "mutability: read-only"
-    And stdout contains "supported operations: get, describe"
+    And stdout contains "mutability: read-write"
+    And stdout contains "supported operations: get, describe, set, unset"
 
   Scenario: settings set writes config.env and reports skipped apply
     Given a temporary LG Buddy config using input HDMI_2
@@ -64,10 +64,10 @@ Feature: Settings CLI
     And config.env contains "screen_backend=gnome"
     And systemctl was invoked with "--user restart LG_Buddy_screen.service"
 
-  Scenario: read-only lifecycle settings are rejected without changing config.env
+  Scenario: settings set writes lifecycle policy without restarting services
     Given a temporary LG Buddy config using input HDMI_2
-    And the current config is remembered
     When I run the command "settings set system.sleep_wake_policy disabled"
-    Then the command fails
-    And stderr contains "setting `system.sleep_wake_policy` does not support `set`"
-    And config.env is unchanged
+    Then the command succeeds
+    And stdout contains "system.sleep_wake_policy=disabled"
+    And stdout contains "apply: no runtime apply action required"
+    And config.env contains "system_sleep_wake_policy=disabled"

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -3,13 +3,15 @@ mod support;
 use lg_buddy::commands::{run_screen_off, run_screen_on, run_system_resume};
 use lg_buddy::session::runner::{RuntimeActionExecutor, SessionEventDispatcher};
 use lg_buddy::session::SessionEvent;
+use lg_buddy::settings::SettingsCommand;
 use lg_buddy::{run_command, Command};
 use std::fs;
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 use support::{
-    MockBscpylgtv, MockNmOnline, MockSystemLogind, RuntimeStateLayout, TestConfigFile, TestEnv,
+    ExecutableScript, MockBscpylgtv, MockNmOnline, MockSystemLogind, RuntimeStateLayout,
+    TestConfigFile, TestEnv,
 };
 
 #[test]
@@ -120,6 +122,174 @@ fn run_screen_on_loads_aggressive_config_and_restores_without_session_marker() {
     let output = String::from_utf8(output).expect("utf8 output");
     assert!(output.contains("Aggressive restore policy is enabled"));
     assert!(output.contains("Screen unblank succeeded."));
+}
+
+#[test]
+fn settings_set_restore_policy_is_loaded_by_screen_runtime() {
+    let mock = MockBscpylgtv::new("entrypoint-settings-set-runtime-tv");
+    mock.set_input("HDMI_3");
+    mock.set_screen_on(false);
+    let wrapper = mock.command_wrapper("entrypoint-settings-set-runtime-wrapper");
+
+    let config = TestConfigFile::new("entrypoint-settings-set-runtime-config");
+    config.write_sample("HDMI_3");
+    let runtime = RuntimeStateLayout::new("entrypoint-settings-set-runtime-state");
+
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_BSCPYLGTV_COMMAND", wrapper.path());
+    env.set("LG_BUDDY_SESSION_RUNTIME_DIR", runtime.session_dir());
+    env.set("LG_BUDDY_SKIP_SYSTEMD_ACTIONS", "1");
+
+    let mut settings_output = Vec::new();
+    run_command(
+        Command::Settings(SettingsCommand::Set {
+            key: "screen.restore_policy".to_string(),
+            value: "aggressive".to_string(),
+        }),
+        &mut settings_output,
+    )
+    .expect("settings set should succeed");
+
+    assert!(fs::read_to_string(config.path())
+        .expect("read config")
+        .contains("screen_restore_policy=aggressive\n"));
+    assert!(String::from_utf8(settings_output)
+        .expect("settings output utf8")
+        .contains("apply: skipped systemd apply"));
+
+    let mut output = Vec::new();
+    run_screen_on(&mut output).expect("screen-on should use settings-written policy");
+
+    runtime.assert_session_marker_absent();
+    assert_eq!(
+        mock.calls()
+            .into_iter()
+            .map(|call| call.command)
+            .collect::<Vec<_>>(),
+        vec!["turn_screen_on".to_string()]
+    );
+    assert!(String::from_utf8(output)
+        .expect("screen output utf8")
+        .contains("Aggressive restore policy is enabled"));
+}
+
+#[test]
+fn settings_unset_restore_policy_is_loaded_as_screen_runtime_default() {
+    let mock = MockBscpylgtv::new("entrypoint-settings-unset-runtime-tv");
+    mock.set_input("HDMI_3");
+    mock.set_screen_on(false);
+    let wrapper = mock.command_wrapper("entrypoint-settings-unset-runtime-wrapper");
+
+    let config = TestConfigFile::new("entrypoint-settings-unset-runtime-config");
+    config.write_sample("HDMI_3");
+    config.append_line("screen_restore_policy=aggressive");
+    let runtime = RuntimeStateLayout::new("entrypoint-settings-unset-runtime-state");
+
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_BSCPYLGTV_COMMAND", wrapper.path());
+    env.set("LG_BUDDY_SESSION_RUNTIME_DIR", runtime.session_dir());
+    env.set("LG_BUDDY_SKIP_SYSTEMD_ACTIONS", "1");
+
+    let mut settings_output = Vec::new();
+    run_command(
+        Command::Settings(SettingsCommand::Unset("screen.restore_policy".to_string())),
+        &mut settings_output,
+    )
+    .expect("settings unset should succeed");
+
+    assert!(!fs::read_to_string(config.path())
+        .expect("read config")
+        .contains("screen_restore_policy="));
+    assert!(String::from_utf8(settings_output)
+        .expect("settings output utf8")
+        .contains("screen.restore_policy unset"));
+
+    let mut output = Vec::new();
+    run_screen_on(&mut output).expect("screen-on should use default conservative policy");
+
+    runtime.assert_session_marker_absent();
+    assert!(mock.calls().is_empty());
+    assert!(String::from_utf8(output)
+        .expect("screen output utf8")
+        .contains("State file not found"));
+}
+
+#[test]
+fn settings_set_screen_key_restarts_active_user_screen_service() {
+    let config = TestConfigFile::new("entrypoint-settings-apply-config");
+    config.write_sample("HDMI_3");
+    let systemctl_log = config.path().with_file_name("systemctl.log");
+    let systemctl = ExecutableScript::new(
+        "entrypoint-settings-apply-systemctl",
+        "systemctl",
+        &format!(
+            "#!/bin/sh\n\
+printf '%s\\n' \"$*\" >> '{}'\n\
+case \"$2\" in\n\
+  cat|is-active|is-enabled|restart) exit 0 ;;\n\
+  *) exit 1 ;;\n\
+esac\n",
+            systemctl_log.display()
+        ),
+    );
+
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_SYSTEMCTL", systemctl.path());
+    env.remove("LG_BUDDY_SKIP_SYSTEMD_ACTIONS");
+
+    let mut output = Vec::new();
+    run_command(
+        Command::Settings(SettingsCommand::Set {
+            key: "screen.idle_timeout".to_string(),
+            value: "600".to_string(),
+        }),
+        &mut output,
+    )
+    .expect("settings set should restart active user service");
+
+    assert!(fs::read_to_string(config.path())
+        .expect("read config")
+        .contains("screen_idle_timeout=600\n"));
+    assert!(String::from_utf8(output)
+        .expect("settings output utf8")
+        .contains("apply: restarted LG_Buddy_screen.service"));
+
+    let systemctl_calls = fs::read_to_string(systemctl_log).expect("read systemctl log");
+    assert!(systemctl_calls.contains("--user cat LG_Buddy_screen.service"));
+    assert!(systemctl_calls.contains("--user is-active --quiet LG_Buddy_screen.service"));
+    assert!(systemctl_calls.contains("--user restart LG_Buddy_screen.service"));
+}
+
+#[test]
+fn settings_set_lifecycle_policy_is_read_only_and_leaves_config_unchanged() {
+    let config = TestConfigFile::new("entrypoint-settings-readonly-config");
+    config.write_sample("HDMI_3");
+    let original = fs::read_to_string(config.path()).expect("read original config");
+
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+
+    let mut output = Vec::new();
+    let err = run_command(
+        Command::Settings(SettingsCommand::Set {
+            key: "system.sleep_wake_policy".to_string(),
+            value: "disabled".to_string(),
+        }),
+        &mut output,
+    )
+    .expect_err("lifecycle policy should remain read-only");
+
+    assert!(err
+        .to_string()
+        .contains("setting `system.sleep_wake_policy` does not support `set`"));
+    assert!(output.is_empty());
+    assert_eq!(
+        fs::read_to_string(config.path()).expect("read config after rejection"),
+        original
+    );
 }
 
 #[test]

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -374,8 +374,19 @@ fn run_lifecycle_monitor_uses_logind_resume_signal_and_runtime_restore() {
     });
 
     wait_until(Duration::from_secs(4), || {
-        logind.queue_prepare_for_sleep_signal(false);
-        mock.calls().iter().any(|call| call.command == "set_input")
+        let calls = mock.calls();
+        let set_input_count = calls
+            .iter()
+            .filter(|call| call.command == "set_input")
+            .count();
+
+        if set_input_count == 0 {
+            logind.queue_prepare_for_sleep_signal(false);
+        }
+
+        set_input_count == 1
+            && !runtime.system_marker_path().exists()
+            && !runtime.system_sleep_attempt_marker_path().exists()
     });
 
     assert_eq!(

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -264,32 +264,29 @@ esac\n",
 }
 
 #[test]
-fn settings_set_lifecycle_policy_is_read_only_and_leaves_config_unchanged() {
-    let config = TestConfigFile::new("entrypoint-settings-readonly-config");
+fn settings_set_lifecycle_policy_updates_config_without_systemd_apply() {
+    let config = TestConfigFile::new("entrypoint-settings-lifecycle-policy-config");
     config.write_sample("HDMI_3");
-    let original = fs::read_to_string(config.path()).expect("read original config");
 
     let mut env = TestEnv::new();
     env.set("LG_BUDDY_CONFIG", config.path());
 
     let mut output = Vec::new();
-    let err = run_command(
+    run_command(
         Command::Settings(SettingsCommand::Set {
             key: "system.sleep_wake_policy".to_string(),
             value: "disabled".to_string(),
         }),
         &mut output,
     )
-    .expect_err("lifecycle policy should remain read-only");
+    .expect("lifecycle policy should be writable");
 
-    assert!(err
-        .to_string()
-        .contains("setting `system.sleep_wake_policy` does not support `set`"));
-    assert!(output.is_empty());
-    assert_eq!(
-        fs::read_to_string(config.path()).expect("read config after rejection"),
-        original
-    );
+    assert!(fs::read_to_string(config.path())
+        .expect("read config")
+        .contains("system_sleep_wake_policy=disabled\n"));
+    let output = String::from_utf8(output).expect("settings output utf8");
+    assert!(output.contains("system.sleep_wake_policy=disabled"));
+    assert!(output.contains("apply: no runtime apply action required"));
 }
 
 #[test]
@@ -533,6 +530,7 @@ fn run_lifecycle_monitor_uses_logind_resume_signal_and_runtime_restore() {
     env.set("LG_BUDDY_STARTUP_INITIAL_WAKE_DELAY_SECS", "0");
     env.set("LG_BUDDY_TV_ROUTE_WAIT_ATTEMPTS", "1");
     env.set("LG_BUDDY_TV_ROUTE_WAIT_DELAY_MS", "0");
+    env.set("LG_BUDDY_LIFECYCLE_MONITOR_TEST_EVENT_LIMIT", "1");
 
     let (done_tx, done_rx) = mpsc::channel();
     let lifecycle_thread = thread::spawn(move || {
@@ -569,12 +567,9 @@ fn run_lifecycle_monitor_uses_logind_resume_signal_and_runtime_restore() {
     runtime.assert_system_marker_absent();
     runtime.assert_system_sleep_attempt_marker_absent();
 
-    config.append_line("system_sleep_wake_policy=disabled");
-    logind.queue_prepare_for_sleep_signal(true);
-
     let (result, output) = done_rx
         .recv_timeout(Duration::from_secs(5))
-        .expect("lifecycle monitor should exit after config is disabled");
+        .expect("lifecycle monitor should exit after test event limit");
     lifecycle_thread
         .join()
         .expect("join lifecycle monitor thread");
@@ -586,7 +581,7 @@ fn run_lifecycle_monitor_uses_logind_resume_signal_and_runtime_restore() {
     assert!(output.contains("System resumed from sleep"));
     assert!(output.contains("Session event `after-resume` requests wake restore"));
     assert!(output.contains("Wake from sleep: LG Buddy turned TV off. Restoring."));
-    assert!(output.contains("stopping lifecycle monitor"));
+    assert!(!output.contains("stopping lifecycle monitor"));
 }
 
 fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) {

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -1043,9 +1043,9 @@ impl TestConfigFile {
 #[allow(dead_code)]
 pub fn sample_config_contents(input: &str) -> String {
     format!(
-        "tv_ip=192.0.2.42\n\
-tv_mac=aa:bb:cc:dd:ee:ff\n\
-input={input}\n\
+        "tvs_primary_ip=192.0.2.42\n\
+tvs_primary_mac=aa:bb:cc:dd:ee:ff\n\
+tvs_primary_input={input}\n\
 screen_backend=auto\n\
 screen_idle_timeout=300\n"
     )

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -371,7 +371,8 @@ power-off is owned by the NetworkManager pre-down gate.
 
 Flow:
 
-1. Load config and exit successfully if `system_sleep_wake_policy=disabled`.
+1. Load config and suppress lifecycle TV actions while
+   `system_sleep_wake_policy=disabled`.
 2. Open the system bus.
 3. Subscribe to logind `PrepareForSleep` signals.
 4. On `PrepareForSleep(true)`:

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -36,6 +36,12 @@ extra behavior surface.
 
 The primary persistent configuration surface is `config.env`.
 
+The structured settings CLI is an access layer over that same file, not a second
+storage location. A dotted setting key such as `screen.restore_policy` maps to
+the existing `config.env` key `screen_restore_policy`. This keeps manual config
+editing, `configure.sh`, installer preservation, and `lg-buddy settings` on one
+durable source of truth.
+
 New behavior should use a config key when users may reasonably want to keep a
 non-default choice across reinstalls or upgrades. Prefer enum-shaped values over
 multiple booleans when the setting describes a mode.
@@ -86,6 +92,8 @@ choice.
 - `aggressive` is available for users who want LG Buddy to reclaim the TV more
   assertively
 - the choice lives in `config.env`
+- it is writeable through `lg-buddy settings set screen.restore_policy <value>`
+  because the command can apply screen-monitor changes
 
 `system_sleep_wake_policy` follows the same model:
 
@@ -94,3 +102,5 @@ choice.
 - the installer should not ask every user whether sleep/wake automation should
   be enabled
 - the supported values are `enabled` and `disabled`
+- it remains read-only through `lg-buddy settings` until the command can safely
+  apply lifecycle service and NetworkManager hook ownership changes

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -42,6 +42,13 @@ the existing `config.env` key `screen_restore_policy`. This keeps manual config
 editing, `configure.sh`, installer preservation, and `lg-buddy settings` on one
 durable source of truth.
 
+The current public settings interface exposes one TV through `tv.ip`, `tv.mac`,
+and `tv.input`. New writes store those values as `tvs_primary_ip`,
+`tvs_primary_mac`, and `tvs_primary_input`. The profile-shaped storage is only an
+extensibility point; LG Buddy does not currently expose multiple TVs or TV
+profile selection. Existing single-TV keys `tv_ip`, `tv_mac`, and `input` remain
+readable for compatibility.
+
 New behavior should use a config key when users may reasonably want to keep a
 non-default choice across reinstalls or upgrades. Prefer enum-shaped values over
 multiple booleans when the setting describes a mode.
@@ -60,6 +67,9 @@ instead.
 Good shapes:
 
 ```ini
+tvs_primary_ip=192.168.1.100
+tvs_primary_mac=aa:bb:cc:dd:ee:ff
+tvs_primary_input=HDMI_2
 screen_restore_policy=conservative
 system_sleep_wake_policy=enabled
 ```

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -42,6 +42,12 @@ the existing `config.env` key `screen_restore_policy`. This keeps manual config
 editing, `configure.sh`, installer preservation, and `lg-buddy settings` on one
 durable source of truth.
 
+The settings CLI should not hide malformed durable config. If a raw
+`config.env` value fails validation, `settings list` and `settings describe`
+should show it as invalid, and `settings get <key>` should return the validation
+error. Mutation commands may still overwrite or unset the bad value so users can
+repair the file through the structured interface.
+
 The current public settings interface exposes one TV through `tv.ip`, `tv.mac`,
 and `tv.input`. New writes store those values as `tvs_primary_ip`,
 `tvs_primary_mac`, and `tvs_primary_input`. The profile-shaped storage is only an

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -98,9 +98,10 @@ choice.
 `system_sleep_wake_policy` follows the same model:
 
 - automatic system sleep/wake handling should default to enabled
-- users who do not want it should opt out through `config.env`
+- users who do not want it should opt out through `config.env` or
+  `lg-buddy settings set system.sleep_wake_policy disabled`
 - the installer should not ask every user whether sleep/wake automation should
   be enabled
 - the supported values are `enabled` and `disabled`
-- it remains read-only through `lg-buddy settings` until the command can safely
-  apply lifecycle service and NetworkManager hook ownership changes
+- lifecycle service and NetworkManager hook installation are integration
+  topology, while this setting controls runtime policy

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -71,6 +71,7 @@ This is the place for integration tests and contract tests.
 ### What belongs here
 
 - runtime entrypoints loading a real temporary `config.env`
+- settings CLI writes feeding normal runtime config loading and apply behavior
 - command flows using real env overrides
 - runtime state directories and marker files
 - subprocess contracts to external tools

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -23,16 +23,19 @@ Available commands:
 - `monitor`
 - `lifecycle`
 - `detect-backend`
+- `settings`
 
 Examples:
 
 ```bash
 lg-buddy detect-backend
+lg-buddy settings list
 lg-buddy monitor
 lg-buddy brightness
 ```
 
-In normal use, systemd starts the relevant commands automatically. Most users only need `brightness` or `configure.sh`.
+In normal use, systemd starts the relevant commands automatically. Most users
+only need `brightness`, `settings`, or `configure.sh`.
 
 `lifecycle`, `nm-pre-down`, `sleep-pre`, and `startup wake` are normally
 service-owned system lifecycle commands. They are documented for
@@ -123,13 +126,36 @@ artifacts from existing installs so there is only one system lifecycle owner.
 
 ## Configuration
 
-To change settings after installation:
+To inspect structured settings after installation:
+
+```bash
+lg-buddy settings list
+lg-buddy settings describe screen.restore_policy
+lg-buddy settings get screen.idle_timeout
+```
+
+To change supported screen settings:
+
+```bash
+lg-buddy settings set screen.idle_timeout 600
+lg-buddy settings set screen.restore_policy aggressive
+lg-buddy settings unset screen.restore_policy
+```
+
+`set` and `unset` write `config.env` and then apply screen-monitor settings by
+restarting `LG_Buddy_screen.service` when the user service is installed and
+active or enabled. If the user service is missing or disabled, the value remains
+saved and applies when that service is installed or started.
+
+To rerun full setup for TV IP, MAC address, HDMI input, or install-time service
+wiring:
 
 ```bash
 ./configure.sh
 ```
 
-The configurator writes `config.env` to:
+The settings CLI, configurator, installer, and manual edits all use the same
+`config.env` file. It is resolved from:
 
 - `LG_BUDDY_CONFIG`, if set
 - otherwise `${XDG_CONFIG_HOME}/lg-buddy/config.env`
@@ -144,6 +170,15 @@ Current config keys:
 - `screen_idle_timeout`
 - `screen_restore_policy`
 - `system_sleep_wake_policy`
+
+Current structured settings:
+
+| Setting key | `config.env` key | Operations |
+| --- | --- | --- |
+| `screen.backend` | `screen_backend` | `get`, `describe`, `set`, `unset` |
+| `screen.idle_timeout` | `screen_idle_timeout` | `get`, `describe`, `set`, `unset` |
+| `screen.restore_policy` | `screen_restore_policy` | `get`, `describe`, `set`, `unset` |
+| `system.sleep_wake_policy` | `system_sleep_wake_policy` | `get`, `describe` |
 
 `screen_idle_timeout` is the inactivity threshold in seconds used by the session monitor.
 LG Buddy currently uses that timeout for both the GNOME and `swayidle` backends.
@@ -164,6 +199,10 @@ LG Buddy currently uses that timeout for both the GNOME and `swayidle` backends.
 The running lifecycle service rereads config and stops cleanly when this value
 is changed to `disabled`. To apply the installed service enable/remove state
 after changing the value, rerun `./install.sh`.
+
+`system.sleep_wake_policy` is read-only in the structured settings CLI for now.
+Write support should only be added when LG Buddy can also apply the lifecycle
+service and NetworkManager hook changes in the same command.
 
 Example:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -195,6 +195,7 @@ are required, so `unset` is not supported.
 
 `screen_idle_timeout` is the inactivity threshold in seconds used by the session monitor.
 LG Buddy currently uses that timeout for both the GNOME and `swayidle` backends.
+Values above 86400 seconds are capped at 86400 seconds.
 
 `screen_restore_policy` controls how aggressively LG Buddy reclaims the display on wake and user activity:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -176,6 +176,13 @@ Current config keys:
 Legacy single-TV keys `tv_ip`, `tv_mac`, and `input` are still read as fallback
 values for existing installs. New writes use `tvs_primary_*` storage keys.
 
+If a direct edit leaves a malformed value in `config.env`, `settings list` and
+`settings describe` show the raw value as invalid with an `invalid config.env`
+source. `settings get <key>` fails with the validation error instead of
+pretending the value is missing or defaulted. Repair the entry with
+`settings set <key> <value>`, `settings unset <key>` when supported, or a manual
+config edit.
+
 Current structured settings:
 
 | Setting key | `config.env` key | Operations |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -134,18 +134,20 @@ lg-buddy settings describe screen.restore_policy
 lg-buddy settings get screen.idle_timeout
 ```
 
-To change supported screen settings:
+To change supported settings:
 
 ```bash
+lg-buddy settings set tv.input HDMI_2
 lg-buddy settings set screen.idle_timeout 600
 lg-buddy settings set screen.restore_policy aggressive
 lg-buddy settings unset screen.restore_policy
 ```
 
-`set` and `unset` write `config.env` and then apply screen-monitor settings by
-restarting `LG_Buddy_screen.service` when the user service is installed and
-active or enabled. If the user service is missing or disabled, the value remains
-saved and applies when that service is installed or started.
+`set` and `unset` write `config.env` and then apply the setting when an explicit
+runtime apply step is needed. Screen-monitor settings restart
+`LG_Buddy_screen.service` when the user service is installed and active or
+enabled. TV identity and system sleep/wake policy changes are read by later
+runtime actions and do not require a service restart.
 
 To rerun full setup for TV IP, MAC address, HDMI input, or install-time service
 wiring:
@@ -163,22 +165,33 @@ The settings CLI, configurator, installer, and manual edits all use the same
 
 Current config keys:
 
-- `tv_ip`
-- `tv_mac`
-- `input`
+- `tvs_primary_ip`
+- `tvs_primary_mac`
+- `tvs_primary_input`
 - `screen_backend`
 - `screen_idle_timeout`
 - `screen_restore_policy`
 - `system_sleep_wake_policy`
 
+Legacy single-TV keys `tv_ip`, `tv_mac`, and `input` are still read as fallback
+values for existing installs. New writes use `tvs_primary_*` storage keys.
+
 Current structured settings:
 
 | Setting key | `config.env` key | Operations |
 | --- | --- | --- |
+| `tv.ip` | `tvs_primary_ip` | `get`, `describe`, `set` |
+| `tv.mac` | `tvs_primary_mac` | `get`, `describe`, `set` |
+| `tv.input` | `tvs_primary_input` | `get`, `describe`, `set` |
 | `screen.backend` | `screen_backend` | `get`, `describe`, `set`, `unset` |
 | `screen.idle_timeout` | `screen_idle_timeout` | `get`, `describe`, `set`, `unset` |
 | `screen.restore_policy` | `screen_restore_policy` | `get`, `describe`, `set`, `unset` |
 | `system.sleep_wake_policy` | `system_sleep_wake_policy` | `get`, `describe`, `set`, `unset` |
+
+The `tv.*` settings expose the single supported TV in the public API. Their
+storage keys are profile-shaped only to leave room for future storage growth;
+this version does not expose multiple TVs or TV profile selection. These values
+are required, so `unset` is not supported.
 
 `screen_idle_timeout` is the inactivity threshold in seconds used by the session monitor.
 LG Buddy currently uses that timeout for both the GNOME and `swayidle` backends.
@@ -205,6 +218,9 @@ runtime policy without reinstalling services.
 Example:
 
 ```ini
+tvs_primary_ip=192.168.1.100
+tvs_primary_mac=aa:bb:cc:dd:ee:ff
+tvs_primary_input=HDMI_2
 screen_idle_timeout=300
 screen_restore_policy=aggressive
 system_sleep_wake_policy=enabled

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -178,7 +178,7 @@ Current structured settings:
 | `screen.backend` | `screen_backend` | `get`, `describe`, `set`, `unset` |
 | `screen.idle_timeout` | `screen_idle_timeout` | `get`, `describe`, `set`, `unset` |
 | `screen.restore_policy` | `screen_restore_policy` | `get`, `describe`, `set`, `unset` |
-| `system.sleep_wake_policy` | `system_sleep_wake_policy` | `get`, `describe` |
+| `system.sleep_wake_policy` | `system_sleep_wake_policy` | `get`, `describe`, `set`, `unset` |
 
 `screen_idle_timeout` is the inactivity threshold in seconds used by the session monitor.
 LG Buddy currently uses that timeout for both the GNOME and `swayidle` backends.
@@ -192,17 +192,15 @@ LG Buddy currently uses that timeout for both the GNOME and `swayidle` backends.
 
 `system_sleep_wake_policy` controls automatic system sleep/wake TV handling:
 
-- `enabled`: default behavior, install the NetworkManager pre-down gate and run
-  the logind lifecycle service
-- `disabled`: do not install an active lifecycle owner
+- `enabled`: default behavior, let the installed NetworkManager pre-down gate
+  and logind lifecycle service control the TV around system sleep and wake
+- `disabled`: leave lifecycle integration installed, but make those commands
+  no-op for sleep/wake TV handling
 
-The running lifecycle service rereads config and stops cleanly when this value
-is changed to `disabled`. To apply the installed service enable/remove state
-after changing the value, rerun `./install.sh`.
-
-`system.sleep_wake_policy` is read-only in the structured settings CLI for now.
-Write support should only be added when LG Buddy can also apply the lifecycle
-service and NetworkManager hook changes in the same command.
+The running lifecycle service rereads config and suppresses actions while this
+value is `disabled`. The NetworkManager pre-down hook also reads config on each
+invocation, so `lg-buddy settings set system.sleep_wake_policy <value>` changes
+runtime policy without reinstalling services.
 
 Example:
 

--- a/install.sh
+++ b/install.sh
@@ -386,32 +386,19 @@ SYSTEM_CONFIG_OVERRIDE_TMP=""
 
 cleanup_legacy_sleep_wake_handlers
 
-if [ "$SYSTEM_SLEEP_WAKE_POLICY" = "enabled" ]; then
-    run_privileged cp "$SCRIPT_DIR/systemd/LG_Buddy_lifecycle.service" "$SYSTEMD_LIFECYCLE_SERVICE_PATH"
-    run_privileged install -d "$SYSTEMD_LIFECYCLE_OVERRIDE_DIR"
-    SYSTEM_CONFIG_OVERRIDE_TMP="$(mktemp)"
-    write_config_override "$SYSTEM_CONFIG_OVERRIDE_TMP" "$CONFIG_FILE"
-    run_privileged install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${SYSTEMD_LIFECYCLE_OVERRIDE_DIR}/config.conf"
-    rm -f "$SYSTEM_CONFIG_OVERRIDE_TMP"
-    SYSTEM_CONFIG_OVERRIDE_TMP=""
-    run_privileged install -d "$NM_PRE_DOWN_DIR"
-    NM_HOOK_TMP="$(mktemp)"
-    write_nm_pre_down_hook "$NM_HOOK_TMP"
-    run_privileged install -m 755 "$NM_HOOK_TMP" "$NM_LIFECYCLE_HOOK_PATH"
-    rm -f "$NM_HOOK_TMP"
-    NM_HOOK_TMP=""
-else
-    if [ "$SKIP_SYSTEMD_ACTIONS" = "1" ]; then
-        echo "Skipping lifecycle service disable because LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1."
-    else
-        run_privileged systemctl disable LG_Buddy_lifecycle.service 2>/dev/null || true
-        run_privileged systemctl stop LG_Buddy_lifecycle.service 2>/dev/null || true
-    fi
-    run_privileged rm -f "$SYSTEMD_LIFECYCLE_SERVICE_PATH"
-    run_privileged rm -f "${SYSTEMD_LIFECYCLE_OVERRIDE_DIR}/config.conf"
-    run_privileged rmdir "$SYSTEMD_LIFECYCLE_OVERRIDE_DIR" 2>/dev/null || true
-    run_privileged rm -f "$NM_LIFECYCLE_HOOK_PATH"
-fi
+run_privileged cp "$SCRIPT_DIR/systemd/LG_Buddy_lifecycle.service" "$SYSTEMD_LIFECYCLE_SERVICE_PATH"
+run_privileged install -d "$SYSTEMD_LIFECYCLE_OVERRIDE_DIR"
+SYSTEM_CONFIG_OVERRIDE_TMP="$(mktemp)"
+write_config_override "$SYSTEM_CONFIG_OVERRIDE_TMP" "$CONFIG_FILE"
+run_privileged install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${SYSTEMD_LIFECYCLE_OVERRIDE_DIR}/config.conf"
+rm -f "$SYSTEM_CONFIG_OVERRIDE_TMP"
+SYSTEM_CONFIG_OVERRIDE_TMP=""
+run_privileged install -d "$NM_PRE_DOWN_DIR"
+NM_HOOK_TMP="$(mktemp)"
+write_nm_pre_down_hook "$NM_HOOK_TMP"
+run_privileged install -m 755 "$NM_HOOK_TMP" "$NM_LIFECYCLE_HOOK_PATH"
+rm -f "$NM_HOOK_TMP"
+NM_HOOK_TMP=""
 
 if [ "$SKIP_SYSTEMD_ACTIONS" = "1" ]; then
     echo "Skipping systemd tmpfiles and enable actions because LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1."
@@ -419,10 +406,8 @@ else
     run_privileged systemd-tmpfiles --create "$TMPFILES_CONF_PATH"
     run_privileged systemctl daemon-reload
     run_privileged systemctl enable LG_Buddy.service
-    if [ "$SYSTEM_SLEEP_WAKE_POLICY" = "enabled" ]; then
-        run_privileged systemctl enable LG_Buddy_lifecycle.service
-        run_privileged systemctl restart LG_Buddy_lifecycle.service
-    fi
+    run_privileged systemctl enable LG_Buddy_lifecycle.service
+    run_privileged systemctl restart LG_Buddy_lifecycle.service
 fi
 echo "Done."
 
@@ -479,7 +464,7 @@ fi
 if [ "$SYSTEM_SLEEP_WAKE_POLICY" = "enabled" ]; then
     echo "System sleep/wake TV control enabled via LG_Buddy_lifecycle.service and NetworkManager pre-down gate."
 else
-    echo "System sleep/wake TV control disabled by config. Startup/shutdown will still work."
+    echo "System sleep/wake TV control disabled by config. Lifecycle integration is installed and will no-op until re-enabled."
 fi
 
 echo "Installation complete!"

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -121,6 +121,8 @@ assert_file "$BUNDLE_DIR/systemd/LG_Buddy_screen.service"
 
 HELP_OUTPUT="$("$BUNDLE_DIR/lg-buddy" 2>&1 || true)"
 printf '%s\n' "$HELP_OUTPUT" | grep -q "lg-buddy"
+printf '%s\n' "$HELP_OUTPUT" | grep -q "settings list"
+printf '%s\n' "$HELP_OUTPUT" | grep -q "settings set <key> <value>"
 
 export HOME="$HOME_DIR"
 export XDG_CONFIG_HOME="$XDG_CONFIG_HOME"
@@ -200,6 +202,8 @@ fi
 
 INSTALLED_HELP_OUTPUT="$("$INSTALLED_BINARY" 2>&1 || true)"
 printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "lg-buddy"
+printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "settings list"
+printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "settings set <key> <value>"
 
 export LG_BUDDY_REMOVE_CONFIG="1"
 (

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -211,6 +211,9 @@ printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "settings set <key> <value>"
 
 "$INSTALLED_BINARY" settings set screen.backend gnome
 "$INSTALLED_BINARY" settings set screen.idle_timeout 900
+"$INSTALLED_BINARY" settings set screen.idle_timeout 90000
+grep -q '^screen_idle_timeout=86400$' "$CONFIG_FILE"
+"$INSTALLED_BINARY" settings set screen.idle_timeout 900
 "$INSTALLED_BINARY" settings set screen.restore_policy aggressive
 "$INSTALLED_BINARY" settings set tv.ip 192.168.1.12
 "$INSTALLED_BINARY" settings set tv.mac 22:33:44:55:66:77

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -193,9 +193,9 @@ if grep -q 'LG_BUDDY_CONFIG' "$NM_LIFECYCLE_HOOK"; then
     exit 1
 fi
 
-grep -q '^tv_ip=192.168.1.10$' "$CONFIG_FILE"
-grep -q '^tv_mac=aa:bb:cc:dd:ee:ff$' "$CONFIG_FILE"
-grep -q '^input=HDMI_2$' "$CONFIG_FILE"
+grep -q '^tvs_primary_ip=192.168.1.10$' "$CONFIG_FILE"
+grep -q '^tvs_primary_mac=aa:bb:cc:dd:ee:ff$' "$CONFIG_FILE"
+grep -q '^tvs_primary_input=HDMI_2$' "$CONFIG_FILE"
 grep -q '^screen_backend=auto$' "$CONFIG_FILE"
 grep -q '^system_sleep_wake_policy=enabled$' "$CONFIG_FILE"
 grep -q "$CONFIG_FILE" "$INSTALLED_POINTER"
@@ -212,9 +212,15 @@ printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "settings set <key> <value>"
 "$INSTALLED_BINARY" settings set screen.backend gnome
 "$INSTALLED_BINARY" settings set screen.idle_timeout 900
 "$INSTALLED_BINARY" settings set screen.restore_policy aggressive
+"$INSTALLED_BINARY" settings set tv.ip 192.168.1.12
+"$INSTALLED_BINARY" settings set tv.mac 22:33:44:55:66:77
+"$INSTALLED_BINARY" settings set tv.input HDMI_4
 grep -q '^screen_backend=gnome$' "$CONFIG_FILE"
 grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"
 grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
+grep -q '^tvs_primary_ip=192.168.1.12$' "$CONFIG_FILE"
+grep -q '^tvs_primary_mac=22:33:44:55:66:77$' "$CONFIG_FILE"
+grep -q '^tvs_primary_input=HDMI_4$' "$CONFIG_FILE"
 
 (
     unset LG_BUDDY_SCREEN_BACKEND
@@ -228,9 +234,9 @@ grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
     ./configure.sh
 )
 
-grep -q '^tv_ip=192.168.1.11$' "$CONFIG_FILE"
-grep -q '^tv_mac=11:22:33:44:55:66$' "$CONFIG_FILE"
-grep -q '^input=HDMI_3$' "$CONFIG_FILE"
+grep -q '^tvs_primary_ip=192.168.1.11$' "$CONFIG_FILE"
+grep -q '^tvs_primary_mac=11:22:33:44:55:66$' "$CONFIG_FILE"
+grep -q '^tvs_primary_input=HDMI_3$' "$CONFIG_FILE"
 grep -q '^screen_backend=gnome$' "$CONFIG_FILE"
 grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"
 grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -162,6 +162,10 @@ DESKTOP_ENTRY="$INSTALL_ROOT/usr/share/applications/LG_Buddy_Brightness.desktop"
 NM_SLEEP_HOOK="$INSTALL_ROOT/etc/NetworkManager/dispatcher.d/pre-down.d/LG_Buddy_sleep"
 NM_LIFECYCLE_HOOK="$INSTALL_ROOT/etc/NetworkManager/dispatcher.d/pre-down.d/LG_Buddy_lifecycle"
 
+# The installed Rust binary does not know about LG_BUDDY_INSTALL_ROOT, so pin
+# CLI config operations to the smoke-test sandbox instead of any host install.
+export LG_BUDDY_CONFIG="$CONFIG_FILE"
+
 assert_file "$CONFIG_FILE"
 assert_executable "$INSTALLED_BINARY"
 assert_executable "$INSTALLED_VENV_PIP"
@@ -204,6 +208,33 @@ INSTALLED_HELP_OUTPUT="$("$INSTALLED_BINARY" 2>&1 || true)"
 printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "lg-buddy"
 printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "settings list"
 printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "settings set <key> <value>"
+
+"$INSTALLED_BINARY" settings set screen.backend gnome
+"$INSTALLED_BINARY" settings set screen.idle_timeout 900
+"$INSTALLED_BINARY" settings set screen.restore_policy aggressive
+grep -q '^screen_backend=gnome$' "$CONFIG_FILE"
+grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"
+grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
+
+(
+    unset LG_BUDDY_SCREEN_BACKEND
+    unset LG_BUDDY_SCREEN_IDLE_TIMEOUT
+    unset LG_BUDDY_SCREEN_RESTORE_POLICY
+    unset LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY
+    export LG_BUDDY_TV_IP="192.168.1.11"
+    export LG_BUDDY_TV_MAC="11:22:33:44:55:66"
+    export LG_BUDDY_INPUT="HDMI_3"
+    cd "$BUNDLE_DIR"
+    ./configure.sh
+)
+
+grep -q '^tv_ip=192.168.1.11$' "$CONFIG_FILE"
+grep -q '^tv_mac=11:22:33:44:55:66$' "$CONFIG_FILE"
+grep -q '^input=HDMI_3$' "$CONFIG_FILE"
+grep -q '^screen_backend=gnome$' "$CONFIG_FILE"
+grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"
+grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
+grep -q '^system_sleep_wake_policy=enabled$' "$CONFIG_FILE"
 
 export LG_BUDDY_REMOVE_CONFIG="1"
 (

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -293,11 +293,8 @@ export LG_BUDDY_SKIP_PIP_INSTALL="1"
 assert_file "$CONFIG_FILE"
 assert_executable "$INSTALLED_BINARY"
 assert_file "$SYSTEM_SERVICE"
+assert_file "$LIFECYCLE_SERVICE"
 assert_file "$USER_SCREEN_SERVICE"
-[ ! -e "$LIFECYCLE_SERVICE" ] || {
-    echo "Lifecycle service installed despite disabled policy: $LIFECYCLE_SERVICE"
-    exit 1
-}
 [ ! -e "$LEGACY_SLEEP_SERVICE" ] || {
     echo "Legacy sleep service installed unexpectedly: $LEGACY_SLEEP_SERVICE"
     exit 1
@@ -310,10 +307,8 @@ assert_file "$USER_SCREEN_SERVICE"
     echo "NetworkManager sleep hook installed unexpectedly: $NM_SLEEP_HOOK"
     exit 1
 }
-[ ! -e "$NM_LIFECYCLE_HOOK" ] || {
-    echo "NetworkManager lifecycle hook installed despite disabled policy: $NM_LIFECYCLE_HOOK"
-    exit 1
-}
+assert_executable "$NM_LIFECYCLE_HOOK"
+grep -q 'lg-buddy nm-pre-down' "$NM_LIFECYCLE_HOOK"
 grep -q '^system_sleep_wake_policy=disabled$' "$CONFIG_FILE"
 
 (


### PR DESCRIPTION
Closes #26

Summary:
- Add a structured settings registry, read-only store, and settings CLI over the existing config.env storage.
- Support targeted set/unset for writable screen settings, including apply behavior for the screen service.
- Document the settings surface and add runtime, Cucumber, and release-bundle coverage.

Verification:
- cargo test -p lg-buddy --lib
- cargo test -p lg-buddy --test cucumber
- release-bundle smoke with --skip-pip-install