### PR TITLE
Add CLI-backed brightness controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It can:
 - turn the TV on at boot and wake
 - turn the TV off at shutdown and before system sleep
 - blank and restore the panel on desktop idle and activity, including gamepad activity on GNOME
-- adjust OLED pixel brightness with a small desktop dialog
+- adjust OLED pixel brightness with a small desktop dialog or CLI command
 
 LG Buddy supports GNOME and `swayidle`-based sessions. Official release bundles include a prebuilt `lg-buddy` binary, so normal installation does not require a Rust toolchain.
 
@@ -87,6 +87,8 @@ LG Buddy is mostly automatic after installation.
 
 - To inspect settings, run `lg-buddy settings list`
 - To change supported settings, use `lg-buddy settings set <key> <value>`
+- To inspect TV brightness, run `lg-buddy brightness get`
+- To set TV brightness directly, run `lg-buddy brightness set <0-100>`
 - To rerun full setup for TV IP, MAC address, or HDMI input, run `./configure.sh`
 - To check the screen monitor, run `systemctl --user status LG_Buddy_screen.service`
 - To remove LG Buddy, run `./uninstall.sh`

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -4,6 +4,7 @@ use std::net::Ipv4Addr;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
+use std::process::Output;
 use std::time::Duration;
 
 use crate::auth::resolve_bscpylgtv_auth_context_from_env;
@@ -27,6 +28,11 @@ trait BrightnessUi {
     fn show_error(&self, title: &str, message: &str) -> io::Result<()>;
 }
 
+trait BrightnessCli {
+    fn get_brightness(&self) -> Result<OledBrightness, RunError>;
+    fn set_brightness(&self, brightness: OledBrightness) -> Result<String, RunError>;
+}
+
 trait Notifier {
     fn notify(&self, title: &str, message: &str) -> io::Result<()>;
 }
@@ -43,14 +49,18 @@ struct ZenityBrightnessUi {
     command_path: PathBuf,
 }
 
+struct CurrentExeBrightnessCli {
+    command_path: PathBuf,
+}
+
 struct NotifySendNotifier {
     command_path: PathBuf,
 }
 
-struct BrightnessDeps<'a, C, R, U, N> {
-    tv_client: &'a C,
+struct BrightnessDialogDeps<'a, R, U, B, N> {
     reachability: &'a R,
     ui: &'a U,
+    brightness_cli: &'a B,
     notifier: &'a N,
 }
 
@@ -108,12 +118,51 @@ impl ZenityBrightnessUi {
     }
 }
 
+impl CurrentExeBrightnessCli {
+    fn from_current_exe() -> Result<Self, RunError> {
+        Ok(Self {
+            command_path: env::current_exe()?,
+        })
+    }
+
+    fn run(&self, args: &[&str]) -> Result<Output, RunError> {
+        ProcessCommand::new(&self.command_path)
+            .args(args)
+            .output()
+            .map_err(RunError::Io)
+    }
+}
+
 impl NotifySendNotifier {
     fn from_env() -> Self {
         Self {
             command_path: env::var_os("LG_BUDDY_NOTIFY_SEND")
                 .map(PathBuf::from)
                 .unwrap_or_else(|| PathBuf::from("notify-send")),
+        }
+    }
+}
+
+impl BrightnessCli for CurrentExeBrightnessCli {
+    fn get_brightness(&self) -> Result<OledBrightness, RunError> {
+        let output = self.run(&["brightness", "get"])?;
+
+        if !output.status.success() {
+            return Err(RunError::Policy(command_output_message(&output)));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        OledBrightness::parse(stdout.trim())
+            .map_err(|err| RunError::Policy(format!("invalid output from `brightness get`: {err}")))
+    }
+
+    fn set_brightness(&self, brightness: OledBrightness) -> Result<String, RunError> {
+        let output = self.run(&["brightness", "set", &brightness.to_string()])?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            Err(RunError::Policy(command_output_message(&output)))
         }
     }
 }
@@ -197,6 +246,31 @@ impl Notifier for NotifySendNotifier {
     }
 }
 
+fn command_output_message(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return strip_lg_buddy_prefix(&stderr).to_string();
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return strip_lg_buddy_prefix(&stdout).to_string();
+    }
+
+    format!(
+        "brightness command failed with status {}",
+        output
+            .status
+            .code()
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "terminated by signal".to_string())
+    )
+}
+
+fn strip_lg_buddy_prefix(value: &str) -> &str {
+    value.strip_prefix("LG Buddy: ").unwrap_or(value)
+}
+
 pub fn run_screen_off<W: Write>(writer: &mut W) -> Result<(), RunError> {
     crate::screen::run_screen_off_from_env(writer)
 }
@@ -258,18 +332,27 @@ pub fn run_brightness<W: Write>(
 ) -> Result<(), RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
     let config = load_config(&config_path).map_err(RunError::Config)?;
-    let tv_client = build_tv_client(&config_path)?;
-    let reachability = PingReachabilityChecker::default();
-    let ui = ZenityBrightnessUi::default();
-    let notifier = NotifySendNotifier::default();
-    let deps = BrightnessDeps {
-        tv_client: &tv_client,
-        reachability: &reachability,
-        ui: &ui,
-        notifier: &notifier,
-    };
 
-    run_brightness_with(writer, &config, command, deps)
+    match command {
+        BrightnessCommand::Prompt => {
+            let reachability = PingReachabilityChecker::default();
+            let ui = ZenityBrightnessUi::default();
+            let brightness_cli = CurrentExeBrightnessCli::from_current_exe()?;
+            let notifier = NotifySendNotifier::default();
+            let deps = BrightnessDialogDeps {
+                reachability: &reachability,
+                ui: &ui,
+                brightness_cli: &brightness_cli,
+                notifier: &notifier,
+            };
+
+            run_brightness_prompt_with(writer, &config, deps)
+        }
+        BrightnessCommand::Get | BrightnessCommand::Set(_) => {
+            let tv_client = build_tv_client(&config_path)?;
+            run_brightness_command_with(writer, &config, command, &tv_client)
+        }
+    }
 }
 
 pub fn run_startup<W: Write>(writer: &mut W, mode: StartupMode) -> Result<(), RunError> {
@@ -367,27 +450,21 @@ fn build_tv_client(
         .with_launcher(UserScopedBscpylgtvCommandLauncher))
 }
 
