### PR TITLE
Add runtime version surface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,9 @@ jobs:
           echo "LG_BUDDY_RELEASE_VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Build lg-buddy
-        run: cargo build --release -p lg-buddy --target x86_64-unknown-linux-musl
+        env:
+          LG_BUDDY_BUILD_COMMIT: ${{ github.sha }}
+        run: LG_BUDDY_RELEASE_VERSION="$LG_BUDDY_RELEASE_VERSION" cargo build --release -p lg-buddy --target x86_64-unknown-linux-musl
 
       - name: Create release bundle
         run: ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version "$LG_BUDDY_RELEASE_VERSION" --output-dir dist

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ LG Buddy is mostly automatic after installation.
 - To change supported settings, use `lg-buddy settings set <key> <value>`
 - To inspect TV brightness, run `lg-buddy brightness get`
 - To set TV brightness directly, run `lg-buddy brightness set <0-100>`
+- To inspect the installed runtime version, run `lg-buddy --version`
 - To rerun full setup for TV IP, MAC address, or HDMI input, run `./configure.sh`
 - To check the screen monitor, run `systemctl --user status LG_Buddy_screen.service`
 - To remove LG Buddy, run `./uninstall.sh`

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -13,6 +13,7 @@ pub mod settings;
 pub mod sources;
 pub mod state;
 pub mod tv;
+pub mod version;
 pub mod wol;
 
 pub use sources::desktop::{gnome, swayidle};
@@ -87,6 +88,7 @@ impl StartupMode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseOutcome {
     Help,
+    Version,
     Command(Command),
 }
 
@@ -228,6 +230,7 @@ LG Buddy Rust runtime
 Usage:
   {program} <command>
   {program} --help
+  {program} --version, -V
 
 Commands:
   startup [mode]  Start or restore the TV output
