### PR TITLE
Add conditional caching for update checks

### DIFF
--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -1,10 +1,13 @@
 use std::error::Error;
 use std::fmt;
-use std::io;
-use std::time::Duration;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use semver::Version;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::notifications::{FreedesktopNotifier, Notification, NotificationError, Notifier};
 use crate::version::{ReleaseChannel, VersionInfo};
@@ -16,6 +19,8 @@ const GITHUB_ACCEPT: &str = "application/vnd.github+json";
 const GITHUB_CONNECT_TIMEOUT_SECONDS: u64 = 5;
 const GITHUB_REQUEST_TIMEOUT_SECONDS: u64 = 20;
 const PRERELEASE_PAGE_SIZE: u8 = 20;
+const CACHE_DIR_NAME: &str = "lg-buddy";
+const UPDATE_CHECK_CACHE_FILE_NAME: &str = "update-check.json";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UpdatesCommand {
@@ -140,7 +145,8 @@ impl fmt::Display for UpdatesParseError {
 
 impl Error for UpdatesParseError {}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum UpdateChannel {
     Stable,
     Prerelease,
@@ -170,6 +176,63 @@ impl UpdateChannel {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct UpdateCachePathSources<'a> {
+    xdg_cache_home: Option<&'a Path>,
+    home: Option<&'a Path>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateCachePathError {
+    NotConfigured,
+}
+
+impl fmt::Display for UpdateCachePathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotConfigured => write!(
+                f,
+                "could not resolve an update cache path from XDG_CACHE_HOME or HOME"
+            ),
+        }
+    }
+}
+
+impl Error for UpdateCachePathError {}
+
+fn resolve_update_cache_path(
+    sources: UpdateCachePathSources<'_>,
+) -> Result<PathBuf, UpdateCachePathError> {
+    if let Some(path) = sources.xdg_cache_home {
+        return Ok(path.join(CACHE_DIR_NAME).join(UPDATE_CHECK_CACHE_FILE_NAME));
+    }
+
+    if let Some(path) = sources.home {
+        return Ok(path
+            .join(".cache")
+            .join(CACHE_DIR_NAME)
+            .join(UPDATE_CHECK_CACHE_FILE_NAME));
+    }
+
+    Err(UpdateCachePathError::NotConfigured)
+}
+
+fn resolve_update_cache_path_from_env() -> Result<PathBuf, UpdateCachePathError> {
+    let xdg_cache_home = non_empty_env_path("XDG_CACHE_HOME");
+    let home = non_empty_env_path("HOME");
+
+    resolve_update_cache_path(UpdateCachePathSources {
+        xdg_cache_home: xdg_cache_home.as_deref(),
+        home: home.as_deref(),
+    })
+}
+
+fn non_empty_env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+}
+
 #[derive(Debug)]
 pub enum UpdatesError {
     Http {
@@ -192,8 +255,38 @@ pub enum UpdatesError {
     NoMatchingRelease {
         channel: UpdateChannel,
     },
+    NotModifiedWithoutCache {
+        channel: UpdateChannel,
+    },
+    CachePath(UpdateCachePathError),
+    CacheEncode(serde_json::Error),
+    DeferredFailures(Vec<UpdatesDeferredFailure>),
     Notification(NotificationError),
     Io(io::Error),
+}
+
+#[derive(Debug)]
+pub enum UpdatesDeferredFailure {
+    Cache(Box<UpdatesError>),
+    Notification(NotificationError),
+}
+
+impl fmt::Display for UpdatesDeferredFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cache(err) => write!(f, "update cache failed: {err}"),
+            Self::Notification(err) => write!(f, "desktop notification failed: {err}"),
+        }
+    }
+}
+
+impl Error for UpdatesDeferredFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Cache(err) => Some(err.as_ref()),
+            Self::Notification(err) => Some(err),
+        }
+    }
 }
 
 impl fmt::Display for UpdatesError {
@@ -232,6 +325,31 @@ impl fmt::Display for UpdatesError {
                     channel.as_str()
                 )
             }
+            Self::NotModifiedWithoutCache { channel } => {
+                write!(
+                    f,
+                    "GitHub releases API reported no changes for {} channel, but the local update cache has no usable release metadata",
+                    channel.as_str()
+                )
+            }
+            Self::CachePath(err) => write!(f, "{err}"),
+            Self::CacheEncode(err) => write!(f, "could not encode update check cache: {err}"),
+            Self::DeferredFailures(failures) => {
+                write!(f, "update check completed with deferred failure")?;
+                if failures.len() != 1 {
+                    write!(f, "s")?;
+                }
+                write!(f, ": ")?;
+
+                for (index, failure) in failures.iter().enumerate() {
+                    if index > 0 {
+                        write!(f, "; ")?;
+                    }
+                    write!(f, "{failure}")?;
+                }
+
+                Ok(())
+            }
             Self::Notification(err) => write!(f, "could not send update notification: {err}"),
             Self::Io(err) => write!(f, "{err}"),
         }
@@ -243,9 +361,17 @@ impl Error for UpdatesError {
         match self {
             Self::ApiShape { source, .. } => Some(source),
             Self::InvalidLocalVersion { source, .. } => Some(source),
+            Self::CachePath(err) => Some(err),
+            Self::CacheEncode(err) => Some(err),
+            Self::DeferredFailures(failures) => {
+                failures.iter().find_map(|failure| failure.source())
+            }
             Self::Notification(err) => Some(err),
             Self::Io(err) => Some(err),
-            Self::Http { .. } | Self::ApiStatus { .. } | Self::NoMatchingRelease { .. } => None,
+            Self::Http { .. }
+            | Self::ApiStatus { .. }
+            | Self::NoMatchingRelease { .. }
+            | Self::NotModifiedWithoutCache { .. } => None,
         }
     }
 }