-fn run_brightness_with<
-    W: Write,
-    C: TvClient,
-    R: ReachabilityChecker,
-    U: BrightnessUi,
-    N: Notifier,
->(
+fn run_brightness_command_with<W: Write, C: TvClient>(
     writer: &mut W,
     config: &Config,
     command: BrightnessCommand,
-    deps: BrightnessDeps<'_, C, R, U, N>,
+    tv_client: &C,
 ) -> Result<(), RunError> {
     match command {
-        BrightnessCommand::Prompt => run_brightness_prompt_with(writer, config, deps),
+        BrightnessCommand::Prompt => unreachable!("prompt is handled by the dialog wrapper"),
         BrightnessCommand::Get => {
-            let brightness = read_oled_brightness(config, deps.tv_client)?;
+            let brightness = read_oled_brightness(config, tv_client)?;
             writeln!(writer, "{brightness}")?;
             Ok(())
         }
         BrightnessCommand::Set(brightness) => {
-            set_oled_brightness(config, deps.tv_client, brightness)?;
+            set_oled_brightness(config, tv_client, brightness)?;
             writeln!(
                 writer,
                 "LG Buddy Brightness: Set OLED pixel brightness to {brightness}%."
@@ -399,17 +476,15 @@ fn run_brightness_with<
 
 fn run_brightness_prompt_with<
     W: Write,
-    C: TvClient,
     R: ReachabilityChecker,
     U: BrightnessUi,
+    B: BrightnessCli,
     N: Notifier,
 >(
     writer: &mut W,
     config: &Config,
-    deps: BrightnessDeps<'_, C, R, U, N>,
+    deps: BrightnessDialogDeps<'_, R, U, B, N>,
 ) -> Result<(), RunError> {
-    let tv = TvDevice::new(deps.tv_client, config.tv_ip);
-
     match deps.reachability.is_reachable(config.tv_ip) {
         Ok(true) => {}
         Ok(false) => {
@@ -424,24 +499,21 @@ fn run_brightness_prompt_with<
         }
     }
 
-    let initial_brightness = tv
-        .picture()
-        .oled_brightness()
+    let initial_brightness = deps
+        .brightness_cli
+        .get_brightness()
         .unwrap_or(OledBrightness::DEFAULT);
 
     let Some(brightness) = deps.ui.prompt_brightness(initial_brightness)? else {
         return Ok(());
     };
 
-    match set_oled_brightness(config, deps.tv_client, brightness) {
-        Ok(_) => {
+    match deps.brightness_cli.set_brightness(brightness) {
+        Ok(stdout) => {
             let _ = deps
                 .notifier
                 .notify("LG TV", &format!("Brightness set to {brightness}%"));
-            writeln!(
-                writer,
-                "LG Buddy Brightness: Set OLED pixel brightness to {brightness}%."
-            )?;
+            write!(writer, "{stdout}")?;
             Ok(())
         }
         Err(err) => {
@@ -479,7 +551,10 @@ mod tests {
         include!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/support/mod.rs"));
     }
 
-    use super::{run_brightness_with, BrightnessDeps, BrightnessUi, Notifier, ReachabilityChecker};
+    use super::{
+        run_brightness_command_with, run_brightness_prompt_with, BrightnessCli,
+        BrightnessDialogDeps, BrightnessUi, Notifier, ReachabilityChecker,
+    };
     use crate::config::{
         Config, HdmiInput, MacAddress, ScreenBackend, ScreenRestorePolicy, SystemSleepWakePolicy,
     };
@@ -492,7 +567,7 @@ mod tests {
     use crate::state::SystemSleepAttemptState;
     use crate::tv::{BscpylgtvCommandClient, OledBrightness};
     use crate::wol::{WakeOnLanError, WakeOnLanSender};
-    use crate::{BrightnessCommand, StartupMode};
+    use crate::{BrightnessCommand, RunError, StartupMode};
     use std::cell::RefCell;
     use std::ffi::CString;
     use std::fs;
@@ -1218,28 +1293,22 @@ mod tests {
     }
 
     #[test]
-    fn brightness_sets_oled_brightness_and_notifies() {
-        let mock = MockBscpylgtv::new("brightness-success-tv");
-        mock.set_backlight(72);
-        let client = client_for_mock(&mock);
+    fn brightness_dialog_uses_cli_get_and_set_then_notifies() {
         let reachability = FakeReachabilityChecker::reachable();
         let ui = FakeBrightnessUi::selected(65);
+        let brightness_cli = FakeBrightnessCli::success(72)
+            .with_set_stdout("LG Buddy Brightness: Set OLED pixel brightness to 65%.\n");
         let notifier = RecordingNotifier::default();
-        let deps = BrightnessDeps {
-            tv_client: &client,
+        let deps = BrightnessDialogDeps {
             reachability: &reachability,
             ui: &ui,
+            brightness_cli: &brightness_cli,
             notifier: &notifier,
         };
 
         let mut output = Vec::new();
-        run_brightness_with(
-            &mut output,
-            &sample_config(HdmiInput::Hdmi2),
-            BrightnessCommand::Prompt,
-            deps,
-        )
-        .expect("brightness should succeed");
+        run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
+            .expect("brightness should succeed");
 
         assert_eq!(ui.initial_values(), vec![72]);
         assert!(ui.error_messages().is_empty());
@@ -1247,8 +1316,10 @@ mod tests {
             notifier.messages(),
             vec![("LG TV".to_string(), "Brightness set to 65%".to_string())]
         );
-        assert_eq!(mock.state_snapshot().backlight, 65);
-        assert_call_commands(&mock, &["get_picture_settings", "set_settings"]);
+        assert_eq!(
+            brightness_cli.calls(),
+            vec![FakeBrightnessCliCall::Get, FakeBrightnessCliCall::Set(65),]
+        );
         assert!(rendered(&output).contains("Set OLED pixel brightness to 65%."));
     }
 
@@ -1257,28 +1328,16 @@ mod tests {
         let mock = MockBscpylgtv::new("brightness-get-tv");
         mock.set_backlight(72);
         let client = client_for_mock(&mock);
-        let reachability = FakeReachabilityChecker::unreachable();
-        let ui = FakeBrightnessUi::cancelled();
-        let notifier = RecordingNotifier::default();
-        let deps = BrightnessDeps {
-            tv_client: &client,
-            reachability: &reachability,
-            ui: &ui,
-            notifier: &notifier,
-        };
-
         let mut output = Vec::new();
-        run_brightness_with(
+        run_brightness_command_with(
             &mut output,
             &sample_config(HdmiInput::Hdmi2),
             BrightnessCommand::Get,
-            deps,
+            &client,
         )
         .expect("brightness get should succeed");
 
         assert_eq!(rendered(&output).trim(), "72");
-        assert!(ui.initial_values().is_empty());
-        assert!(notifier.messages().is_empty());
         assert_call_commands(&mock, &["get_picture_settings"]);
     }
 
@@ -1286,86 +1345,63 @@ mod tests {
     fn brightness_set_updates_oled_brightness_without_dialog() {
         let mock = MockBscpylgtv::new("brightness-set-tv");
         let client = client_for_mock(&mock);
-        let reachability = FakeReachabilityChecker::unreachable();
-        let ui = FakeBrightnessUi::cancelled();
-        let notifier = RecordingNotifier::default();
-        let deps = BrightnessDeps {
-            tv_client: &client,
-            reachability: &reachability,
-            ui: &ui,
-            notifier: &notifier,
-        };
 
         let mut output = Vec::new();
-        run_brightness_with(
+        run_brightness_command_with(
             &mut output,
             &sample_config(HdmiInput::Hdmi2),
             BrightnessCommand::Set(OledBrightness::new(61).expect("valid brightness")),
-            deps,
+            &client,
         )
         .expect("brightness set should succeed");
 
         assert_eq!(mock.state_snapshot().backlight, 61);
-        assert!(ui.initial_values().is_empty());
-        assert!(notifier.messages().is_empty());
         assert_call_commands(&mock, &["set_settings"]);
         assert!(rendered(&output).contains("Set OLED pixel brightness to 61%."));
     }
 
     #[test]
     fn brightness_returns_ok_when_dialog_is_cancelled() {
-        let mock = MockBscpylgtv::new("brightness-cancel-tv");
-        let client = client_for_mock(&mock);
         let reachability = FakeReachabilityChecker::reachable();
         let ui = FakeBrightnessUi::cancelled();
+        let brightness_cli = FakeBrightnessCli::success(50);
         let notifier = RecordingNotifier::default();
-        let deps = BrightnessDeps {
-            tv_client: &client,
+        let deps = BrightnessDialogDeps {
             reachability: &reachability,
             ui: &ui,
+            brightness_cli: &brightness_cli,
             notifier: &notifier,
         };
 
         let mut output = Vec::new();
-        run_brightness_with(
-            &mut output,
-            &sample_config(HdmiInput::Hdmi2),
-            BrightnessCommand::Prompt,
-            deps,
-        )
-        .expect("cancel should exit cleanly");
+        run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
+            .expect("cancel should exit cleanly");
 
         assert_eq!(ui.initial_values(), vec![50]);
-        assert_call_commands(&mock, &["get_picture_settings"]);
+        assert_eq!(brightness_cli.calls(), vec![FakeBrightnessCliCall::Get]);
         assert!(notifier.messages().is_empty());
         assert!(rendered(&output).is_empty());
     }
 
     #[test]
     fn brightness_shows_error_and_fails_when_tv_is_unreachable() {
-        let mock = MockBscpylgtv::new("brightness-unreachable-tv");
-        let client = client_for_mock(&mock);
         let reachability = FakeReachabilityChecker::unreachable();
         let ui = FakeBrightnessUi::selected(50);
+        let brightness_cli = FakeBrightnessCli::success(50);
         let notifier = RecordingNotifier::default();
-        let deps = BrightnessDeps {
-            tv_client: &client,
+        let deps = BrightnessDialogDeps {
             reachability: &reachability,
             ui: &ui,
+            brightness_cli: &brightness_cli,
             notifier: &notifier,
         };
 
         let mut output = Vec::new();
-        let err = run_brightness_with(
-            &mut output,
-            &sample_config(HdmiInput::Hdmi2),
-            BrightnessCommand::Prompt,
-            deps,
-        )
-        .expect_err("unreachable tv should fail");
+        let err = run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
+            .expect_err("unreachable tv should fail");
 
         assert!(matches!(err, crate::RunError::Policy(_)));
-        assert!(mock.calls().is_empty());
+        assert!(brightness_cli.calls().is_empty());
         assert!(notifier.messages().is_empty());
         assert_eq!(
             ui.error_messages(),
@@ -1378,57 +1414,43 @@ mod tests {
 
     #[test]
     fn brightness_defaults_to_fifty_when_current_brightness_query_fails() {
-        let mock = MockBscpylgtv::new("brightness-query-failure-tv");
-        mock.queue_error("get_picture_settings", 1, "offline\n");
-        let client = client_for_mock(&mock);
         let reachability = FakeReachabilityChecker::reachable();
         let ui = FakeBrightnessUi::cancelled();
+        let brightness_cli = FakeBrightnessCli::get_error("offline");
         let notifier = RecordingNotifier::default();
-        let deps = BrightnessDeps {
-            tv_client: &client,
+        let deps = BrightnessDialogDeps {
             reachability: &reachability,
             ui: &ui,
+            brightness_cli: &brightness_cli,
             notifier: &notifier,
         };
 
         let mut output = Vec::new();
-        run_brightness_with(
-            &mut output,
-            &sample_config(HdmiInput::Hdmi2),
-            BrightnessCommand::Prompt,
-            deps,
-        )
-        .expect("fallback to default brightness should still allow cancellation");
+        run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
+            .expect("fallback to default brightness should still allow cancellation");
 
         assert_eq!(ui.initial_values(), vec![50]);
-        assert_call_commands(&mock, &["get_picture_settings"]);
+        assert_eq!(brightness_cli.calls(), vec![FakeBrightnessCliCall::Get]);
         assert!(notifier.messages().is_empty());
         assert!(rendered(&output).is_empty());
     }
 
     #[test]
     fn brightness_notifies_and_fails_when_tv_update_fails() {
-        let mock = MockBscpylgtv::new("brightness-tv-failure");
-        mock.queue_error("set_settings", 1, "offline\n");
-        let client = client_for_mock(&mock);
         let reachability = FakeReachabilityChecker::reachable();
         let ui = FakeBrightnessUi::selected(30);
+        let brightness_cli = FakeBrightnessCli::success(50).with_set_error("offline");
         let notifier = RecordingNotifier::default();
-        let deps = BrightnessDeps {
-            tv_client: &client,
+        let deps = BrightnessDialogDeps {
             reachability: &reachability,
             ui: &ui,
+            brightness_cli: &brightness_cli,
             notifier: &notifier,
         };
 
         let mut output = Vec::new();
-        let err = run_brightness_with(
-            &mut output,
-            &sample_config(HdmiInput::Hdmi2),
-            BrightnessCommand::Prompt,
-            deps,
-        )
-        .expect_err("tv command failure should fail");
+        let err = run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
+            .expect_err("tv command failure should fail");
 
         assert!(matches!(err, crate::RunError::Policy(_)));
         assert_eq!(ui.initial_values(), vec![50]);
@@ -1436,7 +1458,10 @@ mod tests {
             notifier.messages(),
             vec![("LG TV".to_string(), "Failed to set brightness".to_string())]
         );
-        assert_call_commands(&mock, &["get_picture_settings", "set_settings"]);
+        assert_eq!(
+            brightness_cli.calls(),
+            vec![FakeBrightnessCliCall::Get, FakeBrightnessCliCall::Set(30),]
+        );
         assert!(rendered(&output).is_empty());
     }
 
@@ -1834,6 +1859,72 @@ mod tests {
                 Ok(value) => Ok(*value),
                 Err(err) => Err(io::Error::new(err.kind(), err.to_string())),
             }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum FakeBrightnessCliCall {
+        Get,
+        Set(u8),
+    }
+
+    struct FakeBrightnessCli {
+        get_result: Result<OledBrightness, String>,
+        set_result: Result<String, String>,
+        calls: RefCell<Vec<FakeBrightnessCliCall>>,
+    }
+
+    impl FakeBrightnessCli {
+        fn success(current: u8) -> Self {
+            Self {
+                get_result: Ok(
+                    OledBrightness::new(current).expect("fake brightness value should be valid")
+                ),
+                set_result: Ok(String::new()),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn get_error(message: &str) -> Self {
+            Self {
+                get_result: Err(message.to_string()),
+                set_result: Ok(String::new()),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn with_set_error(mut self, message: &str) -> Self {
+            self.set_result = Err(message.to_string());
+            self
+        }
+
+        fn with_set_stdout(mut self, stdout: &str) -> Self {
+            self.set_result = Ok(stdout.to_string());
+            self
+        }
+
+        fn calls(&self) -> Vec<FakeBrightnessCliCall> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl BrightnessCli for FakeBrightnessCli {
+        fn get_brightness(&self) -> Result<OledBrightness, RunError> {
+            self.calls.borrow_mut().push(FakeBrightnessCliCall::Get);
+            self.get_result
+                .as_ref()
+                .copied()
+                .map_err(|message| RunError::Policy(message.clone()))
+        }
+
+        fn set_brightness(&self, brightness: OledBrightness) -> Result<String, RunError> {
+            self.calls
+                .borrow_mut()
+                .push(FakeBrightnessCliCall::Set(brightness.as_percent()));
+            self.set_result
+                .as_ref()
+                .cloned()
+                .map_err(|message| RunError::Policy(message.clone()))
         }
     }
 

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -11,19 +11,19 @@ use crate::config::{load_config, resolve_config_path_from_env, Config};
 use crate::lifecycle::ThreadSleeper;
 use crate::lifecycle::{self, JournalctlSleepDetector, NmOnlineNetworkWaiter};
 use crate::state::{ScreenOwnershipMarker, StateScope, SystemSleepAttemptState};
-use crate::tv::{BscpylgtvCommandClient, TvClient, TvDevice, UserScopedBscpylgtvCommandLauncher};
+use crate::tv::{
+    BscpylgtvCommandClient, OledBrightness, TvClient, TvDevice, UserScopedBscpylgtvCommandLauncher,
+};
 use crate::wol::UdpWakeOnLanSender;
-use crate::{RunError, StartupMode};
+use crate::{BrightnessCommand, RunError, StartupMode};
 
 const SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
-const BRIGHTNESS_DEFAULT_VALUE: u8 = 50;
-
 trait ReachabilityChecker {
     fn is_reachable(&self, tv_ip: Ipv4Addr) -> io::Result<bool>;
 }
 
 trait BrightnessUi {
-    fn prompt_brightness(&self, initial: u8) -> io::Result<Option<u8>>;
+    fn prompt_brightness(&self, initial: OledBrightness) -> io::Result<Option<OledBrightness>>;
     fn show_error(&self, title: &str, message: &str) -> io::Result<()>;
 }
 
@@ -147,7 +147,7 @@ impl ReachabilityChecker for PingReachabilityChecker {
 }
 
 impl BrightnessUi for ZenityBrightnessUi {
-    fn prompt_brightness(&self, initial: u8) -> io::Result<Option<u8>> {
+    fn prompt_brightness(&self, initial: OledBrightness) -> io::Result<Option<OledBrightness>> {
         let output = ProcessCommand::new(&self.command_path)
             .args([
                 "--scale",
@@ -165,19 +165,12 @@ impl BrightnessUi for ZenityBrightnessUi {
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let value = stdout.trim().parse::<u8>().map_err(|err| {
+        let value = OledBrightness::parse(stdout.trim()).map_err(|err| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("invalid zenity brightness value `{}`: {err}", stdout.trim()),
+                format!("invalid zenity brightness value: {err}"),
             )
         })?;
-
-        if value > 100 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("zenity brightness value out of range: {value}"),
-            ));
-        }
 
         Ok(Some(value))
     }
@@ -259,7 +252,10 @@ pub fn run_nm_pre_down<W: Write>(writer: &mut W) -> Result<(), RunError> {
     )
 }
 
-pub fn run_brightness<W: Write>(writer: &mut W) -> Result<(), RunError> {
+pub fn run_brightness<W: Write>(
+    writer: &mut W,
+    command: BrightnessCommand,
+) -> Result<(), RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
     let config = load_config(&config_path).map_err(RunError::Config)?;
     let tv_client = build_tv_client(&config_path)?;
@@ -273,7 +269,7 @@ pub fn run_brightness<W: Write>(writer: &mut W) -> Result<(), RunError> {
         notifier: &notifier,
     };
 
-    run_brightness_with(writer, &config, deps)
+    run_brightness_with(writer, &config, command, deps)
 }
 
 pub fn run_startup<W: Write>(writer: &mut W, mode: StartupMode) -> Result<(), RunError> {
@@ -380,6 +376,36 @@ fn run_brightness_with<
 >(
     writer: &mut W,
     config: &Config,
+    command: BrightnessCommand,
+    deps: BrightnessDeps<'_, C, R, U, N>,
+) -> Result<(), RunError> {
+    match command {
+        BrightnessCommand::Prompt => run_brightness_prompt_with(writer, config, deps),
+        BrightnessCommand::Get => {
+            let brightness = read_oled_brightness(config, deps.tv_client)?;
+            writeln!(writer, "{brightness}")?;
+            Ok(())
+        }
+        BrightnessCommand::Set(brightness) => {
+            set_oled_brightness(config, deps.tv_client, brightness)?;
+            writeln!(
+                writer,
+                "LG Buddy Brightness: Set OLED pixel brightness to {brightness}%."
+            )?;
+            Ok(())
+        }
+    }
+}
+
+fn run_brightness_prompt_with<
+    W: Write,
+    C: TvClient,
+    R: ReachabilityChecker,
+    U: BrightnessUi,
+    N: Notifier,
+>(
+    writer: &mut W,
+    config: &Config,
     deps: BrightnessDeps<'_, C, R, U, N>,
 ) -> Result<(), RunError> {
     let tv = TvDevice::new(deps.tv_client, config.tv_ip);
@@ -401,13 +427,13 @@ fn run_brightness_with<
     let initial_brightness = tv
         .picture()
         .oled_brightness()
-        .unwrap_or(BRIGHTNESS_DEFAULT_VALUE);
+        .unwrap_or(OledBrightness::DEFAULT);
 
     let Some(brightness) = deps.ui.prompt_brightness(initial_brightness)? else {
         return Ok(());
     };
 
-    match tv.picture().set_oled_brightness(brightness) {
+    match set_oled_brightness(config, deps.tv_client, brightness) {
         Ok(_) => {
             let _ = deps
                 .notifier
@@ -420,9 +446,31 @@ fn run_brightness_with<
         }
         Err(err) => {
             let _ = deps.notifier.notify("LG TV", "Failed to set brightness");
-            Err(RunError::Policy(format!("failed to set brightness: {err}")))
+            Err(err)
         }
     }
+}
+
+fn read_oled_brightness<C: TvClient>(
+    config: &Config,
+    tv_client: &C,
+) -> Result<OledBrightness, RunError> {
+    let tv = TvDevice::new(tv_client, config.tv_ip);
+    tv.picture()
+        .oled_brightness()
+        .map_err(|err| RunError::Policy(format!("failed to read brightness: {err}")))
+}
+
+fn set_oled_brightness<C: TvClient>(
+    config: &Config,
+    tv_client: &C,
+    brightness: OledBrightness,
+) -> Result<(), RunError> {
+    let tv = TvDevice::new(tv_client, config.tv_ip);
+    tv.picture()
+        .set_oled_brightness(brightness)
+        .map(|_| ())
+        .map_err(|err| RunError::Policy(format!("failed to set brightness: {err}")))
 }
 
 #[cfg(test)]
@@ -431,10 +479,7 @@ mod tests {
         include!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/support/mod.rs"));
     }
 
-    use super::{
-        run_brightness_with, BrightnessDeps, BrightnessUi, Notifier, ReachabilityChecker,
-        BRIGHTNESS_DEFAULT_VALUE,
-    };
+    use super::{run_brightness_with, BrightnessDeps, BrightnessUi, Notifier, ReachabilityChecker};
     use crate::config::{
         Config, HdmiInput, MacAddress, ScreenBackend, ScreenRestorePolicy, SystemSleepWakePolicy,
     };
@@ -445,9 +490,9 @@ mod tests {
     use crate::screen::{run_screen_off_with, run_screen_on_with};
     use crate::state::ScreenOwnershipMarker;
     use crate::state::SystemSleepAttemptState;
-    use crate::tv::BscpylgtvCommandClient;
+    use crate::tv::{BscpylgtvCommandClient, OledBrightness};
     use crate::wol::{WakeOnLanError, WakeOnLanSender};
-    use crate::StartupMode;
+    use crate::{BrightnessCommand, StartupMode};
     use std::cell::RefCell;
     use std::ffi::CString;
     use std::fs;
@@ -1188,8 +1233,13 @@ mod tests {
         };
 
         let mut output = Vec::new();
-        run_brightness_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect("brightness should succeed");
+        run_brightness_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            BrightnessCommand::Prompt,
+            deps,
+        )
+        .expect("brightness should succeed");
 
         assert_eq!(ui.initial_values(), vec![72]);
         assert!(ui.error_messages().is_empty());
@@ -1200,6 +1250,66 @@ mod tests {
         assert_eq!(mock.state_snapshot().backlight, 65);
         assert_call_commands(&mock, &["get_picture_settings", "set_settings"]);
         assert!(rendered(&output).contains("Set OLED pixel brightness to 65%."));
+    }
+
+    #[test]
+    fn brightness_get_prints_current_oled_brightness() {
+        let mock = MockBscpylgtv::new("brightness-get-tv");
+        mock.set_backlight(72);
+        let client = client_for_mock(&mock);
+        let reachability = FakeReachabilityChecker::unreachable();
+        let ui = FakeBrightnessUi::cancelled();
+        let notifier = RecordingNotifier::default();
+        let deps = BrightnessDeps {
+            tv_client: &client,
+            reachability: &reachability,
+            ui: &ui,
+            notifier: &notifier,
+        };
+
+        let mut output = Vec::new();
+        run_brightness_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            BrightnessCommand::Get,
+            deps,
+        )
+        .expect("brightness get should succeed");
+
+        assert_eq!(rendered(&output).trim(), "72");
+        assert!(ui.initial_values().is_empty());
+        assert!(notifier.messages().is_empty());
+        assert_call_commands(&mock, &["get_picture_settings"]);
+    }
+
+    #[test]
+    fn brightness_set_updates_oled_brightness_without_dialog() {
+        let mock = MockBscpylgtv::new("brightness-set-tv");
+        let client = client_for_mock(&mock);
+        let reachability = FakeReachabilityChecker::unreachable();
+        let ui = FakeBrightnessUi::cancelled();
+        let notifier = RecordingNotifier::default();
+        let deps = BrightnessDeps {
+            tv_client: &client,
+            reachability: &reachability,
+            ui: &ui,
+            notifier: &notifier,
+        };
+
+        let mut output = Vec::new();
+        run_brightness_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            BrightnessCommand::Set(OledBrightness::new(61).expect("valid brightness")),
+            deps,
+        )
+        .expect("brightness set should succeed");
+
+        assert_eq!(mock.state_snapshot().backlight, 61);
+        assert!(ui.initial_values().is_empty());
+        assert!(notifier.messages().is_empty());
+        assert_call_commands(&mock, &["set_settings"]);
+        assert!(rendered(&output).contains("Set OLED pixel brightness to 61%."));
     }
 
     #[test]
@@ -1217,8 +1327,13 @@ mod tests {
         };
 
         let mut output = Vec::new();
-        run_brightness_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect("cancel should exit cleanly");
+        run_brightness_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            BrightnessCommand::Prompt,
+            deps,
+        )
+        .expect("cancel should exit cleanly");
 
         assert_eq!(ui.initial_values(), vec![50]);
         assert_call_commands(&mock, &["get_picture_settings"]);
@@ -1241,8 +1356,13 @@ mod tests {
         };
 
         let mut output = Vec::new();
-        let err = run_brightness_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect_err("unreachable tv should fail");
+        let err = run_brightness_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            BrightnessCommand::Prompt,
+            deps,
+        )
+        .expect_err("unreachable tv should fail");
 
         assert!(matches!(err, crate::RunError::Policy(_)));
         assert!(mock.calls().is_empty());
@@ -1272,10 +1392,15 @@ mod tests {
         };
 
         let mut output = Vec::new();
-        run_brightness_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect("fallback to default brightness should still allow cancellation");
+        run_brightness_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            BrightnessCommand::Prompt,
+            deps,
+        )
+        .expect("fallback to default brightness should still allow cancellation");
 
-        assert_eq!(ui.initial_values(), vec![BRIGHTNESS_DEFAULT_VALUE]);
+        assert_eq!(ui.initial_values(), vec![50]);
         assert_call_commands(&mock, &["get_picture_settings"]);
         assert!(notifier.messages().is_empty());
         assert!(rendered(&output).is_empty());
@@ -1297,8 +1422,13 @@ mod tests {
         };
 
         let mut output = Vec::new();
-        let err = run_brightness_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect_err("tv command failure should fail");
+        let err = run_brightness_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            BrightnessCommand::Prompt,
+            deps,
+        )
+        .expect_err("tv command failure should fail");
 
         assert!(matches!(err, crate::RunError::Policy(_)));
         assert_eq!(ui.initial_values(), vec![50]);
@@ -1708,7 +1838,7 @@ mod tests {
     }
 
     struct FakeBrightnessUi {
-        selection: io::Result<Option<u8>>,
+        selection: io::Result<Option<OledBrightness>>,
         initial_values: RefCell<Vec<u8>>,
         error_messages: RefCell<Vec<(String, String)>>,
     }
@@ -1716,7 +1846,9 @@ mod tests {
     impl FakeBrightnessUi {
         fn selected(value: u8) -> Self {
             Self {
-                selection: Ok(Some(value)),
+                selection: Ok(Some(
+                    OledBrightness::new(value).expect("fake brightness value should be valid"),
+                )),
                 initial_values: RefCell::new(Vec::new()),
                 error_messages: RefCell::new(Vec::new()),
             }
@@ -1740,8 +1872,8 @@ mod tests {
     }
 
     impl BrightnessUi for FakeBrightnessUi {
-        fn prompt_brightness(&self, initial: u8) -> io::Result<Option<u8>> {
-            self.initial_values.borrow_mut().push(initial);
+        fn prompt_brightness(&self, initial: OledBrightness) -> io::Result<Option<OledBrightness>> {
+            self.initial_values.borrow_mut().push(initial.as_percent());
             match &self.selection {
                 Ok(value) => Ok(*value),
                 Err(err) => Err(io::Error::new(err.kind(), err.to_string())),

--- a/crates/lg-buddy/src/events.rs
+++ b/crates/lg-buddy/src/events.rs
@@ -93,7 +93,7 @@ impl RuntimeEventKind {
                     machine_sleep_pending: None,
                 })
             }
-            Command::Brightness => Some(Self::BrightnessRequested),
+            Command::Brightness(_) => Some(Self::BrightnessRequested),
             Command::ScreenOff => Some(Self::ScreenBlankRequested),
             Command::ScreenOn => Some(Self::ScreenRestoreRequested),
             Command::Monitor
@@ -143,7 +143,7 @@ mod tests {
             ))
         );
         assert_eq!(
-            RuntimeEvent::from_command(Command::Brightness),
+            RuntimeEvent::from_command(Command::Brightness(crate::BrightnessCommand::Prompt)),
             Some(RuntimeEvent::new(
                 EventSource::CliApi,
                 RuntimeEventKind::BrightnessRequested

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -31,6 +31,7 @@ use crate::config::{ConfigError, ConfigPathError};
 use crate::session::runner::{run_lifecycle_monitor, run_monitor};
 use crate::settings::{run_settings_command, SettingsCommand, SettingsError, SettingsParseError};
 use crate::state::StateDirError;
+use crate::tv::{OledBrightness, OledBrightnessParseError};
 use std::fmt;
 use std::io::{self, Write};
 
@@ -41,13 +42,20 @@ pub enum Command {
     SleepPre,
     Sleep,
     NetworkManagerPreDown,
-    Brightness,
+    Brightness(BrightnessCommand),
     ScreenOff,
     ScreenOn,
     Monitor,
     Lifecycle,
     DetectBackend,
     Settings(SettingsCommand),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrightnessCommand {
+    Prompt,
+    Get,
+    Set(OledBrightness),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,6 +94,9 @@ pub enum ParseOutcome {
 pub enum ParseError {
     UnknownCommand(String),
     UnknownStartupMode(String),
+    UnknownBrightnessCommand(String),
+    MissingBrightnessValue,
+    InvalidBrightnessValue(OledBrightnessParseError),
     Settings(SettingsParseError),
     UnexpectedArguments {
         command: Command,
@@ -102,6 +113,13 @@ impl fmt::Display for ParseError {
             Self::UnknownStartupMode(mode) => {
                 write!(f, "unknown startup mode `{mode}`")
             }
+            Self::UnknownBrightnessCommand(command) => {
+                write!(f, "unknown brightness command `{command}`")
+            }
+            Self::MissingBrightnessValue => {
+                write!(f, "missing brightness value for `brightness set`")
+            }
+            Self::InvalidBrightnessValue(err) => write!(f, "{err}"),
             Self::Settings(err) => write!(f, "{err}"),
             Self::UnexpectedArguments { command, arguments } => {
                 write!(
@@ -174,7 +192,7 @@ impl Command {
             Self::SleepPre => "sleep-pre",
             Self::Sleep => "sleep",
             Self::NetworkManagerPreDown => "nm-pre-down",
-            Self::Brightness => "brightness",
+            Self::Brightness(_) => "brightness",
             Self::ScreenOff => "screen-off",
             Self::ScreenOn => "screen-on",
             Self::Monitor => "monitor",
@@ -191,7 +209,7 @@ impl Command {
             Self::SleepPre => "TODO: implemented via command handler",
             Self::Sleep => "TODO: implemented via command handler",
             Self::NetworkManagerPreDown => "TODO: implemented via command handler",
-            Self::Brightness => "TODO: implemented via command handler",
+            Self::Brightness(_) => "TODO: implemented via command handler",
             Self::ScreenOff => "TODO: implemented via command handler",
             Self::ScreenOn => "TODO: implemented via command handler",
             Self::Monitor => "TODO: implemented via command handler",
@@ -218,6 +236,9 @@ Commands:
   sleep           Handle the NetworkManager pre-down sleep hook
   nm-pre-down     Handle NetworkManager pre-down system sleep gate
   brightness      Open the TV brightness control dialog
+  brightness get  Print the current TV OLED brightness
+  brightness set <0-100>
+                  Set the TV OLED brightness
   screen-off      Blank the configured TV output if active
   screen-on       Restore the TV output after an LG Buddy screen-off
   monitor         Run the user-session monitor loop
@@ -281,11 +302,11 @@ where
                 .map(|command| ParseOutcome::Command(Command::Settings(command)))
                 .map_err(ParseError::Settings);
         }
+        "brightness" => return parse_brightness_command(args),
         "shutdown" => Command::Shutdown,
         "sleep-pre" => Command::SleepPre,
         "sleep" => Command::Sleep,
         "nm-pre-down" => Command::NetworkManagerPreDown,
-        "brightness" => Command::Brightness,
         "screen-off" => Command::ScreenOff,
         "screen-on" => Command::ScreenOn,
         "monitor" => Command::Monitor,
@@ -312,7 +333,7 @@ pub fn run_command<W: Write>(command: Command, writer: &mut W) -> Result<(), Run
         Command::SleepPre => run_sleep_pre(writer),
         Command::Sleep => run_sleep(writer),
         Command::NetworkManagerPreDown => run_nm_pre_down(writer),
-        Command::Brightness => run_brightness(writer),
+        Command::Brightness(command) => run_brightness(writer, command),
         Command::DetectBackend => run_detect_backend(writer),
         Command::ScreenOff => run_screen_off(writer),
         Command::ScreenOn => run_screen_on(writer),
@@ -321,6 +342,51 @@ pub fn run_command<W: Write>(command: Command, writer: &mut W) -> Result<(), Run
         Command::Settings(command) => {
             run_settings_command(command, writer).map_err(RunError::Settings)
         }
+    }
+}
+
+fn parse_brightness_command<I, S>(args: I) -> Result<ParseOutcome, ParseError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut args = args.into_iter();
+    let Some(subcommand) = args.next() else {
+        return Ok(ParseOutcome::Command(Command::Brightness(
+            BrightnessCommand::Prompt,
+        )));
+    };
+
+    match subcommand.as_ref() {
+        "get" => {
+            let extra_args: Vec<String> = args.map(|arg| arg.as_ref().to_string()).collect();
+            if extra_args.is_empty() {
+                Ok(ParseOutcome::Command(Command::Brightness(
+                    BrightnessCommand::Get,
+                )))
+            } else {
+                Err(ParseError::UnexpectedArguments {
+                    command: Command::Brightness(BrightnessCommand::Get),
+                    arguments: extra_args,
+                })
+            }
+        }
+        "set" => {
+            let value = args.next().ok_or(ParseError::MissingBrightnessValue)?;
+            let brightness = OledBrightness::parse(value.as_ref())
+                .map_err(ParseError::InvalidBrightnessValue)?;
+            let extra_args: Vec<String> = args.map(|arg| arg.as_ref().to_string()).collect();
+            let command = BrightnessCommand::Set(brightness);
+            if extra_args.is_empty() {
+                Ok(ParseOutcome::Command(Command::Brightness(command)))
+            } else {
+                Err(ParseError::UnexpectedArguments {
+                    command: Command::Brightness(command),
+                    arguments: extra_args,
+                })
+            }
+        }
+        other => Err(ParseError::UnknownBrightnessCommand(other.to_string())),
     }
 }
 
@@ -334,8 +400,11 @@ fn run_detect_backend<W: Write>(writer: &mut W) -> Result<(), RunError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_args, usage, Command, ParseError, ParseOutcome, StartupMode};
+    use super::{
+        parse_args, usage, BrightnessCommand, Command, ParseError, ParseOutcome, StartupMode,
+    };
     use crate::settings::{SettingsCommand, SettingsParseError};
+    use crate::tv::OledBrightness;
 
     #[test]
     fn no_args_prints_help() {
@@ -381,7 +450,21 @@ mod tests {
         );
         assert_eq!(
             parse_args(["brightness"]),
-            Ok(ParseOutcome::Command(Command::Brightness))
+            Ok(ParseOutcome::Command(Command::Brightness(
+                BrightnessCommand::Prompt
+            )))
+        );
+        assert_eq!(
+            parse_args(["brightness", "get"]),
+            Ok(ParseOutcome::Command(Command::Brightness(
+                BrightnessCommand::Get
+            )))
+        );
+        assert_eq!(
+            parse_args(["brightness", "set", "65"]),
+            Ok(ParseOutcome::Command(Command::Brightness(
+                BrightnessCommand::Set(brightness(65))
+            )))
         );
         assert_eq!(
             parse_args(["screen-off"]),
@@ -472,6 +555,33 @@ mod tests {
     }
 
     #[test]
+    fn invalid_brightness_command_is_rejected() {
+        assert_eq!(
+            parse_args(["brightness", "show"]),
+            Err(ParseError::UnknownBrightnessCommand("show".to_string()))
+        );
+        assert_eq!(
+            parse_args(["brightness", "set"]),
+            Err(ParseError::MissingBrightnessValue)
+        );
+        assert!(matches!(
+            parse_args(["brightness", "set", "101"]),
+            Err(ParseError::InvalidBrightnessValue(_))
+        ));
+        assert!(matches!(
+            parse_args(["brightness", "set", "abc"]),
+            Err(ParseError::InvalidBrightnessValue(_))
+        ));
+        assert_eq!(
+            parse_args(["brightness", "get", "extra"]),
+            Err(ParseError::UnexpectedArguments {
+                command: Command::Brightness(BrightnessCommand::Get),
+                arguments: vec!["extra".to_string()],
+            })
+        );
+    }
+
+    #[test]
     fn invalid_settings_command_is_rejected() {
         assert_eq!(
             parse_args(["settings"]),
@@ -532,6 +642,10 @@ mod tests {
     fn usage_mentions_settings_commands_without_reserved_notice() {
         let help = usage("lg-buddy");
 
+        for command in ["brightness get", "brightness set <0-100>"] {
+            assert!(help.contains(command), "missing `{command}` from help");
+        }
+
         for command in [
             "settings list",
             "settings describe [key]",
@@ -542,5 +656,9 @@ mod tests {
             assert!(help.contains(command), "missing `{command}` from help");
         }
         assert!(!help.contains("Reserved for write support"));
+    }
+
+    fn brightness(value: u8) -> OledBrightness {
+        OledBrightness::new(value).expect("test brightness should be valid")
     }
 }

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -15,6 +15,8 @@ use crate::config::{HdmiInput, MacAddress};
 use crate::wol::{WakeOnLanError, WakeOnLanSender};
 
 pub const DEFAULT_BSCPYLGTV_COMMAND_PATH: &str = "/usr/bin/LG_Buddy_PIP/bin/bscpylgtvcommand";
+pub const OLED_BRIGHTNESS_MIN: u8 = 0;
+pub const OLED_BRIGHTNESS_MAX: u8 = 100;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandOutput {
@@ -126,14 +128,76 @@ impl TvError {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OledBrightnessParseError {
+    value: String,
+}
+
+impl OledBrightnessParseError {
+    fn new(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
+}
+
+impl fmt::Display for OledBrightnessParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid OLED brightness `{}`; expected an integer from {} to {}",
+            self.value, OLED_BRIGHTNESS_MIN, OLED_BRIGHTNESS_MAX
+        )
+    }
+}
+
+impl Error for OledBrightnessParseError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OledBrightness(u8);
+
+impl OledBrightness {
+    pub const DEFAULT: Self = Self(50);
+
+    pub fn new(value: u8) -> Result<Self, OledBrightnessParseError> {
+        if value <= OLED_BRIGHTNESS_MAX {
+            Ok(Self(value))
+        } else {
+            Err(OledBrightnessParseError::new(value.to_string()))
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, OledBrightnessParseError> {
+        match value.parse::<i64>() {
+            Ok(parsed)
+                if parsed >= i64::from(OLED_BRIGHTNESS_MIN)
+                    && parsed <= i64::from(OLED_BRIGHTNESS_MAX) =>
+            {
+                Ok(Self(parsed as u8))
+            }
+            _ => Err(OledBrightnessParseError::new(value)),
+        }
+    }
+
+    pub fn as_percent(self) -> u8 {
+        self.0
+    }
+}
+
+impl fmt::Display for OledBrightness {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 pub trait TvClient {
     fn get_input(&self, tv_ip: Ipv4Addr) -> Result<String, TvError>;
-    fn get_oled_brightness(&self, tv_ip: Ipv4Addr) -> Result<u8, TvError>;
+    fn get_oled_brightness(&self, tv_ip: Ipv4Addr) -> Result<OledBrightness, TvError>;
     fn set_input(&self, tv_ip: Ipv4Addr, input: HdmiInput) -> Result<CommandOutput, TvError>;
     fn set_oled_brightness(
         &self,
         tv_ip: Ipv4Addr,
-        brightness: u8,
+        brightness: OledBrightness,
     ) -> Result<CommandOutput, TvError>;
     fn power_off(&self, tv_ip: Ipv4Addr) -> Result<CommandOutput, TvError>;
     fn turn_screen_off(&self, tv_ip: Ipv4Addr) -> Result<CommandOutput, TvError>;
@@ -251,11 +315,14 @@ pub struct TvPicture<'a, C> {
 }
 
 impl<'a, C: TvClient> TvPicture<'a, C> {
-    pub fn oled_brightness(&self) -> Result<u8, TvError> {
+    pub fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
         self.client.get_oled_brightness(self.tv_ip)
     }
 
-    pub fn set_oled_brightness(&self, brightness: u8) -> Result<CommandOutput, TvError> {
+    pub fn set_oled_brightness(
+        &self,
+        brightness: OledBrightness,
+    ) -> Result<CommandOutput, TvError> {
         self.client.set_oled_brightness(self.tv_ip, brightness)
     }
 }
@@ -687,7 +754,7 @@ impl<L: BscpylgtvCommandLauncher> TvClient for BscpylgtvCommandClient<L> {
         })
     }
 
-    fn get_oled_brightness(&self, tv_ip: Ipv4Addr) -> Result<u8, TvError> {
+    fn get_oled_brightness(&self, tv_ip: Ipv4Addr) -> Result<OledBrightness, TvError> {
         let output = self.run_command(tv_ip, "get_picture_settings", &[])?;
         parse_backlight(output.stdout()).ok_or(TvError::InvalidOutput {
             command: "get_picture_settings",
@@ -703,7 +770,7 @@ impl<L: BscpylgtvCommandLauncher> TvClient for BscpylgtvCommandClient<L> {
     fn set_oled_brightness(
         &self,
         tv_ip: Ipv4Addr,
-        brightness: u8,
+        brightness: OledBrightness,
     ) -> Result<CommandOutput, TvError> {
         let backlight = format!("{{\"backlight\": {brightness}}}");
         self.run_command(tv_ip, "set_settings", &["picture", backlight.as_str()])
@@ -730,7 +797,7 @@ fn last_non_empty_line(output: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn parse_backlight(output: &str) -> Option<u8> {
+fn parse_backlight(output: &str) -> Option<OledBrightness> {
     for token in output.split([',', '{', '}', '\n']) {
         let token = token.trim();
         if !(token.starts_with("'backlight'") || token.starts_with("\"backlight\"")) {
@@ -745,7 +812,7 @@ fn parse_backlight(output: &str) -> Option<u8> {
             .parse::<u16>()
             .ok()?;
         if parsed <= 100 {
-            return Some(parsed as u8);
+            return Some(OledBrightness(parsed as u8));
         }
     }
 
@@ -761,8 +828,8 @@ mod tests {
     use super::{
         build_user_scoped_launch_plan, current_euid, BscpylgtvCommandClient,
         BscpylgtvCommandLauncher, BscpylgtvInvocation, BscpylgtvLaunchResult, CommandOutput,
-        CurrentInput, TvClient, TvDevice, TvError, UserScopedBscpylgtvCommandLauncher,
-        UserScopedLaunchPlan, DEFAULT_BSCPYLGTV_COMMAND_PATH,
+        CurrentInput, OledBrightness, TvClient, TvDevice, TvError,
+        UserScopedBscpylgtvCommandLauncher, UserScopedLaunchPlan, DEFAULT_BSCPYLGTV_COMMAND_PATH,
     };
     use crate::auth::{BscpylgtvAuthContext, SystemUser};
     use crate::config::{HdmiInput, MacAddress};
@@ -774,6 +841,29 @@ mod tests {
     use std::rc::Rc;
     use std::time::Duration;
     use support::{ExecutableScript, MockBscpylgtv};
+
+    #[test]
+    fn oled_brightness_accepts_boundary_values() {
+        let minimum = OledBrightness::parse("0").expect("minimum brightness should parse");
+        let maximum = OledBrightness::parse("100").expect("maximum brightness should parse");
+
+        assert_eq!(minimum.as_percent(), 0);
+        assert_eq!(maximum.as_percent(), 100);
+        assert_eq!(minimum.to_string(), "0");
+        assert_eq!(OledBrightness::DEFAULT.as_percent(), 50);
+    }
+
+    #[test]
+    fn oled_brightness_rejects_invalid_values() {
+        for value in ["-1", "101", "abc", "50.5"] {
+            let err = OledBrightness::parse(value).expect_err("invalid brightness should fail");
+            assert!(err
+                .to_string()
+                .contains("expected an integer from 0 to 100"));
+        }
+
+        assert!(OledBrightness::new(101).is_err());
+    }
 
     #[test]
     fn default_client_uses_expected_command_path() {
@@ -863,7 +953,7 @@ mod tests {
         let mock = MockBscpylgtv::new("tv-set-brightness");
         let client = client_for_mock(&mock);
         client
-            .set_oled_brightness(ip("10.0.0.5"), 65)
+            .set_oled_brightness(ip("10.0.0.5"), brightness(65))
             .expect("set_oled_brightness should succeed");
 
         assert_eq!(
@@ -890,7 +980,7 @@ mod tests {
             .get_oled_brightness(ip("10.0.0.5"))
             .expect("get_oled_brightness should succeed");
 
-        assert_eq!(brightness, 72);
+        assert_eq!(brightness.as_percent(), 72);
         assert_eq!(
             mock.calls()
                 .into_iter()
@@ -978,7 +1068,7 @@ mod tests {
         let client = client_for_mock(&mock);
         let tv = TvDevice::new(&client, ip("10.0.0.12"));
         tv.picture()
-            .set_oled_brightness(40)
+            .set_oled_brightness(brightness(40))
             .expect("brightness set should succeed");
 
         assert_eq!(
@@ -1006,7 +1096,7 @@ mod tests {
             .oled_brightness()
             .expect("brightness read should succeed");
 
-        assert_eq!(brightness, 33);
+        assert_eq!(brightness.as_percent(), 33);
         assert_eq!(
             mock.calls()
                 .into_iter()
@@ -1357,6 +1447,10 @@ mod tests {
 
     fn ip(value: &str) -> Ipv4Addr {
         value.parse().expect("parse IPv4 address")
+    }
+
+    fn brightness(value: u8) -> OledBrightness {
+        OledBrightness::new(value).expect("test brightness should be valid")
     }
 
     fn parse_mac(value: &str) -> MacAddress {

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -809,11 +809,9 @@ fn parse_backlight(output: &str) -> Option<OledBrightness> {
             .trim()
             .trim_matches('\'')
             .trim_matches('"')
-            .parse::<u16>()
+            .parse::<u8>()
             .ok()?;
-        if parsed <= 100 {
-            return Some(OledBrightness(parsed as u8));
-        }
+        return OledBrightness::new(parsed).ok();
     }
 
     None

--- a/crates/lg-buddy/tests/features/brightness.feature
+++ b/crates/lg-buddy/tests/features/brightness.feature
@@ -26,6 +26,37 @@ Feature: Brightness
     And the TV client did not receive "set_settings"
     And the TV brightness is 44
 
+  Scenario: Brightness get prints the current OLED brightness
+    Given a temporary LG Buddy config using input HDMI_2
+    And a mock TV client
+    And the TV backlight is 58
+    When I run the command "brightness get"
+    Then the command succeeds
+    And stdout is "58"
+    And the TV client received "get_picture_settings"
+    And the TV client did not receive "set_settings"
+
+  Scenario: Brightness set updates OLED brightness without opening a dialog
+    Given a temporary LG Buddy config using input HDMI_2
+    And a mock TV client
+    And the TV backlight is 44
+    When I run the command "brightness set 66"
+    Then the command succeeds
+    And stdout contains "Set OLED pixel brightness to 66%."
+    And the TV client received "set_settings"
+    And the TV brightness is 66
+
+  Scenario: Brightness set rejects invalid values before touching the TV
+    Given a temporary LG Buddy config using input HDMI_2
+    And a mock TV client
+    And the TV backlight is 44
+    When I run the command "brightness set 101"
+    Then the command fails
+    And stderr contains "invalid OLED brightness"
+    And the TV client did not receive "get_picture_settings"
+    And the TV client did not receive "set_settings"
+    And the TV brightness is 44
+
   Scenario: Brightness fails when the TV is unreachable
     Given a temporary LG Buddy config using input HDMI_2
     And a mock TV client

--- a/crates/lg-buddy/tests/mock_bscpylgtvcommand.rs
+++ b/crates/lg-buddy/tests/mock_bscpylgtvcommand.rs
@@ -1,7 +1,7 @@
 mod support;
 
 use lg_buddy::config::HdmiInput;
-use lg_buddy::tv::{BscpylgtvCommandClient, TvClient, TvError};
+use lg_buddy::tv::{BscpylgtvCommandClient, OledBrightness, TvClient, TvError};
 use std::net::Ipv4Addr;
 use support::MockBscpylgtv;
 
@@ -57,7 +57,7 @@ fn mock_set_settings_updates_backlight() {
     let client = mock_client(&mock);
 
     let output = client
-        .set_oled_brightness(ip("10.0.0.39"), 70)
+        .set_oled_brightness(ip("10.0.0.39"), brightness(70))
         .expect("mock set_oled_brightness should succeed");
 
     assert_eq!(output.stdout(), "{'returnValue': True}\n");
@@ -74,7 +74,7 @@ fn mock_get_picture_settings_includes_backlight() {
         .get_oled_brightness(ip("10.0.0.39"))
         .expect("mock get_oled_brightness should succeed");
 
-    assert_eq!(brightness, 62);
+    assert_eq!(brightness.as_percent(), 62);
 }
 
 #[test]
@@ -180,4 +180,8 @@ fn mock_client(mock: &MockBscpylgtv) -> BscpylgtvCommandClient {
 
 fn ip(value: &str) -> Ipv4Addr {
     value.parse().expect("parse IPv4 address")
+}
+
+fn brightness(value: u8) -> OledBrightness {
+    OledBrightness::new(value).expect("test brightness should be valid")
 }

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -290,8 +290,10 @@ The binary currently supports these commands:
 the runtime command handlers in `commands.rs` and `session/runner.rs`.
 `commands.rs` then delegates screen and lifecycle decisions to their domain
 modules and delegates platform ingestion to `sources/`.
-The brightness command uses the TV picture abstraction in `tv.rs` for typed
-OLED brightness validation and live TV read/write operations.
+The `brightness get` and `brightness set` commands use the TV picture
+abstraction in `tv.rs` for typed OLED brightness validation and live TV
+read/write operations. The interactive brightness dialog delegates its TV
+operations back through those CLI commands.
 
 This keeps CLI parsing separate from operational behavior.
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -49,9 +49,19 @@ main.rs
 
 ## System Diagram
 
-The current runtime can be visualized as desktop and system event paths into the
-Rust runtime, and then one control path from policy code into the TV transport
+The current runtime can be visualized as several consumer paths into the Rust
+runtime, and then one control path from policy code into the TV transport
 boundary.
+
+The main runtime consumers are:
+
+- system lifecycle and service integrations, including systemd,
+  NetworkManager, and logind
+- desktop environment and session integrations, including GNOME, `swayidle`,
+  and Linux input activity sources
+- TTY users invoking the CLI directly
+- frontend surfaces, currently the zenity brightness dialog, which delegate
+  back through the CLI/API command surface
 
 ```mermaid
 flowchart LR
@@ -64,6 +74,14 @@ flowchart LR
     subgraph SystemLifecycle["System Lifecycle"]
         LOGIND["logind system bus<br/>PrepareForSleep"]
         NM["NetworkManager dispatcher<br/>pre-down"]
+    end
+
+    subgraph TTY["TTY / CLI"]
+        TERMINAL["terminal commands<br/>settings / brightness / manual actions"]
+    end
+
+    subgraph Frontend["Frontend"]
+        ZENITY["zenity brightness dialog<br/>interactive prompt"]
     end
 
     subgraph Rust["Rust Runtime"]
@@ -117,6 +135,8 @@ flowchart LR
     BUS --> LOGINDADAPTER
     LOGINDADAPTER -->|"RuntimeEvent"| EVENTS
     NM --> MAIN
+    TERMINAL --> MAIN
+    ZENITY --> MAIN
     MAIN --> COMMANDS
     COMMANDS --> EVENTS
     COMMANDS --> NMGATE

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -277,16 +277,21 @@ The binary currently supports these commands:
 - `sleep`
 - `nm-pre-down`
 - `brightness`
+- `brightness get`
+- `brightness set <0-100>`
 - `screen-off`
 - `screen-on`
 - `monitor`
 - `lifecycle`
 - `detect-backend`
+- `settings`
 
 `lib.rs` parses the command line into a typed command enum and dispatches into
 the runtime command handlers in `commands.rs` and `session/runner.rs`.
 `commands.rs` then delegates screen and lifecycle decisions to their domain
 modules and delegates platform ingestion to `sources/`.
+The brightness command uses the TV picture abstraction in `tv.rs` for typed
+OLED brightness validation and live TV read/write operations.
 
 This keeps CLI parsing separate from operational behavior.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -18,6 +18,8 @@ Available commands:
 - `sleep`
 - `nm-pre-down`
 - `brightness`
+- `brightness get`
+- `brightness set <0-100>`
 - `screen-off`
 - `screen-on`
 - `monitor`
@@ -32,10 +34,15 @@ lg-buddy detect-backend
 lg-buddy settings list
 lg-buddy monitor
 lg-buddy brightness
+lg-buddy brightness get
+lg-buddy brightness set 65
 ```
 
 In normal use, systemd starts the relevant commands automatically. Most users
 only need `brightness`, `settings`, or `configure.sh`.
+
+`brightness` opens the desktop brightness dialog. `brightness get` prints the
+current TV OLED brightness, and `brightness set <0-100>` updates it directly.
 
 `lifecycle`, `nm-pre-down`, `sleep-pre`, and `startup wake` are normally
 service-owned system lifecycle commands. They are documented for


### PR DESCRIPTION
## Summary
- add `lg-buddy brightness get` and `lg-buddy brightness set <0-100>` as the canonical CLI brightness control surface
- route the zenity brightness dialog through those CLI commands
- document TTY and frontend runtime consumers in the architecture overview

## Tests
- `cargo test -p lg-buddy`
- `cargo test -p lg-buddy --test cucumber`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `git diff --check`