@@ -274,6 +277,9 @@ where
     let first = first.as_ref();
     if matches!(first, "-h" | "--help" | "help") {
         return Ok(ParseOutcome::Help);
+    }
+    if matches!(first, "-V" | "--version") {
+        return Ok(ParseOutcome::Version);
     }
 
     let command = match first {
@@ -416,6 +422,12 @@ mod tests {
         assert_eq!(parse_args(["--help"]), Ok(ParseOutcome::Help));
         assert_eq!(parse_args(["-h"]), Ok(ParseOutcome::Help));
         assert_eq!(parse_args(["help"]), Ok(ParseOutcome::Help));
+    }
+
+    #[test]
+    fn explicit_version_prints_version() {
+        assert_eq!(parse_args(["--version"]), Ok(ParseOutcome::Version));
+        assert_eq!(parse_args(["-V"]), Ok(ParseOutcome::Version));
     }
 
     #[test]
@@ -647,6 +659,7 @@ mod tests {
         }
 
         for command in [
+            "--version, -V",
             "settings list",
             "settings describe [key]",
             "settings get <key>",

--- a/crates/lg-buddy/src/main.rs
+++ b/crates/lg-buddy/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::process::ExitCode;
 
-use lg_buddy::{parse_args, run_command, usage, ParseOutcome};
+use lg_buddy::{parse_args, run_command, usage, version, ParseOutcome};
 
 fn main() -> ExitCode {
     let program = env::args().next().unwrap_or_else(|| "lg-buddy".to_string());
@@ -9,6 +9,10 @@ fn main() -> ExitCode {
     match parse_args(env::args().skip(1)) {
         Ok(ParseOutcome::Help) => {
             print!("{}", usage(&program));
+            ExitCode::SUCCESS
+        }
+        Ok(ParseOutcome::Version) => {
+            print!("{}", version::version_text());
             ExitCode::SUCCESS
         }
         Ok(ParseOutcome::Command(command)) => match run_command(command, &mut std::io::stdout()) {

--- a/crates/lg-buddy/src/version.rs
+++ b/crates/lg-buddy/src/version.rs
@@ -1,0 +1,166 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VersionInfo {
+    version: &'static str,
+    channel: ReleaseChannel,
+    commit: Option<&'static str>,
+}
+
+impl VersionInfo {
+    pub fn current() -> Self {
+        let release_version = non_empty(option_env!("LG_BUDDY_RELEASE_VERSION"));
+
+        Self {
+            version: release_version.unwrap_or(env!("CARGO_PKG_VERSION")),
+            channel: ReleaseChannel::from_release_version(release_version),
+            commit: option_env!("LG_BUDDY_BUILD_COMMIT"),
+        }
+    }
+
+    pub fn version(self) -> &'static str {
+        self.version
+    }
+
+    pub fn commit(self) -> Option<&'static str> {
+        non_empty(self.commit)
+    }
+
+    pub fn channel(self) -> ReleaseChannel {
+        self.channel
+    }
+
+    pub fn is_release_build(self) -> bool {
+        self.channel() != ReleaseChannel::Dev
+    }
+
+    pub fn render(self) -> String {
+        format!(
+            "lg-buddy {}\nversion: {}\nchannel: {}\ncommit: {}\n",
+            self.version(),
+            self.version(),
+            self.channel().as_str(),
+            self.commit().unwrap_or("unknown")
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseChannel {
+    Dev,
+    Prerelease,
+    Stable,
+}
+
+impl ReleaseChannel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Dev => "dev",
+            Self::Prerelease => "prerelease",
+            Self::Stable => "stable",
+        }
+    }
+
+    fn from_release_version(version: Option<&str>) -> Self {
+        match version {
+            None => Self::Dev,
+            Some(version) if is_prerelease_version(version) => Self::Prerelease,
+            Some(_) => Self::Stable,
+        }
+    }
+}
+
+pub fn version_text() -> String {
+    VersionInfo::current().render()
+}
+
+fn non_empty(value: Option<&'static str>) -> Option<&'static str> {
+    value.and_then(|value| {
+        let value = value.trim();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    })
+}
+
+fn is_prerelease_version(version: &str) -> bool {
+    version.contains('-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{version_text, ReleaseChannel, VersionInfo};
+
+    #[test]
+    fn dev_version_output_reports_package_version_channel_and_unknown_commit() {
+        let info = VersionInfo {
+            version: "1.1.0",
+            channel: ReleaseChannel::Dev,
+            commit: None,
+        };
+
+        assert_eq!(
+            info.render(),
+            "lg-buddy 1.1.0\nversion: 1.1.0\nchannel: dev\ncommit: unknown\n"
+        );
+        assert!(!info.is_release_build());
+    }
+
+    #[test]
+    fn stable_release_output_reports_version_channel_and_commit() {
+        let info = VersionInfo {
+            version: "1.1.0",
+            channel: ReleaseChannel::Stable,
+            commit: Some("7f1fb0c"),
+        };
+
+        assert_eq!(
+            info.render(),
+            "lg-buddy 1.1.0\nversion: 1.1.0\nchannel: stable\ncommit: 7f1fb0c\n"
+        );
+        assert!(info.is_release_build());
+    }
+
+    #[test]
+    fn prerelease_channel_is_derived_from_release_version_suffix() {
+        assert_eq!(
+            ReleaseChannel::from_release_version(Some("1.1.0-beta.1")),
+            ReleaseChannel::Prerelease
+        );
+    }
+
+    #[test]
+    fn commit_metadata_is_trimmed_and_blank_commit_metadata_is_treated_as_absent() {
+        let info = VersionInfo {
+            version: "1.1.0",
+            channel: ReleaseChannel::Stable,
+            commit: Some("  7f1fb0c  "),
+        };
+
+        assert_eq!(
+            info.render(),
+            "lg-buddy 1.1.0\nversion: 1.1.0\nchannel: stable\ncommit: 7f1fb0c\n"
+        );
+
+        let info = VersionInfo {
+            version: "1.1.0",
+            channel: ReleaseChannel::Stable,
+            commit: Some(""),
+        };
+
+        assert_eq!(
+            info.render(),
+            "lg-buddy 1.1.0\nversion: 1.1.0\nchannel: stable\ncommit: unknown\n"
+        );
+    }
+
+    #[test]
+    fn current_version_output_mentions_package_version() {
+        let output = version_text();
+
+        assert!(output.starts_with(&format!("lg-buddy {}\n", env!("CARGO_PKG_VERSION"))));
+        assert!(output.contains("version: "));
+        assert!(output.contains("channel: "));
+        assert!(output.contains("commit: "));
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,16 @@ Build the runtime from source with:
 cargo build --release -p lg-buddy
 ```
 
+Official release builds inject version identity into the binary:
+
+```bash
+LG_BUDDY_RELEASE_VERSION=1.1.0 LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
+```
+
+Without those environment variables, `lg-buddy --version` reports the Cargo
+package version with `channel: dev` and `commit: unknown`.
+Supported channel values are `dev`, `prerelease`, and `stable`.
+
 The resulting binary will be at:
 
 ```text

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,6 +36,7 @@ lg-buddy monitor
 lg-buddy brightness
 lg-buddy brightness get
 lg-buddy brightness set 65
+lg-buddy --version
 ```
 
 In normal use, systemd starts the relevant commands automatically. Most users
@@ -43,6 +44,8 @@ only need `brightness`, `settings`, or `configure.sh`.
 
 `brightness` opens the desktop brightness dialog. `brightness get` prints the
 current TV OLED brightness, and `brightness set <0-100>` updates it directly.
+`--version` prints the installed runtime version, release channel, and commit
+metadata when the binary was built as an official release artifact.
 
 `lifecycle`, `nm-pre-down`, `sleep-pre`, and `startup wake` are normally
 service-owned system lifecycle commands. They are documented for

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -124,6 +124,12 @@ printf '%s\n' "$HELP_OUTPUT" | grep -q "lg-buddy"
 printf '%s\n' "$HELP_OUTPUT" | grep -q "settings list"
 printf '%s\n' "$HELP_OUTPUT" | grep -q "settings set <key> <value>"
 
+VERSION_OUTPUT="$("$BUNDLE_DIR/lg-buddy" --version)"
+printf '%s\n' "$VERSION_OUTPUT" | grep -q "^lg-buddy "
+printf '%s\n' "$VERSION_OUTPUT" | grep -q "^version: "
+printf '%s\n' "$VERSION_OUTPUT" | grep -q "^channel: "
+printf '%s\n' "$VERSION_OUTPUT" | grep -q "^commit: "
+
 export HOME="$HOME_DIR"
 export XDG_CONFIG_HOME="$XDG_CONFIG_HOME"
 export LG_BUDDY_INSTALL_ROOT="$INSTALL_ROOT"
@@ -208,6 +214,12 @@ INSTALLED_HELP_OUTPUT="$("$INSTALLED_BINARY" 2>&1 || true)"
 printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "lg-buddy"
 printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "settings list"
 printf '%s\n' "$INSTALLED_HELP_OUTPUT" | grep -q "settings set <key> <value>"
+
+INSTALLED_VERSION_OUTPUT="$("$INSTALLED_BINARY" --version)"
+printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^lg-buddy "
+printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^version: "
+printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^channel: "
+printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^commit: "
 
 "$INSTALLED_BINARY" settings set screen.backend gnome
 "$INSTALLED_BINARY" settings set screen.idle_timeout 900


### PR DESCRIPTION
## Summary
- add `lg-buddy --version` / `-V`
- report version, channel (`dev`, `prerelease`, `stable`), and commit metadata
- inject release version and commit metadata in the tagged release workflow
- cover the version command in docs and release-bundle smoke checks

## Tests
- `cargo test -p lg-buddy --lib`
- `cargo test -p lg-buddy --lib version`
- `cargo test -p lg-buddy --lib explicit_version_prints_version`
- `cargo run -q -p lg-buddy -- --version`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh`
- `git diff --check`