@@ -275,6 +401,61 @@ impl ReleaseInfo {
     pub fn url(&self) -> &str {
         &self.url
     }
+
+    fn to_cached(&self) -> CachedReleaseInfo {
+        CachedReleaseInfo {
+            version: self.version.to_string(),
+            channel: self.channel,
+            url: self.url.clone(),
+        }
+    }
+
+    fn from_cached(cached: &CachedReleaseInfo) -> Option<Self> {
+        Version::parse(&cached.version).ok().map(|version| Self {
+            version,
+            channel: cached.channel,
+            url: cached.url.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct UpdateCheckCache {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    stable: Option<CachedUpdateCheck>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    prerelease: Option<CachedUpdateCheck>,
+}
+
+impl UpdateCheckCache {
+    fn entry(&self, channel: UpdateChannel) -> Option<&CachedUpdateCheck> {
+        match channel {
+            UpdateChannel::Stable => self.stable.as_ref(),
+            UpdateChannel::Prerelease => self.prerelease.as_ref(),
+        }
+    }
+
+    fn set_entry(&mut self, channel: UpdateChannel, entry: CachedUpdateCheck) {
+        match channel {
+            UpdateChannel::Stable => self.stable = Some(entry),
+            UpdateChannel::Prerelease => self.prerelease = Some(entry),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct CachedUpdateCheck {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    etag: Option<String>,
+    last_checked_at_unix_seconds: u64,
+    latest: CachedReleaseInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct CachedReleaseInfo {
+    version: String,
+    channel: UpdateChannel,
+    url: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -322,7 +503,18 @@ impl UpdateCheckResult {
 }
 
 trait GitHubReleasesClient {
-    fn get(&self, endpoint: ReleaseEndpoint, user_agent: &str) -> Result<String, UpdatesError>;
+    fn get(
+        &self,
+        endpoint: ReleaseEndpoint,
+        user_agent: &str,
+        if_none_match: Option<&str>,
+    ) -> Result<GitHubReleaseResponse, UpdatesError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GitHubReleaseResponse {
+    Ok { body: String, etag: Option<String> },
+    NotModified,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -365,21 +557,38 @@ impl Default for UreqGitHubReleasesClient {
 }
 
 impl GitHubReleasesClient for UreqGitHubReleasesClient {
-    fn get(&self, endpoint: ReleaseEndpoint, user_agent: &str) -> Result<String, UpdatesError> {
+    fn get(
+        &self,
+        endpoint: ReleaseEndpoint,
+        user_agent: &str,
+        if_none_match: Option<&str>,
+    ) -> Result<GitHubReleaseResponse, UpdatesError> {
         let url = endpoint.url(self.base_url);
-        let result = self
+        let mut request = self
             .agent
             .get(&url)
             .set("Accept", GITHUB_ACCEPT)
             .set("User-Agent", user_agent)
-            .set("X-GitHub-Api-Version", GITHUB_API_VERSION)
-            .call();
+            .set("X-GitHub-Api-Version", GITHUB_API_VERSION);
+
+        if let Some(etag) = if_none_match {
+            request = request.set("If-None-Match", etag);
+        }
+
+        let result = request.call();
 
         match result {
-            Ok(response) => response.into_string().map_err(|err| UpdatesError::Http {
-                url,
-                message: err.to_string(),
-            }),
+            Ok(response) => {
+                let etag = response.header("ETag").map(str::to_string);
+                response
+                    .into_string()
+                    .map(|body| GitHubReleaseResponse::Ok { body, etag })
+                    .map_err(|err| UpdatesError::Http {
+                        url,
+                        message: err.to_string(),
+                    })
+            }
+            Err(ureq::Error::Status(304, _)) => Ok(GitHubReleaseResponse::NotModified),
             Err(ureq::Error::Status(status, response)) => {
                 let body = response.into_string().unwrap_or_default();
                 Err(UpdatesError::ApiStatus { url, status, body })
@@ -390,6 +599,122 @@ impl GitHubReleasesClient for UreqGitHubReleasesClient {
             }),
         }
     }
+}
+
+trait UpdateCacheStore {
+    fn load(&self) -> Result<UpdateCheckCache, UpdatesError>;
+    fn save(&self, cache: &UpdateCheckCache) -> Result<(), UpdatesError>;
+}
+
+struct FileUpdateCacheStore {
+    path: PathBuf,
+}
+
+impl FileUpdateCacheStore {
+    #[cfg(test)]
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+enum DefaultUpdateCacheStore {
+    File(FileUpdateCacheStore),
+    Unavailable(UpdateCachePathError),
+}
+
+impl DefaultUpdateCacheStore {
+    fn from_env() -> Self {
+        match resolve_update_cache_path_from_env() {
+            Ok(path) => Self::File(FileUpdateCacheStore { path }),
+            Err(err) => Self::Unavailable(err),
+        }
+    }
+}
+
+impl UpdateCacheStore for DefaultUpdateCacheStore {
+    fn load(&self) -> Result<UpdateCheckCache, UpdatesError> {
+        match self {
+            Self::File(store) => store.load(),
+            Self::Unavailable(_) => Ok(UpdateCheckCache::default()),
+        }
+    }
+
+    fn save(&self, cache: &UpdateCheckCache) -> Result<(), UpdatesError> {
+        match self {
+            Self::File(store) => store.save(cache),
+            Self::Unavailable(err) => Err(UpdatesError::CachePath(err.clone())),
+        }
+    }
+}
+
+impl UpdateCacheStore for FileUpdateCacheStore {
+    fn load(&self) -> Result<UpdateCheckCache, UpdatesError> {
+        match fs::read_to_string(&self.path) {
+            Ok(contents) => Ok(serde_json::from_str(&contents).unwrap_or_default()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(UpdateCheckCache::default()),
+            Err(err) => Err(UpdatesError::Io(err)),
+        }
+    }
+
+    fn save(&self, cache: &UpdateCheckCache) -> Result<(), UpdatesError> {
+        let contents = serde_json::to_vec_pretty(cache).map_err(UpdatesError::CacheEncode)?;
+        atomic_write_file(&self.path, &contents).map_err(UpdatesError::Io)
+    }
+}
+
+fn atomic_write_file(path: &Path, contents: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    let mut last_error = None;
+    for attempt in 0..100 {
+        let temp_path = atomic_temp_path(path, attempt);
+        let mut file = match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+        {
+            Ok(file) => file,
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                last_error = Some(err);
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
+
+        let result = (|| {
+            file.write_all(contents)?;
+            file.flush()?;
+            file.sync_all()?;
+            drop(file);
+            fs::rename(&temp_path, path)
+        })();
+
+        if let Err(err) = result {
+            let _ = fs::remove_file(&temp_path);
+            return Err(err);
+        }
+
+        return Ok(());
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not create unique update cache temporary file",
+        )
+    }))
+}
+
+fn atomic_temp_path(path: &Path, attempt: u8) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(UPDATE_CHECK_CACHE_FILE_NAME);
+    path.with_file_name(format!(".{file_name}.{}.{}.tmp", process::id(), attempt))
 }
 
 #[derive(Debug, Deserialize)]
@@ -407,34 +732,77 @@ pub fn run_updates_command<W: io::Write>(
     let client = UreqGitHubReleasesClient::default();
     let version = VersionInfo::current();
     let notifier = FreedesktopNotifier;
+    let cache_store = DefaultUpdateCacheStore::from_env();
 
-    run_updates_command_with(command, writer, version, &client, &notifier)
+    run_updates_command_with(
+        command,
+        writer,
+        version,
+        &client,
+        &notifier,
+        &cache_store,
+        current_unix_seconds(),
+    )
 }
 
-fn run_updates_command_with<W: io::Write, C: GitHubReleasesClient, N: Notifier>(
+fn run_updates_command_with<
+    W: io::Write,
+    C: GitHubReleasesClient,
+    N: Notifier,
+    S: UpdateCacheStore,
+>(
     command: UpdatesCommand,
     writer: &mut W,
     version: VersionInfo,
     client: &C,
     notifier: &N,
+    cache_store: &S,
+    now_unix_seconds: u64,
 ) -> Result<(), UpdatesError> {
     let notify = command.notify();
-    let result = check_updates(command, version, client)?;
+    let mut deferred_failures = Vec::new();
+    let mut cache = match cache_store.load() {
+        Ok(cache) => cache,
+        Err(err) => {
+            deferred_failures.push(UpdatesDeferredFailure::Cache(Box::new(err)));
+            UpdateCheckCache::default()
+        }
+    };
+    let result = check_updates_with_cache(command, version, client, &mut cache, now_unix_seconds)?;
 
     writer.write_all(result.render().as_bytes())?;
     if notify && result.update_available() {
-        notifier
-            .notify(&result.notification())
-            .map_err(UpdatesError::Notification)?;
+        if let Err(err) = notifier.notify(&result.notification()) {
+            deferred_failures.push(UpdatesDeferredFailure::Notification(err));
+        }
+    }
+    if let Err(err) = cache_store.save(&cache) {
+        deferred_failures.push(UpdatesDeferredFailure::Cache(Box::new(err)));
+    }
+
+    if !deferred_failures.is_empty() {
+        return Err(UpdatesError::DeferredFailures(deferred_failures));
     }
 
     Ok(())
 }
 
+#[cfg(test)]
 fn check_updates<C: GitHubReleasesClient>(
     command: UpdatesCommand,
     current: VersionInfo,
     client: &C,
+) -> Result<UpdateCheckResult, UpdatesError> {
+    let mut cache = UpdateCheckCache::default();
+    check_updates_with_cache(command, current, client, &mut cache, current_unix_seconds())
+}
+
+fn check_updates_with_cache<C: GitHubReleasesClient>(
+    command: UpdatesCommand,
+    current: VersionInfo,
+    client: &C,
+    cache: &mut UpdateCheckCache,
+    now_unix_seconds: u64,
 ) -> Result<UpdateCheckResult, UpdatesError> {
     match command {
         UpdatesCommand::Check { channel, .. } => {
@@ -445,7 +813,7 @@ fn check_updates<C: GitHubReleasesClient>(
                     source,
                 }
             })?;
-            let latest = fetch_latest_release(channel, current, client)?;
+            let latest = fetch_latest_release(channel, current, client, cache, now_unix_seconds)?;
 
             Ok(UpdateCheckResult {
                 current_version,
@@ -460,38 +828,84 @@ fn fetch_latest_release<C: GitHubReleasesClient>(
     channel: UpdateChannel,
     current: VersionInfo,
     client: &C,
+    cache: &mut UpdateCheckCache,
+    now_unix_seconds: u64,
 ) -> Result<ReleaseInfo, UpdatesError> {
     let user_agent = format!("lg-buddy/{}", current.version());
+    let cached_etag = cache.entry(channel).and_then(|entry| entry.etag.as_deref());
 
     match channel {
         UpdateChannel::Stable => {
             let endpoint = ReleaseEndpoint::LatestStable;
-            let body = client.get(endpoint, &user_agent)?;
-            let release: GitHubRelease =
-                serde_json::from_str(&body).map_err(|source| UpdatesError::ApiShape {
-                    endpoint: endpoint.label(),
-                    source,
-                })?;
+            let response = client.get(endpoint, &user_agent, cached_etag)?;
 
-            release_info_from_api_release(release, channel)
-                .ok_or(UpdatesError::NoMatchingRelease { channel })
+            latest_from_response(channel, response, cache, now_unix_seconds, |body| {
+                let release: GitHubRelease =
+                    serde_json::from_str(body).map_err(|source| UpdatesError::ApiShape {
+                        endpoint: endpoint.label(),
+                        source,
+                    })?;
+
+                release_info_from_api_release(release, channel)
+                    .ok_or(UpdatesError::NoMatchingRelease { channel })
+            })
         }
         UpdateChannel::Prerelease => {
             let endpoint = ReleaseEndpoint::ReleasesList {
                 per_page: PRERELEASE_PAGE_SIZE,
             };
-            let body = client.get(endpoint, &user_agent)?;
-            let releases: Vec<GitHubRelease> =
-                serde_json::from_str(&body).map_err(|source| UpdatesError::ApiShape {
-                    endpoint: endpoint.label(),
-                    source,
-                })?;
+            let response = client.get(endpoint, &user_agent, cached_etag)?;
 
-            releases
-                .into_iter()
-                .filter_map(|release| release_info_from_api_release(release, channel))
-                .max_by(|left, right| left.version.cmp(&right.version))
-                .ok_or(UpdatesError::NoMatchingRelease { channel })
+            latest_from_response(channel, response, cache, now_unix_seconds, |body| {
+                let releases: Vec<GitHubRelease> =
+                    serde_json::from_str(body).map_err(|source| UpdatesError::ApiShape {
+                        endpoint: endpoint.label(),
+                        source,
+                    })?;
+
+                releases
+                    .into_iter()
+                    .filter_map(|release| release_info_from_api_release(release, channel))
+                    .max_by(|left, right| left.version.cmp(&right.version))
+                    .ok_or(UpdatesError::NoMatchingRelease { channel })
+            })
+        }
+    }
+}
+
+fn latest_from_response<F>(
+    channel: UpdateChannel,
+    response: GitHubReleaseResponse,
+    cache: &mut UpdateCheckCache,
+    now_unix_seconds: u64,
+    parse_latest: F,
+) -> Result<ReleaseInfo, UpdatesError>
+where
+    F: FnOnce(&str) -> Result<ReleaseInfo, UpdatesError>,
+{
+    match response {
+        GitHubReleaseResponse::Ok { body, etag } => {
+            let latest = parse_latest(&body)?;
+            cache.set_entry(
+                channel,
+                CachedUpdateCheck {
+                    etag,
+                    last_checked_at_unix_seconds: now_unix_seconds,
+                    latest: latest.to_cached(),
+                },
+            );
+            Ok(latest)
+        }
+        GitHubReleaseResponse::NotModified => {
+            let mut entry = cache
+                .entry(channel)
+                .cloned()
+                .ok_or(UpdatesError::NotModifiedWithoutCache { channel })?;
+            let latest = ReleaseInfo::from_cached(&entry.latest)
+                .ok_or(UpdatesError::NotModifiedWithoutCache { channel })?;
+            entry.last_checked_at_unix_seconds = now_unix_seconds;
+            cache.set_entry(channel, entry);
+            Ok(latest)
         }
     }
 }
@@ -526,26 +940,57 @@ fn parse_release_version(tag_name: &str) -> Option<Version> {
     Version::parse(tag_name.strip_prefix('v').unwrap_or(tag_name)).ok()
 }
 
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        check_updates, parse_release_version, run_updates_command_with, GitHubReleasesClient,
-        ReleaseEndpoint, UpdateChannel, UpdatesCommand, UpdatesError,
+        atomic_write_file, check_updates, check_updates_with_cache, parse_release_version,
+        resolve_update_cache_path, run_updates_command_with, CachedReleaseInfo, CachedUpdateCheck,
+        DefaultUpdateCacheStore, FileUpdateCacheStore, GitHubReleaseResponse, GitHubReleasesClient,
+        ReleaseEndpoint, UpdateCachePathError, UpdateCachePathSources, UpdateCacheStore,
+        UpdateChannel, UpdateCheckCache, UpdatesCommand, UpdatesDeferredFailure, UpdatesError,
     };
     use crate::notifications::{
         Notification, NotificationCapabilities, NotificationError, NotificationId, Notifier,
     };
     use crate::version::{ReleaseChannel, VersionInfo};
     use std::cell::RefCell;
+    use std::fs;
+    use std::io;
+    use std::path::PathBuf;
+    use std::process;
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex, OnceLock,
+    };
+
+    const TEST_NOW: u64 = 1_778_234_400;
 
     #[derive(Debug)]
     struct MockGitHubReleasesClient {
-        responses: RefCell<Vec<Result<String, UpdatesError>>>,
-        requests: RefCell<Vec<(String, String)>>,
+        responses: RefCell<Vec<Result<GitHubReleaseResponse, UpdatesError>>>,
+        requests: RefCell<Vec<(String, String, Option<String>)>>,
     }
 
     impl MockGitHubReleasesClient {
         fn new(responses: Vec<Result<String, UpdatesError>>) -> Self {
+            Self::new_responses(
+                responses
+                    .into_iter()
+                    .map(|response| {
+                        response.map(|body| GitHubReleaseResponse::Ok { body, etag: None })
+                    })
+                    .collect(),
+            )
+        }
+
+        fn new_responses(responses: Vec<Result<GitHubReleaseResponse, UpdatesError>>) -> Self {
             Self {
                 responses: RefCell::new(responses),
                 requests: RefCell::new(Vec::new()),
@@ -553,17 +998,81 @@ mod tests {
         }
 
         fn requests(&self) -> Vec<(String, String)> {
+            self.requests
+                .borrow()
+                .iter()
+                .map(|(url, user_agent, _)| (url.clone(), user_agent.clone()))
+                .collect()
+        }
+
+        fn requests_with_etags(&self) -> Vec<(String, String, Option<String>)> {
             self.requests.borrow().clone()
         }
     }
 
     impl GitHubReleasesClient for MockGitHubReleasesClient {
-        fn get(&self, endpoint: ReleaseEndpoint, user_agent: &str) -> Result<String, UpdatesError> {
+        fn get(
+            &self,
+            endpoint: ReleaseEndpoint,
+            user_agent: &str,
+            if_none_match: Option<&str>,
+        ) -> Result<GitHubReleaseResponse, UpdatesError> {
             self.requests.borrow_mut().push((
                 endpoint.url("https://api.example.test/releases"),
                 user_agent.to_string(),
+                if_none_match.map(str::to_string),
             ));
             self.responses.borrow_mut().remove(0)
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct MemoryUpdateCacheStore {
+        cache: RefCell<UpdateCheckCache>,
+    }
+
+    impl MemoryUpdateCacheStore {
+        fn with_cache(cache: UpdateCheckCache) -> Self {
+            Self {
+                cache: RefCell::new(cache),
+            }
+        }
+
+        fn cache(&self) -> UpdateCheckCache {
+            self.cache.borrow().clone()
+        }
+    }
+
+    impl UpdateCacheStore for MemoryUpdateCacheStore {
+        fn load(&self) -> Result<UpdateCheckCache, UpdatesError> {
+            Ok(self.cache())
+        }
+
+        fn save(&self, cache: &UpdateCheckCache) -> Result<(), UpdatesError> {
+            self.cache.replace(cache.clone());
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct FailingSaveUpdateCacheStore {
+        cache: RefCell<UpdateCheckCache>,
+    }
+
+    impl FailingSaveUpdateCacheStore {
+        fn cache(&self) -> UpdateCheckCache {
+            self.cache.borrow().clone()
+        }
+    }
+
+    impl UpdateCacheStore for FailingSaveUpdateCacheStore {
+        fn load(&self) -> Result<UpdateCheckCache, UpdatesError> {
+            Ok(self.cache())
+        }
+
+        fn save(&self, cache: &UpdateCheckCache) -> Result<(), UpdatesError> {
+            self.cache.replace(cache.clone());
+            Err(UpdatesError::Io(io::Error::other("cache unwritable")))
         }
     }
 
@@ -627,6 +1136,31 @@ mod tests {
         )
     }
 
+    fn api_response(body: String, etag: Option<&str>) -> GitHubReleaseResponse {
+        GitHubReleaseResponse::Ok {
+            body,
+            etag: etag.map(str::to_string),
+        }
+    }
+
+    fn cached_entry(
+        etag: Option<&str>,
+        version: &str,
+        channel: UpdateChannel,
+        url: &str,
+        last_checked_at_unix_seconds: u64,
+    ) -> CachedUpdateCheck {
+        CachedUpdateCheck {
+            etag: etag.map(str::to_string),
+            last_checked_at_unix_seconds,
+            latest: CachedReleaseInfo {
+                version: version.to_string(),
+                channel,
+                url: url.to_string(),
+            },
+        }
+    }
+
     fn rendered(output: &[u8]) -> String {
         String::from_utf8(output.to_vec()).expect("utf8 output")
     }
@@ -643,6 +1177,561 @@ mod tests {
             channel,
             notify: true,
         }
+    }
+
+    static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let counter = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "lg-buddy-updates-{label}-{}-{counter}",
+            process::id()
+        ));
+        fs::create_dir_all(&path).expect("create test temp dir");
+        path
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn cache_path_resolver_prefers_xdg_cache_home() {
+        let xdg_cache_home = PathBuf::from("/tmp/xdg-cache");
+        let home = PathBuf::from("/home/test-user");
+
+        let path = resolve_update_cache_path(UpdateCachePathSources {
+            xdg_cache_home: Some(&xdg_cache_home),
+            home: Some(&home),
+        })
+        .expect("resolve cache path");
+
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/xdg-cache/lg-buddy/update-check.json")
+        );
+    }
+
+    #[test]
+    fn cache_path_resolver_falls_back_to_home_cache() {
+        let home = PathBuf::from("/home/test-user");
+
+        let path = resolve_update_cache_path(UpdateCachePathSources {
+            xdg_cache_home: None,
+            home: Some(&home),
+        })
+        .expect("resolve cache path");
+
+        assert_eq!(
+            path,
+            PathBuf::from("/home/test-user/.cache/lg-buddy/update-check.json")
+        );
+    }
+
+    #[test]
+    fn empty_env_paths_are_treated_as_unset_for_cache_resolution() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let original_xdg_cache_home = std::env::var_os("XDG_CACHE_HOME");
+        let original_home = std::env::var_os("HOME");
+
+        std::env::set_var("XDG_CACHE_HOME", "");
+        std::env::set_var("HOME", "/home/test-user");
+
+        let path = super::resolve_update_cache_path_from_env().expect("resolve cache path");
+
+        assert_eq!(
+            path,
+            PathBuf::from("/home/test-user/.cache/lg-buddy/update-check.json")
+        );
+
+        match original_xdg_cache_home {
+            Some(value) => std::env::set_var("XDG_CACHE_HOME", value),
+            None => std::env::remove_var("XDG_CACHE_HOME"),
+        }
+        match original_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    fn missing_and_malformed_cache_load_as_empty() {
+        let dir = unique_temp_dir("malformed-cache");
+        let path = dir.join("lg-buddy").join("update-check.json");
+        let store = FileUpdateCacheStore::new(path.clone());
+
+        assert_eq!(
+            store.load().expect("missing cache should load"),
+            UpdateCheckCache::default()
+        );
+
+        fs::create_dir_all(path.parent().expect("cache path parent")).expect("create cache dir");
+        fs::write(&path, "{").expect("write malformed cache");
+
+        assert_eq!(
+            store.load().expect("malformed cache should load"),
+            UpdateCheckCache::default()
+        );
+
+        fs::remove_dir_all(dir).expect("remove test temp dir");
+    }
+
+    #[test]
+    fn file_cache_round_trips_entries_and_preserves_other_channel() {
+        let dir = unique_temp_dir("cache-roundtrip");
+        let path = dir.join("lg-buddy").join("update-check.json");
+        let store = FileUpdateCacheStore::new(path);
+
+        let mut cache = UpdateCheckCache::default();
+        cache.set_entry(
+            UpdateChannel::Stable,
+            cached_entry(
+                Some("\"stable-etag\""),
+                "1.1.0",
+                UpdateChannel::Stable,
+                "https://github.test/releases/tag/v1.1.0",
+                TEST_NOW,
+            ),
+        );
+        cache.set_entry(
+            UpdateChannel::Prerelease,
+            cached_entry(
+                Some("\"prerelease-etag\""),
+                "1.2.0-beta.1",
+                UpdateChannel::Prerelease,
+                "https://github.test/releases/tag/v1.2.0-beta.1",
+                TEST_NOW + 1,
+            ),
+        );
+
+        store.save(&cache).expect("save cache");
+        assert_eq!(store.load().expect("load cache"), cache);
+
+        let mut updated = store.load().expect("load cache for update");
+        updated.set_entry(
+            UpdateChannel::Stable,
+            cached_entry(
+                Some("\"stable-etag-2\""),
+                "1.1.1",
+                UpdateChannel::Stable,
+                "https://github.test/releases/tag/v1.1.1",
+                TEST_NOW + 2,
+            ),
+        );
+        store.save(&updated).expect("save updated cache");
+
+        let loaded = store.load().expect("load updated cache");
+        assert_eq!(
+            loaded.entry(UpdateChannel::Stable),
+            updated.entry(UpdateChannel::Stable)
+        );
+        assert_eq!(
+            loaded.entry(UpdateChannel::Prerelease),
+            cache.entry(UpdateChannel::Prerelease)
+        );
+
+        fs::remove_dir_all(dir).expect("remove test temp dir");
+    }
+
+    #[test]
+    fn failed_atomic_write_does_not_replace_existing_target() {
+        let dir = unique_temp_dir("atomic-write-failure");
+        let path = dir.join("update-check.json");
+        fs::create_dir_all(&path).expect("create directory at target path");
+
+        let err = atomic_write_file(&path, b"{}").expect_err("rename over directory should fail");
+
+        assert!(err.kind() != io::ErrorKind::NotFound);
+        assert!(path.is_dir());
+
+        fs::remove_dir_all(dir).expect("remove test temp dir");
+    }
+
+    #[test]
+    fn update_check_sends_cached_etag_and_stores_response_etag() {
+        let client = MockGitHubReleasesClient::new_responses(vec![Ok(api_response(
+            stable_release("v1.2.0"),
+            Some("\"next-etag\""),
+        ))]);
+        let mut cache = UpdateCheckCache::default();
+        cache.set_entry(
+            UpdateChannel::Stable,
+            cached_entry(
+                Some("\"cached-etag\""),
+                "1.1.0",
+                UpdateChannel::Stable,
+                "https://github.test/releases/tag/v1.1.0",
+                TEST_NOW - 1,
+            ),
+        );
+
+        let result = check_updates_with_cache(
+            check(Some(UpdateChannel::Stable)),
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &mut cache,
+            TEST_NOW,
+        )
+        .expect("stable update check should succeed");
+
+        assert!(result.update_available());
+        assert_eq!(
+            client.requests_with_etags(),
+            vec![(
+                "https://api.example.test/releases/latest".to_string(),
+                "lg-buddy/1.1.0".to_string(),
+                Some("\"cached-etag\"".to_string())
+            )]
+        );
+        let entry = cache
+            .entry(UpdateChannel::Stable)
+            .expect("stable cache entry");
+        assert_eq!(entry.etag.as_deref(), Some("\"next-etag\""));
+        assert_eq!(entry.last_checked_at_unix_seconds, TEST_NOW);
+        assert_eq!(entry.latest.version, "1.2.0");
+    }
+
+    #[test]
+    fn stable_not_modified_uses_cached_release_metadata() {
+        let client =
+            MockGitHubReleasesClient::new_responses(vec![Ok(GitHubReleaseResponse::NotModified)]);
+        let mut cache = UpdateCheckCache::default();
+        cache.set_entry(
+            UpdateChannel::Stable,
+            cached_entry(
+                Some("\"stable-etag\""),
+                "1.1.1",
+                UpdateChannel::Stable,
+                "https://github.test/releases/tag/v1.1.1",
+                TEST_NOW - 10,
+            ),
+        );
+
+        let result = check_updates_with_cache(
+            check(Some(UpdateChannel::Stable)),
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &mut cache,
+            TEST_NOW,
+        )
+        .expect("cached stable update check should succeed");
+
+        assert!(result.update_available());
+        assert_eq!(
+            result.render(),
+            "status: update available\ncurrent: 1.1.0 (stable)\nlatest: 1.1.1 (stable)\nurl: https://github.test/releases/tag/v1.1.1\n"
+        );
+        assert_eq!(
+            client.requests_with_etags(),
+            vec![(
+                "https://api.example.test/releases/latest".to_string(),
+                "lg-buddy/1.1.0".to_string(),
+                Some("\"stable-etag\"".to_string())
+            )]
+        );
+        let entry = cache
+            .entry(UpdateChannel::Stable)
+            .expect("stable cache entry");
+        assert_eq!(entry.etag.as_deref(), Some("\"stable-etag\""));
+        assert_eq!(entry.last_checked_at_unix_seconds, TEST_NOW);
+    }
+
+    #[test]
+    fn prerelease_not_modified_can_use_cached_stable_latest_release() {
+        let client =
+            MockGitHubReleasesClient::new_responses(vec![Ok(GitHubReleaseResponse::NotModified)]);
+        let mut cache = UpdateCheckCache::default();
+        cache.set_entry(
+            UpdateChannel::Prerelease,
+            cached_entry(
+                Some("\"prerelease-etag\""),
+                "1.2.0",
+                UpdateChannel::Stable,
+                "https://github.test/releases/tag/v1.2.0",
+                TEST_NOW - 10,
+            ),
+        );
+
+        let result = check_updates_with_cache(
+            check(Some(UpdateChannel::Prerelease)),
+            version_info("1.2.0-beta.1", ReleaseChannel::Prerelease),
+            &client,
+            &mut cache,
+            TEST_NOW,
+        )
+        .expect("cached prerelease update check should succeed");
+
+        assert!(result.update_available());
+        assert_eq!(result.latest.channel(), UpdateChannel::Stable);
+        assert_eq!(
+            client.requests_with_etags(),
+            vec![(
+                "https://api.example.test/releases?per_page=20".to_string(),
+                "lg-buddy/1.2.0-beta.1".to_string(),
+                Some("\"prerelease-etag\"".to_string())
+            )]
+        );
+    }
+
+    #[test]
+    fn not_modified_without_cached_release_metadata_is_reported() {
+        let client =
+            MockGitHubReleasesClient::new_responses(vec![Ok(GitHubReleaseResponse::NotModified)]);
+        let mut cache = UpdateCheckCache::default();
+
+        let err = check_updates_with_cache(
+            check(Some(UpdateChannel::Stable)),
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &mut cache,
+            TEST_NOW,
+        )
+        .expect_err("304 without cache should fail");
+
+        assert!(matches!(
+            err,
+            UpdatesError::NotModifiedWithoutCache {
+                channel: UpdateChannel::Stable
+            }
+        ));
+    }
+
+    #[test]
+    fn manual_update_check_reuses_cache_on_not_modified() {
+        let client = MockGitHubReleasesClient::new_responses(vec![
+            Ok(api_response(
+                stable_release("v1.1.1"),
+                Some("\"stable-etag\""),
+            )),
+            Ok(GitHubReleaseResponse::NotModified),
+        ]);
+        let notifier = RecordingNotifier::default();
+        let cache_store = MemoryUpdateCacheStore::default();
+        let mut first_output = Vec::new();
+        let mut second_output = Vec::new();
+
+        run_updates_command_with(
+            check(Some(UpdateChannel::Stable)),
+            &mut first_output,
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &notifier,
+            &cache_store,
+            TEST_NOW,
+        )
+        .expect("initial update check should succeed");
+        run_updates_command_with(
+            check(Some(UpdateChannel::Stable)),
+            &mut second_output,
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &notifier,
+            &cache_store,
+            TEST_NOW + 1,
+        )
+        .expect("cached update check should succeed");
+
+        assert_eq!(rendered(&first_output), rendered(&second_output));
+        assert_eq!(
+            client.requests_with_etags(),
+            vec![
+                (
+                    "https://api.example.test/releases/latest".to_string(),
+                    "lg-buddy/1.1.0".to_string(),
+                    None
+                ),
+                (
+                    "https://api.example.test/releases/latest".to_string(),
+                    "lg-buddy/1.1.0".to_string(),
+                    Some("\"stable-etag\"".to_string())
+                )
+            ]
+        );
+        let cache = cache_store.cache();
+        assert_eq!(
+            cache
+                .entry(UpdateChannel::Stable)
+                .expect("stable cache entry")
+                .last_checked_at_unix_seconds,
+            TEST_NOW + 1
+        );
+        assert!(notifier.notifications().is_empty());
+    }
+
+    #[test]
+    fn unavailable_cache_path_does_not_block_update_check_but_fails_after_result() {
+        let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
+        let notifier = RecordingNotifier::default();
+        let cache_store = DefaultUpdateCacheStore::Unavailable(UpdateCachePathError::NotConfigured);
+        let mut output = Vec::new();
+
+        let err = run_updates_command_with(
+            check(Some(UpdateChannel::Stable)),
+            &mut output,
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &notifier,
+            &cache_store,
+            TEST_NOW,
+        )
+        .expect_err("unavailable cache path should be reported after update check");
+
+        assert!(rendered(&output).contains("status: update available"));
+        assert_eq!(
+            client.requests_with_etags(),
+            vec![(
+                "https://api.example.test/releases/latest".to_string(),
+                "lg-buddy/1.1.0".to_string(),
+                None
+            )]
+        );
+        assert!(notifier.notifications().is_empty());
+        let UpdatesError::DeferredFailures(failures) = err else {
+            panic!("expected deferred cache failure");
+        };
+        assert_eq!(failures.len(), 1);
+        assert!(matches!(
+            &failures[0],
+            UpdatesDeferredFailure::Cache(cache_err)
+                if matches!(cache_err.as_ref(), UpdatesError::CachePath(UpdateCachePathError::NotConfigured))
+        ));
+    }
+
+    #[test]
+    fn cache_save_failure_does_not_block_requested_notification_but_fails_afterwards() {
+        let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
+        let notifier = RecordingNotifier::default();
+        let cache_store = FailingSaveUpdateCacheStore::default();
+        let mut output = Vec::new();
+
+        let err = run_updates_command_with(
+            check_notify(Some(UpdateChannel::Stable)),
+            &mut output,
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &notifier,
+            &cache_store,
+            TEST_NOW,
+        )
+        .expect_err("cache save failure should be reported after notification");
+
+        assert!(rendered(&output).contains("status: update available"));
+        assert_eq!(notifier.notifications().len(), 1);
+        let UpdatesError::DeferredFailures(failures) = err else {
+            panic!("expected deferred cache failure");
+        };
+        assert_eq!(failures.len(), 1);
+        assert!(matches!(
+            &failures[0],
+            UpdatesDeferredFailure::Cache(cache_err)
+                if matches!(cache_err.as_ref(), UpdatesError::Io(_))
+        ));
+    }
+
+    #[test]
+    fn notification_and_cache_save_failures_are_reported_together() {
+        let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
+        let notifier = RecordingNotifier::failing("bus unavailable");
+        let cache_store = FailingSaveUpdateCacheStore::default();
+        let mut output = Vec::new();
+
+        let err = run_updates_command_with(
+            check_notify(Some(UpdateChannel::Stable)),
+            &mut output,
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &notifier,
+            &cache_store,
+            TEST_NOW,
+        )
+        .expect_err("notification and cache failures should both be reported");
+
+        assert!(rendered(&output).contains("status: update available"));
+        assert_eq!(notifier.notifications().len(), 1);
+        let UpdatesError::DeferredFailures(failures) = err else {
+            panic!("expected deferred failures");
+        };
+        assert_eq!(failures.len(), 2);
+        assert!(matches!(
+            &failures[0],
+            UpdatesDeferredFailure::Notification(_)
+        ));
+        assert!(matches!(
+            &failures[1],
+            UpdatesDeferredFailure::Cache(cache_err)
+                if matches!(cache_err.as_ref(), UpdatesError::Io(_))
+        ));
+    }
+
+    #[test]
+    fn notify_sends_notification_when_cached_not_modified_update_is_available() {
+        let client =
+            MockGitHubReleasesClient::new_responses(vec![Ok(GitHubReleaseResponse::NotModified)]);
+        let notifier = RecordingNotifier::default();
+        let mut cache = UpdateCheckCache::default();
+        cache.set_entry(
+            UpdateChannel::Stable,
+            cached_entry(
+                Some("\"stable-etag\""),
+                "1.1.1",
+                UpdateChannel::Stable,
+                "https://github.test/releases/tag/v1.1.1",
+                TEST_NOW - 10,
+            ),
+        );
+        let cache_store = MemoryUpdateCacheStore::with_cache(cache);
+        let mut output = Vec::new();
+
+        run_updates_command_with(
+            check_notify(Some(UpdateChannel::Stable)),
+            &mut output,
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &notifier,
+            &cache_store,
+            TEST_NOW,
+        )
+        .expect("notifying cached update check should succeed");
+
+        assert!(rendered(&output).contains("status: update available"));
+        assert_eq!(notifier.notifications().len(), 1);
+    }
+
+    #[test]
+    fn notify_does_not_send_notification_when_cached_not_modified_is_up_to_date() {
+        let client =
+            MockGitHubReleasesClient::new_responses(vec![Ok(GitHubReleaseResponse::NotModified)]);
+        let notifier = RecordingNotifier::default();
+        let mut cache = UpdateCheckCache::default();
+        cache.set_entry(
+            UpdateChannel::Stable,
+            cached_entry(
+                Some("\"stable-etag\""),
+                "1.1.0",
+                UpdateChannel::Stable,
+                "https://github.test/releases/tag/v1.1.0",
+                TEST_NOW - 10,
+            ),
+        );
+        let cache_store = MemoryUpdateCacheStore::with_cache(cache);
+        let mut output = Vec::new();
+
+        run_updates_command_with(
+            check_notify(Some(UpdateChannel::Stable)),
+            &mut output,
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &notifier,
+            &cache_store,
+            TEST_NOW,
+        )
+        .expect("notifying cached update check should succeed");
+
+        assert!(rendered(&output).contains("status: up to date"));
+        assert!(notifier.notifications().is_empty());
     }
 
     #[test]
@@ -718,6 +1807,7 @@ mod tests {
     fn plain_updates_check_does_not_send_notification() {
         let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
         let notifier = RecordingNotifier::default();
+        let cache_store = MemoryUpdateCacheStore::default();
         let mut output = Vec::new();
 
         run_updates_command_with(
@@ -726,6 +1816,8 @@ mod tests {
             version_info("1.1.0", ReleaseChannel::Stable),
             &client,
             &notifier,
+            &cache_store,
+            TEST_NOW,
         )
         .expect("plain update check should succeed");
 
@@ -737,6 +1829,7 @@ mod tests {
     fn notify_sends_notification_when_update_is_available() {
         let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
         let notifier = RecordingNotifier::default();
+        let cache_store = MemoryUpdateCacheStore::default();
         let mut output = Vec::new();
 
         run_updates_command_with(
@@ -745,6 +1838,8 @@ mod tests {
             version_info("1.1.0", ReleaseChannel::Stable),
             &client,
             &notifier,
+            &cache_store,
+            TEST_NOW,
         )
         .expect("notifying update check should succeed");
 
@@ -762,6 +1857,7 @@ mod tests {
     fn notify_does_not_send_notification_when_up_to_date() {
         let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.0"))]);
         let notifier = RecordingNotifier::default();
+        let cache_store = MemoryUpdateCacheStore::default();
         let mut output = Vec::new();
 
         run_updates_command_with(
@@ -770,6 +1866,8 @@ mod tests {
             version_info("1.1.0", ReleaseChannel::Stable),
             &client,
             &notifier,
+            &cache_store,
+            TEST_NOW,
         )
         .expect("notifying update check should succeed");
 
@@ -781,6 +1879,7 @@ mod tests {
     fn notify_failure_after_available_update_returns_error_after_rendering_output() {
         let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
         let notifier = RecordingNotifier::failing("bus unavailable");
+        let cache_store = MemoryUpdateCacheStore::default();
         let mut output = Vec::new();
 
         let err = run_updates_command_with(
@@ -789,15 +1888,24 @@ mod tests {
             version_info("1.1.0", ReleaseChannel::Stable),
             &client,
             &notifier,
+            &cache_store,
+            TEST_NOW,
         )
         .expect_err("notification failure should fail notifying update check");
 
-        assert!(matches!(err, UpdatesError::Notification(_)));
         assert!(rendered(&output).contains("status: update available"));
         assert_eq!(notifier.notifications().len(), 1);
+        let UpdatesError::DeferredFailures(failures) = &err else {
+            panic!("expected deferred notification failure");
+        };
+        assert_eq!(failures.len(), 1);
+        assert!(matches!(
+            &failures[0],
+            UpdatesDeferredFailure::Notification(_)
+        ));
         assert_eq!(
             err.to_string(),
-            "could not send update notification: desktop notification service error: bus unavailable"
+            "update check completed with deferred failure: desktop notification failed: desktop notification service error: bus unavailable"
         );
     }
 
@@ -809,6 +1917,7 @@ mod tests {
             body: "server error".to_string(),
         })]);
         let notifier = RecordingNotifier::default();
+        let cache_store = MemoryUpdateCacheStore::default();
         let mut output = Vec::new();
 
         let err = run_updates_command_with(
@@ -817,6 +1926,8 @@ mod tests {
             version_info("1.1.0", ReleaseChannel::Stable),
             &client,
             &notifier,
+            &cache_store,
+            TEST_NOW,
         )
         .expect_err("API failure should fail before notification");
 

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -259,6 +259,10 @@ pub enum UpdatesError {
         channel: UpdateChannel,
     },
     CachePath(UpdateCachePathError),
+    CacheDecode {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
     CacheEncode(serde_json::Error),
     DeferredFailures(Vec<UpdatesDeferredFailure>),
     Notification(NotificationError),
@@ -333,6 +337,13 @@ impl fmt::Display for UpdatesError {
                 )
             }
             Self::CachePath(err) => write!(f, "{err}"),
+            Self::CacheDecode { path, source } => {
+                write!(
+                    f,
+                    "could not parse update check cache `{}`: {source}",
+                    path.display()
+                )
+            }
             Self::CacheEncode(err) => write!(f, "could not encode update check cache: {err}"),
             Self::DeferredFailures(failures) => {
                 write!(f, "update check completed with deferred failure")?;
@@ -362,6 +373,7 @@ impl Error for UpdatesError {
             Self::ApiShape { source, .. } => Some(source),
             Self::InvalidLocalVersion { source, .. } => Some(source),
             Self::CachePath(err) => Some(err),
+            Self::CacheDecode { source, .. } => Some(source),
             Self::CacheEncode(err) => Some(err),
             Self::DeferredFailures(failures) => {
                 failures.iter().find_map(|failure| failure.source())
@@ -650,7 +662,12 @@ impl UpdateCacheStore for DefaultUpdateCacheStore {
 impl UpdateCacheStore for FileUpdateCacheStore {
     fn load(&self) -> Result<UpdateCheckCache, UpdatesError> {
         match fs::read_to_string(&self.path) {
-            Ok(contents) => Ok(serde_json::from_str(&contents).unwrap_or_default()),
+            Ok(contents) => {
+                serde_json::from_str(&contents).map_err(|source| UpdatesError::CacheDecode {
+                    path: self.path.clone(),
+                    source,
+                })
+            }
             Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(UpdateCheckCache::default()),
             Err(err) => Err(UpdatesError::Io(err)),
         }
@@ -1258,7 +1275,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_and_malformed_cache_load_as_empty() {
+    fn missing_cache_loads_as_empty_and_malformed_cache_reports_decode_error() {
         let dir = unique_temp_dir("malformed-cache");
         let path = dir.join("lg-buddy").join("update-check.json");
         let store = FileUpdateCacheStore::new(path.clone());
@@ -1271,9 +1288,12 @@ mod tests {
         fs::create_dir_all(path.parent().expect("cache path parent")).expect("create cache dir");
         fs::write(&path, "{").expect("write malformed cache");
 
-        assert_eq!(
-            store.load().expect("malformed cache should load"),
-            UpdateCheckCache::default()
+        let err = store
+            .load()
+            .expect_err("malformed cache should report decode error");
+
+        assert!(
+            matches!(err, UpdatesError::CacheDecode { path: error_path, .. } if error_path == path)
         );
 
         fs::remove_dir_all(dir).expect("remove test temp dir");
@@ -1598,6 +1618,63 @@ mod tests {
             UpdatesDeferredFailure::Cache(cache_err)
                 if matches!(cache_err.as_ref(), UpdatesError::CachePath(UpdateCachePathError::NotConfigured))
         ));
+    }
+
+    #[test]
+    fn malformed_cache_does_not_block_update_check_but_fails_after_result() {
+        let dir = unique_temp_dir("malformed-cache-command");
+        let path = dir.join("lg-buddy").join("update-check.json");
+        fs::create_dir_all(path.parent().expect("cache path parent")).expect("create cache dir");
+        fs::write(&path, "{").expect("write malformed cache");
+
+        let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
+        let notifier = RecordingNotifier::default();
+        let cache_store = FileUpdateCacheStore::new(path.clone());
+        let mut output = Vec::new();
+
+        let err = run_updates_command_with(
+            check(Some(UpdateChannel::Stable)),
+            &mut output,
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &notifier,
+            &cache_store,
+            TEST_NOW,
+        )
+        .expect_err("malformed cache should be reported after update check");
+
+        assert!(rendered(&output).contains("status: update available"));
+        assert_eq!(
+            client.requests_with_etags(),
+            vec![(
+                "https://api.example.test/releases/latest".to_string(),
+                "lg-buddy/1.1.0".to_string(),
+                None
+            )]
+        );
+        assert!(notifier.notifications().is_empty());
+        let UpdatesError::DeferredFailures(failures) = err else {
+            panic!("expected deferred cache decode failure");
+        };
+        assert_eq!(failures.len(), 1);
+        assert!(matches!(
+            &failures[0],
+            UpdatesDeferredFailure::Cache(cache_err)
+                if matches!(cache_err.as_ref(), UpdatesError::CacheDecode { path: error_path, .. } if error_path == &path)
+        ));
+        assert_eq!(
+            cache_store
+                .load()
+                .expect("successful check should replace malformed cache")
+                .entry(UpdateChannel::Stable)
+                .expect("stable cache entry")
+                .latest
+                .version
+                .as_str(),
+            "1.1.1"
+        );
+
+        fs::remove_dir_all(dir).expect("remove test temp dir");
     }
 
     #[test]

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -321,7 +321,10 @@ the runtime command handlers in `commands.rs` and `session/runner.rs`.
 modules and delegates platform ingestion to `sources/`. The on-demand
 `updates check` command consumes the GitHub Releases API without entering the
 screen, lifecycle, settings, or scheduling paths. It enters notification
-dispatch only when `--notify` is passed and an update is available.
+dispatch only when `--notify` is passed and an update is available. It owns an
+operational cache under the user cache directory for GitHub ETag and latest
+release metadata; that cache is not user configuration and is not part of the
+settings API.
 The `brightness get` and `brightness set` commands use the TV picture
 abstraction in `tv.rs` for typed OLED brightness validation and live TV
 read/write operations. The interactive brightness dialog delegates its TV

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -53,7 +53,8 @@ metadata when the binary was built as an official release artifact.
 release is available. Stable builds check stable releases by default, while
 prerelease builds check the prerelease channel, which includes both prerelease
 and stable releases. Use `--channel stable` or `--channel prerelease` to choose
-the channel explicitly. Add `--notify` to send a desktop notification when the
+the channel explicitly. The command may cache GitHub response metadata to reduce
+repeated API downloads. Add `--notify` to send a desktop notification when the
 check finds an available update.
 
 `lifecycle`, `nm-pre-down`, `sleep-pre`, and `startup wake` are normally


### PR DESCRIPTION
## Summary
- add a per-channel update-check cache with GitHub ETag support
- reuse cached release metadata on 304 Not Modified responses
- keep cache failures loud but deferred so update results and requested notifications still run
- document the user-visible cache behavior and architecture ownership

## Tests
- cargo test -p lg-buddy updates --lib
- cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
- cargo test -p lg-buddy
- git diff --check

Refs #27