### PR TITLE
Add actionable update notifications

### DIFF
--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 dbus = { version = "0.9.11", features = ["vendored"] }
+dbus-crossroads = "0.5.3"
 evdev = "0.13.2"
 libc = "0.2"
 semver = "1"
@@ -22,7 +23,6 @@ path = "src/main.rs"
 
 [dev-dependencies]
 cucumber = "0.22.1"
-dbus-crossroads = "0.5.3"
 tokio = { version = "1", features = ["macros", "rt"] }
 
 [[test]]

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -10,6 +10,7 @@ pub mod runtime_phase;
 pub mod screen;
 pub mod session;
 pub mod session_bus;
+pub mod session_notifications;
 pub mod settings;
 pub mod sources;
 pub mod state;

--- a/crates/lg-buddy/src/notifications.rs
+++ b/crates/lg-buddy/src/notifications.rs
@@ -1,11 +1,12 @@
+use crate::session_bus::{BusSignal, BusValue};
 use dbus::arg::PropMap;
 use dbus::blocking::Connection as DbusConnection;
 use std::fmt;
 use std::time::Duration;
 
-const NOTIFICATION_SERVICE: &str = "org.freedesktop.Notifications";
-const NOTIFICATION_PATH: &str = "/org/freedesktop/Notifications";
-const NOTIFICATION_INTERFACE: &str = "org.freedesktop.Notifications";
+pub(crate) const NOTIFICATION_SERVICE: &str = "org.freedesktop.Notifications";
+pub(crate) const NOTIFICATION_PATH: &str = "/org/freedesktop/Notifications";
+pub(crate) const NOTIFICATION_INTERFACE: &str = "org.freedesktop.Notifications";
 const METHOD_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_APP_NAME: &str = "LG Buddy";
 const DEFAULT_EXPIRE_TIMEOUT_MS: i32 = -1;
@@ -50,8 +51,71 @@ impl NotificationCapabilities {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NotificationId(pub u32);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NotificationSignal {
+    ActionInvoked {
+        id: NotificationId,
+        action_key: String,
+    },
+    Closed {
+        id: NotificationId,
+        reason: NotificationCloseReason,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NotificationCloseReason {
+    Expired,
+    Dismissed,
+    ClosedByCall,
+    Undefined,
+    Other(u32),
+}
+
+impl NotificationCloseReason {
+    fn from_raw(value: u32) -> Self {
+        match value {
+            1 => Self::Expired,
+            2 => Self::Dismissed,
+            3 => Self::ClosedByCall,
+            4 => Self::Undefined,
+            other => Self::Other(other),
+        }
+    }
+}
+
+pub(crate) fn parse_notification_signal(signal: &BusSignal) -> Option<NotificationSignal> {
+    if signal.path != NOTIFICATION_PATH || signal.interface != NOTIFICATION_INTERFACE {
+        return None;
+    }
+
+    match signal.member.as_str() {
+        "ActionInvoked" => {
+            let [BusValue::U32(id), BusValue::String(action_key)] = signal.body.as_slice() else {
+                return None;
+            };
+
+            Some(NotificationSignal::ActionInvoked {
+                id: NotificationId(*id),
+                action_key: action_key.clone(),
+            })
+        }
+        "NotificationClosed" => {
+            let [BusValue::U32(id), BusValue::U32(reason)] = signal.body.as_slice() else {
+                return None;
+            };
+
+            Some(NotificationSignal::Closed {
+                id: NotificationId(*id),
+                reason: NotificationCloseReason::from_raw(*reason),
+            })
+        }
+        _ => None,
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NotificationError {
@@ -199,9 +263,12 @@ impl NotificationTransport for DbusNotificationTransport {
 #[cfg(test)]
 mod tests {
     use super::{
-        Notification, NotificationAction, NotificationDispatcher, NotificationError,
-        NotificationId, NotificationRequest, NotificationTransport, Notifier,
+        parse_notification_signal, Notification, NotificationAction, NotificationCloseReason,
+        NotificationDispatcher, NotificationError, NotificationId, NotificationRequest,
+        NotificationSignal, NotificationTransport, Notifier, NOTIFICATION_INTERFACE,
+        NOTIFICATION_PATH,
     };
+    use crate::session_bus::{BusSignal, BusValue};
     use std::cell::RefCell;
 
     #[derive(Debug)]
@@ -345,6 +412,52 @@ mod tests {
             err.to_string(),
             "desktop notification service error: bus unavailable"
         );
+    }
+
+    #[test]
+    fn action_invoked_signal_decodes_notification_id_and_action_key() {
+        let signal = BusSignal::new(NOTIFICATION_PATH, NOTIFICATION_INTERFACE, "ActionInvoked")
+            .with_body(vec![
+                BusValue::U32(7),
+                BusValue::String("view-release".to_string()),
+            ]);
+
+        assert_eq!(
+            parse_notification_signal(&signal),
+            Some(NotificationSignal::ActionInvoked {
+                id: NotificationId(7),
+                action_key: "view-release".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn notification_closed_signal_decodes_notification_id_and_reason() {
+        let signal = BusSignal::new(
+            NOTIFICATION_PATH,
+            NOTIFICATION_INTERFACE,
+            "NotificationClosed",
+        )
+        .with_body(vec![BusValue::U32(7), BusValue::U32(2)]);
+
+        assert_eq!(
+            parse_notification_signal(&signal),
+            Some(NotificationSignal::Closed {
+                id: NotificationId(7),
+                reason: NotificationCloseReason::Dismissed,
+            })
+        );
+    }
+
+    #[test]
+    fn notification_signal_parser_ignores_unrelated_or_malformed_signals() {
+        let unrelated = BusSignal::new("/elsewhere", NOTIFICATION_INTERFACE, "ActionInvoked")
+            .with_body(vec![BusValue::U32(7), BusValue::String("open".to_string())]);
+        let malformed = BusSignal::new(NOTIFICATION_PATH, NOTIFICATION_INTERFACE, "ActionInvoked")
+            .with_body(vec![BusValue::U32(7)]);
+
+        assert_eq!(parse_notification_signal(&unrelated), None);
+        assert_eq!(parse_notification_signal(&malformed), None);
     }
 
     impl<T: NotificationTransport> NotificationTransport for &T {

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -34,6 +34,7 @@ use crate::session_bus::{
     new_session_bus_client, new_system_bus_client, BusSignal, BusSignalMatch, SessionBusClient,
     DBUS_INTERFACE, DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
 };
+use crate::session_notifications::spawn_session_notification_service;
 use crate::sources::desktop::gnome::{
     current_idle_monitor_idletime_ms, map_screen_saver_signal, resolve_screen_saver_owner,
     screen_saver_owner_changed, GnomeBackend, SystemGnomeProbe, GNOME_SCREEN_SAVER_INTERFACE,
@@ -423,6 +424,16 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
     let backend =
         detect_backend_from_system(configured).map_err(SessionRunnerError::BackendDetection)?;
     let mut dispatcher = SessionEventDispatcher::new(executor);
+    let _session_service = match spawn_session_notification_service() {
+        Ok(service) => Some(service),
+        Err(err) => {
+            writeln!(
+                writer,
+                "LG Buddy Monitor: session notification service unavailable: {err}"
+            )?;
+            None
+        }
+    };
 
     match backend {
         ScreenBackend::Gnome => run_gnome_monitor(writer, &mut dispatcher),

--- a/crates/lg-buddy/src/session_bus.rs
+++ b/crates/lg-buddy/src/session_bus.rs
@@ -58,6 +58,7 @@ impl std::error::Error for SessionBusError {}
 pub enum BusValue {
     Bool(bool),
     UnixFd(RawFd),
+    U32(u32),
     U64(u64),
     String(String),
     Variant(Box<BusValue>),
@@ -68,6 +69,7 @@ impl BusValue {
         match self {
             Self::Bool(_) => "bool",
             Self::UnixFd(_) => "fd",
+            Self::U32(_) => "u32",
             Self::U64(_) => "u64",
             Self::String(_) => "string",
             Self::Variant(_) => "variant",
@@ -115,6 +117,20 @@ impl BusReply {
             }),
             _ => Err(SessionBusError::UnexpectedReplyShape {
                 expected: "single u64",
+                actual: "multiple values",
+            }),
+        }
+    }
+
+    pub fn single_u32(&self) -> Result<u32, SessionBusError> {
+        match self.body.as_slice() {
+            [BusValue::U32(value)] => Ok(*value),
+            [value] => Err(SessionBusError::UnexpectedReplyShape {
+                expected: "single u32",
+                actual: value.kind(),
+            }),
+            _ => Err(SessionBusError::UnexpectedReplyShape {
+                expected: "single u32",
                 actual: "multiple values",
             }),
         }
@@ -548,6 +564,7 @@ fn append_dbus_message_value(
             let fd = unsafe { dbus::arg::OwnedFd::from_raw_fd(value) };
             Ok(message.append1(fd))
         }
+        BusValue::U32(value) => Ok(message.append1(value)),
         BusValue::U64(value) => Ok(message.append1(value)),
         BusValue::String(value) => Ok(message.append1(value)),
         BusValue::Variant(_) => Err(SessionBusError::UnsupportedMessageBody {
@@ -561,19 +578,22 @@ fn bus_value_from_dbus_message_item(item: DbusMessageItem) -> Result<BusValue, S
     match item {
         DbusMessageItem::Bool(value) => Ok(BusValue::Bool(value)),
         DbusMessageItem::UnixFd(value) => Ok(BusValue::UnixFd(value.into_raw_fd())),
+        DbusMessageItem::UInt32(value) => Ok(BusValue::U32(value)),
         DbusMessageItem::UInt64(value) => Ok(BusValue::U64(value)),
         DbusMessageItem::Str(value) => Ok(BusValue::String(value)),
         DbusMessageItem::Variant(value) => {
             bus_value_from_dbus_message_item(*value).map(|value| BusValue::Variant(Box::new(value)))
         }
         other => Err(SessionBusError::UnexpectedReplyShape {
-            expected: "bool/u64/string/fd/variant",
+            expected: "bool/u32/u64/string/fd/variant",
             actual: dbus_message_item_kind(&other),
         }),
     }
 }
 
-fn bus_signal_from_dbus_message(message: DbusMessage) -> Result<BusSignal, SessionBusError> {
+pub(crate) fn bus_signal_from_dbus_message(
+    message: DbusMessage,
+) -> Result<BusSignal, SessionBusError> {
     let path = message
         .path()
         .ok_or_else(|| SessionBusError::Transport("signal missing object path".to_string()))?

--- a/crates/lg-buddy/src/session_notifications.rs
+++ b/crates/lg-buddy/src/session_notifications.rs
@@ -540,12 +540,24 @@ where
     N: Notifier + Send + 'static,
     O: ReleaseOpener + Send + 'static,
 {
+    if session_service_startup_stopped(&stop) {
+        return Ok(());
+    }
+
     let connection = DbusConnection::new_session()
         .map_err(|err| SessionServiceError::Transport(err.to_string()))?;
-    match connection
+    if session_service_startup_stopped(&stop) {
+        return Ok(());
+    }
+
+    let name_reply = connection
         .request_name(SESSION_BUS_NAME, false, false, true)
-        .map_err(|err| SessionServiceError::Transport(err.to_string()))?
-    {
+        .map_err(|err| SessionServiceError::Transport(err.to_string()))?;
+    if session_service_startup_stopped(&stop) {
+        return Ok(());
+    }
+
+    match name_reply {
         RequestNameReply::PrimaryOwner | RequestNameReply::AlreadyOwner => {}
         reply => {
             return Err(SessionServiceError::NameUnavailable {
@@ -556,8 +568,17 @@ where
     }
 
     let dispatcher = Arc::new(Mutex::new(dispatcher));
+    if session_service_startup_stopped(&stop) {
+        return Ok(());
+    }
     register_session_methods(&connection, Arc::clone(&dispatcher))?;
+    if session_service_startup_stopped(&stop) {
+        return Ok(());
+    }
     register_notification_signal_handler(&connection, dispatcher)?;
+    if session_service_startup_stopped(&stop) {
+        return Ok(());
+    }
     if ready.send(Ok(())).is_err() {
         return Ok(());
     }
@@ -570,6 +591,10 @@ where
     }
 
     Ok(())
+}
+
+fn session_service_startup_stopped(stop: &AtomicBool) -> bool {
+    stop.load(Ordering::SeqCst)
 }
 
 fn register_session_methods<N, O>(

--- a/crates/lg-buddy/src/session_notifications.rs
+++ b/crates/lg-buddy/src/session_notifications.rs
@@ -21,9 +21,12 @@ use semver::Version;
 use crate::notifications::{
     parse_notification_signal, FreedesktopNotifier, Notification, NotificationAction,
     NotificationError, NotificationId, NotificationSignal, Notifier, NOTIFICATION_INTERFACE,
-    NOTIFICATION_PATH,
+    NOTIFICATION_PATH, NOTIFICATION_SERVICE,
 };
-use crate::session_bus::{bus_signal_from_dbus_message, SessionBusError};
+use crate::session_bus::{
+    bus_signal_from_dbus_message, SessionBusError, DBUS_INTERFACE, DBUS_OBJECT_PATH,
+    DBUS_SERVICE_NAME,
+};
 use crate::updates::UpdateChannel;
 use crate::version::ReleaseChannel;
 
@@ -35,6 +38,7 @@ pub(crate) const VIEW_RELEASE_ACTION_KEY: &str = "view-release";
 
 const SESSION_PROCESS_INTERVAL: Duration = Duration::from_millis(50);
 const SESSION_START_TIMEOUT: Duration = Duration::from_secs(2);
+const NOTIFICATION_OWNER_LOOKUP_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct UpdateNotificationRequest {
@@ -487,7 +491,21 @@ where
         }
     });
 
-    match ready_receiver.recv_timeout(SESSION_START_TIMEOUT) {
+    wait_for_session_notification_service_start_with_timeout(
+        stop,
+        handle,
+        ready_receiver,
+        SESSION_START_TIMEOUT,
+    )
+}
+
+fn wait_for_session_notification_service_start_with_timeout(
+    stop: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
+    ready_receiver: mpsc::Receiver<Result<(), SessionServiceError>>,
+    timeout: Duration,
+) -> Result<SessionNotificationServiceThread, SessionServiceError> {
+    match ready_receiver.recv_timeout(timeout) {
         Ok(Ok(())) => Ok(SessionNotificationServiceThread {
             stop,
             handle: Some(handle),
@@ -499,7 +517,7 @@ where
         }
         Err(mpsc::RecvTimeoutError::Timeout) => {
             stop.store(true, Ordering::SeqCst);
-            let _ = handle.join();
+            drop(handle);
             Err(SessionServiceError::StartupTimeout)
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -656,8 +674,8 @@ where
 
     connection.start_receive(
         signal_rule,
-        Box::new(move |message, _| {
-            let signal = match bus_signal_from_dbus_message(message) {
+        Box::new(move |message, conn| {
+            let bus_signal = match bus_signal_from_dbus_message(message) {
                 Ok(signal) => signal,
                 Err(err) => {
                     eprintln!("LG Buddy Session: notification signal parse failed: {err}");
@@ -665,14 +683,27 @@ where
                 }
             };
 
-            let Some(signal) = parse_notification_signal(&signal) else {
+            let Some(notification_signal) = parse_notification_signal(&bus_signal) else {
                 return true;
             };
+
+            let notification_service_owner = match current_notification_service_owner(conn) {
+                Ok(owner) => owner,
+                Err(err) => {
+                    eprintln!("LG Buddy Session: notification signal owner check failed: {err}");
+                    return true;
+                }
+            };
+            if !notification_signal_sender_matches_owner(&bus_signal, &notification_service_owner) {
+                return true;
+            }
 
             let result = dispatcher
                 .lock()
                 .map_err(|_| UpdateNotificationError::Session(SessionServiceError::Poisoned))
-                .and_then(|mut dispatcher| dispatcher.handle_notification_signal(signal));
+                .and_then(|mut dispatcher| {
+                    dispatcher.handle_notification_signal(notification_signal)
+                });
 
             if let Err(err) = result {
                 eprintln!("LG Buddy Session: update notification action failed: {err}");
@@ -685,20 +716,55 @@ where
     Ok(())
 }
 
+fn current_notification_service_owner(
+    connection: &DbusConnection,
+) -> Result<String, SessionServiceError> {
+    let proxy = connection.with_proxy(
+        DBUS_SERVICE_NAME,
+        DBUS_OBJECT_PATH,
+        NOTIFICATION_OWNER_LOOKUP_TIMEOUT,
+    );
+    let (owner,): (String,) = proxy
+        .method_call(DBUS_INTERFACE, "GetNameOwner", (NOTIFICATION_SERVICE,))
+        .map_err(|err| {
+            SessionServiceError::Transport(format!(
+                "could not resolve `{NOTIFICATION_SERVICE}` owner: {err}"
+            ))
+        })?;
+
+    Ok(owner)
+}
+
+fn notification_signal_sender_matches_owner(
+    signal: &crate::session_bus::BusSignal,
+    owner: &str,
+) -> bool {
+    signal.sender.as_deref() == Some(owner)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        ReleaseOpener, SessionUpdateNotificationDispatcher, UpdateNotificationError,
+        notification_signal_sender_matches_owner,
+        wait_for_session_notification_service_start_with_timeout, ReleaseOpener,
+        SessionServiceError, SessionUpdateNotificationDispatcher, UpdateNotificationError,
         UpdateNotificationOutcome, UpdateNotificationRequest, VIEW_RELEASE_ACTION_KEY,
     };
     use crate::notifications::{
         Notification, NotificationCapabilities, NotificationError, NotificationId,
-        NotificationSignal, Notifier,
+        NotificationSignal, Notifier, NOTIFICATION_INTERFACE, NOTIFICATION_PATH,
     };
+    use crate::session_bus::BusSignal;
     use crate::updates::UpdateChannel;
     use crate::version::ReleaseChannel;
     use semver::Version;
     use std::cell::RefCell;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    };
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     #[derive(Debug)]
     struct RecordingNotifier {
@@ -872,6 +938,45 @@ mod tests {
             .expect_err("notification should fail");
 
         assert_eq!(dispatcher.pending_len(), 0);
+    }
+
+    #[test]
+    fn startup_timeout_does_not_join_blocked_worker() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (ready_sender, ready_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let _ready_sender = ready_sender;
+            let _ = release_receiver.recv_timeout(Duration::from_secs(5));
+        });
+
+        let started = Instant::now();
+        let result = wait_for_session_notification_service_start_with_timeout(
+            Arc::clone(&stop),
+            handle,
+            ready_receiver,
+            Duration::from_millis(20),
+        );
+
+        assert!(matches!(result, Err(SessionServiceError::StartupTimeout)));
+        assert!(stop.load(Ordering::SeqCst));
+        assert!(started.elapsed() < Duration::from_millis(500));
+        release_sender
+            .send(())
+            .expect("blocked worker should still be releasable");
+    }
+
+    #[test]
+    fn notification_signal_sender_must_match_notification_daemon_owner() {
+        let signal = BusSignal::new(NOTIFICATION_PATH, NOTIFICATION_INTERFACE, "ActionInvoked")
+            .with_sender(":1.42");
+
+        assert!(notification_signal_sender_matches_owner(&signal, ":1.42"));
+        assert!(!notification_signal_sender_matches_owner(&signal, ":1.99"));
+        assert!(!notification_signal_sender_matches_owner(
+            &BusSignal::new(NOTIFICATION_PATH, NOTIFICATION_INTERFACE, "ActionInvoked"),
+            ":1.42",
+        ));
     }
 
     #[test]

--- a/crates/lg-buddy/src/session_notifications.rs
+++ b/crates/lg-buddy/src/session_notifications.rs
@@ -1,0 +1,937 @@
+use std::collections::HashMap;
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::path::PathBuf;
+use std::process::{Command as ProcessCommand, Stdio};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc, Arc, Mutex,
+};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use dbus::blocking::stdintf::org_freedesktop_dbus::RequestNameReply;
+use dbus::blocking::Connection as DbusConnection;
+use dbus::channel::MatchingReceiver;
+use dbus::message::{MatchRule as DbusMatchRule, MessageType as DbusMessageType};
+use dbus_crossroads::{Crossroads, MethodErr};
+use semver::Version;
+
+use crate::notifications::{
+    parse_notification_signal, FreedesktopNotifier, Notification, NotificationAction,
+    NotificationError, NotificationId, NotificationSignal, Notifier, NOTIFICATION_INTERFACE,
+    NOTIFICATION_PATH,
+};
+use crate::session_bus::{bus_signal_from_dbus_message, SessionBusError};
+use crate::updates::UpdateChannel;
+use crate::version::ReleaseChannel;
+
+pub(crate) const SESSION_BUS_NAME: &str = "io.github.Staphylococcus.LGBuddy";
+pub(crate) const SESSION_OBJECT_PATH: &str = "/io/github/Staphylococcus/LGBuddy/Session";
+pub(crate) const SESSION_INTERFACE: &str = "io.github.Staphylococcus.LGBuddy.Session1";
+pub(crate) const SHOW_UPDATE_NOTIFICATION_METHOD: &str = "ShowUpdateNotification";
+pub(crate) const VIEW_RELEASE_ACTION_KEY: &str = "view-release";
+
+const SESSION_PROCESS_INTERVAL: Duration = Duration::from_millis(50);
+const SESSION_START_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UpdateNotificationRequest {
+    check_channel: UpdateChannel,
+    current_version: Version,
+    current_channel: ReleaseChannel,
+    latest_version: Version,
+    latest_channel: UpdateChannel,
+    release_url: String,
+}
+
+impl UpdateNotificationRequest {
+    pub(crate) fn new(
+        check_channel: UpdateChannel,
+        current_version: Version,
+        current_channel: ReleaseChannel,
+        latest_version: Version,
+        latest_channel: UpdateChannel,
+        release_url: impl Into<String>,
+    ) -> Result<Self, UpdateNotificationError> {
+        let release_url = release_url.into();
+        if !valid_release_url(&release_url) {
+            return Err(UpdateNotificationError::InvalidRequest(format!(
+                "invalid release URL `{release_url}`"
+            )));
+        }
+
+        Ok(Self {
+            check_channel,
+            current_version,
+            current_channel,
+            latest_version,
+            latest_channel,
+            release_url,
+        })
+    }
+
+    pub(crate) fn from_dbus_fields(
+        check_channel: String,
+        current_version: String,
+        current_channel: String,
+        latest_version: String,
+        latest_channel: String,
+        release_url: String,
+    ) -> Result<Self, UpdateNotificationError> {
+        Self::new(
+            parse_update_channel(&check_channel)?,
+            parse_version("current version", &current_version)?,
+            parse_release_channel(&current_channel)?,
+            parse_version("latest version", &latest_version)?,
+            parse_update_channel(&latest_channel)?,
+            release_url,
+        )
+    }
+
+    pub(crate) fn to_dbus_fields(&self) -> (String, String, String, String, String, String) {
+        (
+            self.check_channel.as_str().to_string(),
+            self.current_version.to_string(),
+            self.current_channel.as_str().to_string(),
+            self.latest_version.to_string(),
+            self.latest_channel.as_str().to_string(),
+            self.release_url.clone(),
+        )
+    }
+
+    pub(crate) fn release_url(&self) -> &str {
+        &self.release_url
+    }
+
+    fn notification(&self, actions_supported: bool) -> Notification {
+        let mut notification = Notification::new(
+            "LG Buddy update available",
+            format!(
+                "LG Buddy {} ({}) is available.\nCurrent: {} ({})\n{}",
+                self.latest_version,
+                self.latest_channel.as_str(),
+                self.current_version,
+                self.current_channel.as_str(),
+                self.release_url
+            ),
+        );
+
+        if actions_supported {
+            notification.actions = vec![NotificationAction {
+                key: VIEW_RELEASE_ACTION_KEY.to_string(),
+                label: "View Release".to_string(),
+            }];
+        }
+
+        notification
+    }
+}
+
+fn valid_release_url(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty() && (trimmed.starts_with("https://") || trimmed.starts_with("http://"))
+}
+
+fn parse_update_channel(value: &str) -> Result<UpdateChannel, UpdateNotificationError> {
+    match value {
+        "stable" => Ok(UpdateChannel::Stable),
+        "prerelease" => Ok(UpdateChannel::Prerelease),
+        other => Err(UpdateNotificationError::InvalidRequest(format!(
+            "invalid update channel `{other}`"
+        ))),
+    }
+}
+
+fn parse_release_channel(value: &str) -> Result<ReleaseChannel, UpdateNotificationError> {
+    match value {
+        "dev" => Ok(ReleaseChannel::Dev),
+        "prerelease" => Ok(ReleaseChannel::Prerelease),
+        "stable" => Ok(ReleaseChannel::Stable),
+        other => Err(UpdateNotificationError::InvalidRequest(format!(
+            "invalid release channel `{other}`"
+        ))),
+    }
+}
+
+fn parse_version(label: &'static str, value: &str) -> Result<Version, UpdateNotificationError> {
+    Version::parse(value).map_err(|err| {
+        UpdateNotificationError::InvalidRequest(format!("invalid {label} `{value}`: {err}"))
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UpdateNotificationOutcome {
+    Sent,
+}
+
+impl UpdateNotificationOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sent => "sent",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, UpdateNotificationError> {
+        match value {
+            "sent" => Ok(Self::Sent),
+            other => Err(UpdateNotificationError::Transport(format!(
+                "LG Buddy session service returned unknown update notification outcome `{other}`"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum UpdateNotificationError {
+    InvalidRequest(String),
+    Transport(String),
+    Notification(NotificationError),
+    Session(SessionServiceError),
+    OpenRelease { url: String, message: String },
+}
+
+impl fmt::Display for UpdateNotificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest(message) => {
+                write!(f, "invalid update notification request: {message}")
+            }
+            Self::Transport(message) => {
+                write!(f, "could not request update notification from LG Buddy session service: {message}")
+            }
+            Self::Notification(err) => write!(f, "{err}"),
+            Self::Session(err) => write!(f, "{err}"),
+            Self::OpenRelease { url, message } => {
+                write!(f, "could not open release URL `{url}`: {message}")
+            }
+        }
+    }
+}
+
+impl Error for UpdateNotificationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Notification(err) => Some(err),
+            Self::Session(err) => Some(err),
+            Self::InvalidRequest(_) | Self::Transport(_) | Self::OpenRelease { .. } => None,
+        }
+    }
+}
+
+impl From<NotificationError> for UpdateNotificationError {
+    fn from(value: NotificationError) -> Self {
+        Self::Notification(value)
+    }
+}
+
+impl From<SessionServiceError> for UpdateNotificationError {
+    fn from(value: SessionServiceError) -> Self {
+        Self::Session(value)
+    }
+}
+
+pub(crate) trait UpdateNotificationHandoff {
+    fn show_update_notification(
+        &self,
+        request: &UpdateNotificationRequest,
+    ) -> Result<UpdateNotificationOutcome, UpdateNotificationError>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct SessionBusUpdateNotificationHandoff;
+
+impl UpdateNotificationHandoff for SessionBusUpdateNotificationHandoff {
+    fn show_update_notification(
+        &self,
+        request: &UpdateNotificationRequest,
+    ) -> Result<UpdateNotificationOutcome, UpdateNotificationError> {
+        let connection = DbusConnection::new_session()
+            .map_err(|err| UpdateNotificationError::Transport(err.to_string()))?;
+        let proxy = connection.with_proxy(
+            SESSION_BUS_NAME,
+            SESSION_OBJECT_PATH,
+            Duration::from_secs(2),
+        );
+        let (check_channel, current_version, current_channel, latest_version, latest_channel, url) =
+            request.to_dbus_fields();
+        let (outcome,): (String,) = proxy
+            .method_call(
+                SESSION_INTERFACE,
+                SHOW_UPDATE_NOTIFICATION_METHOD,
+                (
+                    check_channel,
+                    current_version,
+                    current_channel,
+                    latest_version,
+                    latest_channel,
+                    url,
+                ),
+            )
+            .map_err(|err| UpdateNotificationError::Transport(err.to_string()))?;
+
+        UpdateNotificationOutcome::parse(&outcome)
+    }
+}
+
+pub(crate) trait ReleaseOpener {
+    fn open_release(&self, url: &str) -> Result<(), UpdateNotificationError>;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SystemReleaseOpener {
+    command_path: PathBuf,
+}
+
+impl Default for SystemReleaseOpener {
+    fn default() -> Self {
+        Self {
+            command_path: env::var_os("LG_BUDDY_XDG_OPEN")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("xdg-open")),
+        }
+    }
+}
+
+impl ReleaseOpener for SystemReleaseOpener {
+    fn open_release(&self, url: &str) -> Result<(), UpdateNotificationError> {
+        let output = ProcessCommand::new(&self.command_path)
+            .arg(url)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|err| UpdateNotificationError::OpenRelease {
+                url: url.to_string(),
+                message: err.to_string(),
+            })?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(UpdateNotificationError::OpenRelease {
+                url: url.to_string(),
+                message: if stderr.is_empty() {
+                    format!("opener exited with status {}", output.status)
+                } else {
+                    stderr
+                },
+            })
+        }
+    }
+}
+
+pub(crate) struct SessionUpdateNotificationDispatcher<N, O> {
+    notifier: N,
+    opener: O,
+    pending: HashMap<NotificationId, UpdateNotificationRequest>,
+}
+
+impl<N, O> SessionUpdateNotificationDispatcher<N, O> {
+    fn new(notifier: N, opener: O) -> Self {
+        Self {
+            notifier,
+            opener,
+            pending: HashMap::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+impl<N, O> SessionUpdateNotificationDispatcher<N, O>
+where
+    N: Notifier,
+    O: ReleaseOpener,
+{
+    fn show_update_notification(
+        &mut self,
+        request: UpdateNotificationRequest,
+    ) -> Result<UpdateNotificationOutcome, UpdateNotificationError> {
+        let capabilities = self.notifier.capabilities()?;
+        let notification = request.notification(capabilities.actions);
+        let notification_id = self.notifier.notify(&notification)?;
+
+        if capabilities.actions {
+            self.pending.insert(notification_id, request);
+        }
+
+        Ok(UpdateNotificationOutcome::Sent)
+    }
+
+    fn handle_notification_signal(
+        &mut self,
+        signal: NotificationSignal,
+    ) -> Result<Option<SessionNotificationEvent>, UpdateNotificationError> {
+        match signal {
+            NotificationSignal::ActionInvoked { id, action_key } => {
+                let Some(request) = self.pending.remove(&id) else {
+                    return Ok(None);
+                };
+
+                if action_key == VIEW_RELEASE_ACTION_KEY {
+                    self.opener.open_release(request.release_url())?;
+                    Ok(Some(SessionNotificationEvent::ReleaseOpened))
+                } else {
+                    Ok(Some(SessionNotificationEvent::UnknownAction))
+                }
+            }
+            NotificationSignal::Closed { id, .. } => {
+                if self.pending.remove(&id).is_some() {
+                    Ok(Some(SessionNotificationEvent::Closed))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionNotificationEvent {
+    ReleaseOpened,
+    Closed,
+    UnknownAction,
+}
+
+#[derive(Debug, Clone)]
+pub enum SessionServiceError {
+    Transport(String),
+    NameUnavailable {
+        name: &'static str,
+        reply: RequestNameReply,
+    },
+    StartupTimeout,
+    Poisoned,
+}
+
+impl fmt::Display for SessionServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transport(message) => {
+                write!(f, "LG Buddy session D-Bus service error: {message}")
+            }
+            Self::NameUnavailable { name, reply } => {
+                write!(
+                    f,
+                    "could not own LG Buddy session D-Bus name `{name}`: {reply:?}"
+                )
+            }
+            Self::StartupTimeout => write!(f, "timed out starting LG Buddy session D-Bus service"),
+            Self::Poisoned => write!(f, "LG Buddy session notification state lock was poisoned"),
+        }
+    }
+}
+
+impl Error for SessionServiceError {}
+
+impl From<SessionBusError> for SessionServiceError {
+    fn from(value: SessionBusError) -> Self {
+        Self::Transport(value.to_string())
+    }
+}
+
+pub(crate) struct SessionNotificationServiceThread {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for SessionNotificationServiceThread {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+pub(crate) fn spawn_session_notification_service(
+) -> Result<SessionNotificationServiceThread, SessionServiceError> {
+    let dispatcher = SessionUpdateNotificationDispatcher::new(
+        FreedesktopNotifier,
+        SystemReleaseOpener::default(),
+    );
+    spawn_session_notification_service_with(dispatcher)
+}
+
+fn spawn_session_notification_service_with<N, O>(
+    dispatcher: SessionUpdateNotificationDispatcher<N, O>,
+) -> Result<SessionNotificationServiceThread, SessionServiceError>
+where
+    N: Notifier + Send + 'static,
+    O: ReleaseOpener + Send + 'static,
+{
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = Arc::clone(&stop);
+    let started = Arc::new(AtomicBool::new(false));
+    let thread_started = Arc::clone(&started);
+    let (ready_sender, ready_receiver) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let loop_ready = ready_sender.clone();
+        let result = run_session_notification_service_loop(
+            dispatcher,
+            thread_stop,
+            loop_ready,
+            thread_started,
+        );
+        if let Err(err) = result {
+            if started.load(Ordering::SeqCst) {
+                eprintln!("LG Buddy Session: {err}");
+            } else {
+                let _ = ready_sender.send(Err(err));
+            }
+        }
+    });
+
+    match ready_receiver.recv_timeout(SESSION_START_TIMEOUT) {
+        Ok(Ok(())) => Ok(SessionNotificationServiceThread {
+            stop,
+            handle: Some(handle),
+        }),
+        Ok(Err(err)) => {
+            stop.store(true, Ordering::SeqCst);
+            let _ = handle.join();
+            Err(err)
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            stop.store(true, Ordering::SeqCst);
+            let _ = handle.join();
+            Err(SessionServiceError::StartupTimeout)
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            stop.store(true, Ordering::SeqCst);
+            let _ = handle.join();
+            Err(SessionServiceError::Transport(
+                "session service thread exited before startup completed".to_string(),
+            ))
+        }
+    }
+}
+
+fn run_session_notification_service_loop<N, O>(
+    dispatcher: SessionUpdateNotificationDispatcher<N, O>,
+    stop: Arc<AtomicBool>,
+    ready: mpsc::Sender<Result<(), SessionServiceError>>,
+    started: Arc<AtomicBool>,
+) -> Result<(), SessionServiceError>
+where
+    N: Notifier + Send + 'static,
+    O: ReleaseOpener + Send + 'static,
+{
+    let connection = DbusConnection::new_session()
+        .map_err(|err| SessionServiceError::Transport(err.to_string()))?;
+    match connection
+        .request_name(SESSION_BUS_NAME, false, false, true)
+        .map_err(|err| SessionServiceError::Transport(err.to_string()))?
+    {
+        RequestNameReply::PrimaryOwner | RequestNameReply::AlreadyOwner => {}
+        reply => {
+            return Err(SessionServiceError::NameUnavailable {
+                name: SESSION_BUS_NAME,
+                reply,
+            })
+        }
+    }
+
+    let dispatcher = Arc::new(Mutex::new(dispatcher));
+    register_session_methods(&connection, Arc::clone(&dispatcher))?;
+    register_notification_signal_handler(&connection, dispatcher)?;
+    if ready.send(Ok(())).is_err() {
+        return Ok(());
+    }
+    started.store(true, Ordering::SeqCst);
+
+    while !stop.load(Ordering::SeqCst) {
+        connection
+            .process(SESSION_PROCESS_INTERVAL)
+            .map_err(|err| SessionServiceError::Transport(err.to_string()))?;
+    }
+
+    Ok(())
+}
+
+fn register_session_methods<N, O>(
+    connection: &DbusConnection,
+    dispatcher: Arc<Mutex<SessionUpdateNotificationDispatcher<N, O>>>,
+) -> Result<(), SessionServiceError>
+where
+    N: Notifier + Send + 'static,
+    O: ReleaseOpener + Send + 'static,
+{
+    let mut crossroads = Crossroads::new();
+    let method_dispatcher = Arc::clone(&dispatcher);
+    let iface = crossroads.register(SESSION_INTERFACE, move |builder| {
+        let method_dispatcher = Arc::clone(&method_dispatcher);
+        builder.method(
+            SHOW_UPDATE_NOTIFICATION_METHOD,
+            (
+                "check_channel",
+                "current_version",
+                "current_channel",
+                "latest_version",
+                "latest_channel",
+                "release_url",
+            ),
+            ("outcome",),
+            move |_,
+                  _,
+                  (
+                check_channel,
+                current_version,
+                current_channel,
+                latest_version,
+                latest_channel,
+                release_url,
+            ): (String, String, String, String, String, String)| {
+                let request = UpdateNotificationRequest::from_dbus_fields(
+                    check_channel,
+                    current_version,
+                    current_channel,
+                    latest_version,
+                    latest_channel,
+                    release_url,
+                )
+                .map_err(|err| MethodErr::failed(&err.to_string()))?;
+
+                let outcome = method_dispatcher
+                    .lock()
+                    .map_err(|_| MethodErr::failed(&SessionServiceError::Poisoned.to_string()))?
+                    .show_update_notification(request)
+                    .map_err(|err| MethodErr::failed(&err.to_string()))?;
+
+                Ok((outcome.as_str().to_string(),))
+            },
+        );
+    });
+    crossroads.insert(SESSION_OBJECT_PATH, &[iface], ());
+
+    let shared_crossroads = Arc::new(Mutex::new(crossroads));
+    let crossroads_receiver = Arc::clone(&shared_crossroads);
+    connection.start_receive(
+        DbusMatchRule::new_method_call(),
+        Box::new(move |message, conn| {
+            let result = crossroads_receiver
+                .lock()
+                .map_err(|_| SessionServiceError::Poisoned)
+                .and_then(|mut crossroads| {
+                    crossroads
+                        .handle_message(message, conn)
+                        .map(|_| ())
+                        .map_err(|_| {
+                            SessionServiceError::Transport(
+                                "failed to handle session D-Bus method call".to_string(),
+                            )
+                        })
+                });
+
+            if let Err(err) = result {
+                eprintln!("LG Buddy Session: {err}");
+            }
+            true
+        }),
+    );
+
+    Ok(())
+}
+
+fn register_notification_signal_handler<N, O>(
+    connection: &DbusConnection,
+    dispatcher: Arc<Mutex<SessionUpdateNotificationDispatcher<N, O>>>,
+) -> Result<(), SessionServiceError>
+where
+    N: Notifier + Send + 'static,
+    O: ReleaseOpener + Send + 'static,
+{
+    let signal_rule = DbusMatchRule::new()
+        .with_type(DbusMessageType::Signal)
+        .with_path(NOTIFICATION_PATH)
+        .with_interface(NOTIFICATION_INTERFACE);
+    connection
+        .add_match_no_cb(&signal_rule.match_str())
+        .map_err(|err| SessionServiceError::Transport(err.to_string()))?;
+
+    connection.start_receive(
+        signal_rule,
+        Box::new(move |message, _| {
+            let signal = match bus_signal_from_dbus_message(message) {
+                Ok(signal) => signal,
+                Err(err) => {
+                    eprintln!("LG Buddy Session: notification signal parse failed: {err}");
+                    return true;
+                }
+            };
+
+            let Some(signal) = parse_notification_signal(&signal) else {
+                return true;
+            };
+
+            let result = dispatcher
+                .lock()
+                .map_err(|_| UpdateNotificationError::Session(SessionServiceError::Poisoned))
+                .and_then(|mut dispatcher| dispatcher.handle_notification_signal(signal));
+
+            if let Err(err) = result {
+                eprintln!("LG Buddy Session: update notification action failed: {err}");
+            }
+
+            true
+        }),
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ReleaseOpener, SessionUpdateNotificationDispatcher, UpdateNotificationError,
+        UpdateNotificationOutcome, UpdateNotificationRequest, VIEW_RELEASE_ACTION_KEY,
+    };
+    use crate::notifications::{
+        Notification, NotificationCapabilities, NotificationError, NotificationId,
+        NotificationSignal, Notifier,
+    };
+    use crate::updates::UpdateChannel;
+    use crate::version::ReleaseChannel;
+    use semver::Version;
+    use std::cell::RefCell;
+
+    #[derive(Debug)]
+    struct RecordingNotifier {
+        capabilities: NotificationCapabilities,
+        result: Result<NotificationId, NotificationError>,
+        notifications: RefCell<Vec<Notification>>,
+    }
+
+    impl RecordingNotifier {
+        fn new(actions: bool) -> Self {
+            Self {
+                capabilities: NotificationCapabilities { actions },
+                result: Ok(NotificationId(7)),
+                notifications: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                capabilities: NotificationCapabilities { actions: true },
+                result: Err(NotificationError::Transport("bus unavailable".to_string())),
+                notifications: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn notifications(&self) -> Vec<Notification> {
+            self.notifications.borrow().clone()
+        }
+    }
+
+    impl Notifier for RecordingNotifier {
+        fn capabilities(&self) -> Result<NotificationCapabilities, NotificationError> {
+            Ok(self.capabilities)
+        }
+
+        fn notify(&self, notification: &Notification) -> Result<NotificationId, NotificationError> {
+            self.notifications.borrow_mut().push(notification.clone());
+            self.result.clone()
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingOpener {
+        opened: RefCell<Vec<String>>,
+        fail: bool,
+    }
+
+    impl RecordingOpener {
+        fn failing() -> Self {
+            Self {
+                opened: RefCell::new(Vec::new()),
+                fail: true,
+            }
+        }
+
+        fn opened(&self) -> Vec<String> {
+            self.opened.borrow().clone()
+        }
+    }
+
+    impl ReleaseOpener for RecordingOpener {
+        fn open_release(&self, url: &str) -> Result<(), UpdateNotificationError> {
+            self.opened.borrow_mut().push(url.to_string());
+            if self.fail {
+                Err(UpdateNotificationError::OpenRelease {
+                    url: url.to_string(),
+                    message: "open failed".to_string(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn request() -> UpdateNotificationRequest {
+        UpdateNotificationRequest::new(
+            UpdateChannel::Stable,
+            Version::parse("1.1.0").unwrap(),
+            ReleaseChannel::Stable,
+            Version::parse("1.1.1").unwrap(),
+            UpdateChannel::Stable,
+            "https://github.test/releases/tag/v1.1.1",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn request_round_trips_through_dbus_fields() {
+        let request = request();
+        let fields = request.to_dbus_fields();
+
+        let parsed = UpdateNotificationRequest::from_dbus_fields(
+            fields.0, fields.1, fields.2, fields.3, fields.4, fields.5,
+        )
+        .expect("request should parse");
+
+        assert_eq!(parsed, request);
+    }
+
+    #[test]
+    fn invalid_request_fields_are_rejected() {
+        assert!(UpdateNotificationRequest::from_dbus_fields(
+            "nightly".to_string(),
+            "1.1.0".to_string(),
+            "stable".to_string(),
+            "1.1.1".to_string(),
+            "stable".to_string(),
+            "https://github.test/releases/tag/v1.1.1".to_string(),
+        )
+        .is_err());
+        assert!(UpdateNotificationRequest::from_dbus_fields(
+            "stable".to_string(),
+            "not-semver".to_string(),
+            "stable".to_string(),
+            "1.1.1".to_string(),
+            "stable".to_string(),
+            "https://github.test/releases/tag/v1.1.1".to_string(),
+        )
+        .is_err());
+        assert!(UpdateNotificationRequest::from_dbus_fields(
+            "stable".to_string(),
+            "1.1.0".to_string(),
+            "stable".to_string(),
+            "1.1.1".to_string(),
+            "stable".to_string(),
+            "".to_string(),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn action_capable_notification_attaches_view_release_button() {
+        let notifier = RecordingNotifier::new(true);
+        let opener = RecordingOpener::default();
+        let mut dispatcher = SessionUpdateNotificationDispatcher::new(notifier, opener);
+
+        let outcome = dispatcher
+            .show_update_notification(request())
+            .expect("notification should send");
+
+        assert_eq!(outcome, UpdateNotificationOutcome::Sent);
+        let notifications = dispatcher.notifier.notifications();
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0].actions.len(), 1);
+        assert_eq!(notifications[0].actions[0].key, VIEW_RELEASE_ACTION_KEY);
+        assert_eq!(dispatcher.pending_len(), 1);
+    }
+
+    #[test]
+    fn passive_notification_does_not_store_pending_action_state() {
+        let notifier = RecordingNotifier::new(false);
+        let opener = RecordingOpener::default();
+        let mut dispatcher = SessionUpdateNotificationDispatcher::new(notifier, opener);
+
+        dispatcher
+            .show_update_notification(request())
+            .expect("notification should send");
+
+        assert!(dispatcher.notifier.notifications()[0].actions.is_empty());
+        assert_eq!(dispatcher.pending_len(), 0);
+    }
+
+    #[test]
+    fn notification_failure_does_not_store_pending_state() {
+        let notifier = RecordingNotifier::failing();
+        let opener = RecordingOpener::default();
+        let mut dispatcher = SessionUpdateNotificationDispatcher::new(notifier, opener);
+
+        dispatcher
+            .show_update_notification(request())
+            .expect_err("notification should fail");
+
+        assert_eq!(dispatcher.pending_len(), 0);
+    }
+
+    #[test]
+    fn view_release_action_opens_url_and_clears_pending_state() {
+        let notifier = RecordingNotifier::new(true);
+        let opener = RecordingOpener::default();
+        let mut dispatcher = SessionUpdateNotificationDispatcher::new(notifier, opener);
+        dispatcher
+            .show_update_notification(request())
+            .expect("notification should send");
+
+        dispatcher
+            .handle_notification_signal(NotificationSignal::ActionInvoked {
+                id: NotificationId(7),
+                action_key: VIEW_RELEASE_ACTION_KEY.to_string(),
+            })
+            .expect("action should succeed");
+
+        assert_eq!(
+            dispatcher.opener.opened(),
+            vec!["https://github.test/releases/tag/v1.1.1".to_string()]
+        );
+        assert_eq!(dispatcher.pending_len(), 0);
+    }
+
+    #[test]
+    fn opener_failure_clears_pending_state_and_reports_error() {
+        let notifier = RecordingNotifier::new(true);
+        let opener = RecordingOpener::failing();
+        let mut dispatcher = SessionUpdateNotificationDispatcher::new(notifier, opener);
+        dispatcher
+            .show_update_notification(request())
+            .expect("notification should send");
+
+        dispatcher
+            .handle_notification_signal(NotificationSignal::ActionInvoked {
+                id: NotificationId(7),
+                action_key: VIEW_RELEASE_ACTION_KEY.to_string(),
+            })
+            .expect_err("open should fail");
+
+        assert_eq!(dispatcher.pending_len(), 0);
+    }
+
+    #[test]
+    fn closed_signal_clears_pending_state() {
+        let notifier = RecordingNotifier::new(true);
+        let opener = RecordingOpener::default();
+        let mut dispatcher = SessionUpdateNotificationDispatcher::new(notifier, opener);
+        dispatcher
+            .show_update_notification(request())
+            .expect("notification should send");
+
+        dispatcher
+            .handle_notification_signal(NotificationSignal::Closed {
+                id: NotificationId(7),
+                reason: crate::notifications::NotificationCloseReason::Dismissed,
+            })
+            .expect("close should succeed");
+
+        assert_eq!(dispatcher.pending_len(), 0);
+    }
+}

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -282,7 +282,7 @@ impl fmt::Display for UpdatesDeferredFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Cache(err) => write!(f, "update cache failed: {err}"),
-            Self::Notification(err) => write!(f, "desktop notification failed: {err}"),
+            Self::Notification(err) => write!(f, "update notification handoff failed: {err}"),
         }
     }
 }
@@ -364,7 +364,7 @@ impl fmt::Display for UpdatesError {
 
                 Ok(())
             }
-            Self::Notification(err) => write!(f, "could not send update notification: {err}"),
+            Self::Notification(err) => write!(f, "could not request update notification: {err}"),
             Self::Io(err) => write!(f, "{err}"),
         }
     }
@@ -2042,7 +2042,7 @@ mod tests {
         ));
         assert_eq!(
             err.to_string(),
-            "update check completed with deferred failure: desktop notification failed: could not request update notification from LG Buddy session service: bus unavailable"
+            "update check completed with deferred failure: update notification handoff failed: could not request update notification from LG Buddy session service: bus unavailable"
         );
     }
 

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -9,7 +9,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use crate::notifications::{FreedesktopNotifier, Notification, NotificationError, Notifier};
+use crate::session_notifications::{
+    SessionBusUpdateNotificationHandoff, UpdateNotificationError, UpdateNotificationHandoff,
+    UpdateNotificationRequest,
+};
 use crate::version::{ReleaseChannel, VersionInfo};
 
 const GITHUB_RELEASES_API_BASE: &str =
@@ -265,14 +268,14 @@ pub enum UpdatesError {
     },
     CacheEncode(serde_json::Error),
     DeferredFailures(Vec<UpdatesDeferredFailure>),
-    Notification(NotificationError),
+    Notification(UpdateNotificationError),
     Io(io::Error),
 }
 
 #[derive(Debug)]
 pub enum UpdatesDeferredFailure {
     Cache(Box<UpdatesError>),
-    Notification(NotificationError),
+    Notification(UpdateNotificationError),
 }
 
 impl fmt::Display for UpdatesDeferredFailure {
@@ -472,6 +475,7 @@ struct CachedReleaseInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateCheckResult {
+    check_channel: UpdateChannel,
     current_version: Version,
     current_channel: ReleaseChannel,
     latest: ReleaseInfo,
@@ -499,17 +503,14 @@ impl UpdateCheckResult {
         )
     }
 
-    fn notification(&self) -> Notification {
-        Notification::new(
-            "LG Buddy update available",
-            format!(
-                "LG Buddy {} ({}) is available.\nCurrent: {} ({})\n{}",
-                self.latest.version(),
-                self.latest.channel().as_str(),
-                self.current_version,
-                self.current_channel.as_str(),
-                self.latest.url()
-            ),
+    fn notification_request(&self) -> Result<UpdateNotificationRequest, UpdateNotificationError> {
+        UpdateNotificationRequest::new(
+            self.check_channel,
+            self.current_version.clone(),
+            self.current_channel,
+            self.latest.version().clone(),
+            self.latest.channel(),
+            self.latest.url().to_string(),
         )
     }
 }
@@ -591,6 +592,10 @@ impl GitHubReleasesClient for UreqGitHubReleasesClient {
 
         match result {
             Ok(response) => {
+                if response.status() == 304 {
+                    return Ok(GitHubReleaseResponse::NotModified);
+                }
+
                 let etag = response.header("ETag").map(str::to_string);
                 response
                     .into_string()
@@ -748,7 +753,7 @@ pub fn run_updates_command<W: io::Write>(
 ) -> Result<(), UpdatesError> {
     let client = UreqGitHubReleasesClient::default();
     let version = VersionInfo::current();
-    let notifier = FreedesktopNotifier;
+    let notification_handoff = SessionBusUpdateNotificationHandoff;
     let cache_store = DefaultUpdateCacheStore::from_env();
 
     run_updates_command_with(
@@ -756,7 +761,7 @@ pub fn run_updates_command<W: io::Write>(
         writer,
         version,
         &client,
-        &notifier,
+        &notification_handoff,
         &cache_store,
         current_unix_seconds(),
     )
@@ -765,7 +770,7 @@ pub fn run_updates_command<W: io::Write>(
 fn run_updates_command_with<
     W: io::Write,
     C: GitHubReleasesClient,
-    N: Notifier,
+    N: UpdateNotificationHandoff,
     S: UpdateCacheStore,
 >(
     command: UpdatesCommand,
@@ -789,7 +794,10 @@ fn run_updates_command_with<
 
     writer.write_all(result.render().as_bytes())?;
     if notify && result.update_available() {
-        if let Err(err) = notifier.notify(&result.notification()) {
+        let notification_result = result
+            .notification_request()
+            .and_then(|request| notifier.show_update_notification(&request));
+        if let Err(err) = notification_result {
             deferred_failures.push(UpdatesDeferredFailure::Notification(err));
         }
     }
@@ -833,6 +841,7 @@ fn check_updates_with_cache<C: GitHubReleasesClient>(
             let latest = fetch_latest_release(channel, current, client, cache, now_unix_seconds)?;
 
             Ok(UpdateCheckResult {
+                check_channel: channel,
                 current_version,
                 current_channel: current.channel(),
                 latest,
@@ -972,20 +981,25 @@ mod tests {
         DefaultUpdateCacheStore, FileUpdateCacheStore, GitHubReleaseResponse, GitHubReleasesClient,
         ReleaseEndpoint, UpdateCachePathError, UpdateCachePathSources, UpdateCacheStore,
         UpdateChannel, UpdateCheckCache, UpdatesCommand, UpdatesDeferredFailure, UpdatesError,
+        UreqGitHubReleasesClient, PRERELEASE_PAGE_SIZE,
     };
-    use crate::notifications::{
-        Notification, NotificationCapabilities, NotificationError, NotificationId, Notifier,
+    use crate::session_notifications::{
+        UpdateNotificationError, UpdateNotificationHandoff, UpdateNotificationOutcome,
+        UpdateNotificationRequest,
     };
     use crate::version::{ReleaseChannel, VersionInfo};
     use std::cell::RefCell;
     use std::fs;
-    use std::io;
+    use std::io::{self, Read, Write};
+    use std::net::TcpListener;
     use std::path::PathBuf;
     use std::process;
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         Mutex, OnceLock,
     };
+    use std::thread;
+    use std::time::Duration;
 
     const TEST_NOW: u64 = 1_778_234_400;
 
@@ -1094,19 +1108,19 @@ mod tests {
     }
 
     struct RecordingNotifier {
-        notifications: RefCell<Vec<Notification>>,
-        result: Result<NotificationId, NotificationError>,
+        notifications: RefCell<Vec<UpdateNotificationRequest>>,
+        result: Result<UpdateNotificationOutcome, UpdateNotificationError>,
     }
 
     impl RecordingNotifier {
         fn failing(message: &str) -> Self {
             Self {
                 notifications: RefCell::new(Vec::new()),
-                result: Err(NotificationError::Transport(message.to_string())),
+                result: Err(UpdateNotificationError::Transport(message.to_string())),
             }
         }
 
-        fn notifications(&self) -> Vec<Notification> {
+        fn notifications(&self) -> Vec<UpdateNotificationRequest> {
             self.notifications.borrow().clone()
         }
     }
@@ -1115,18 +1129,17 @@ mod tests {
         fn default() -> Self {
             Self {
                 notifications: RefCell::new(Vec::new()),
-                result: Ok(NotificationId(1)),
+                result: Ok(UpdateNotificationOutcome::Sent),
             }
         }
     }
 
-    impl Notifier for RecordingNotifier {
-        fn capabilities(&self) -> Result<NotificationCapabilities, NotificationError> {
-            Ok(NotificationCapabilities { actions: true })
-        }
-
-        fn notify(&self, notification: &Notification) -> Result<NotificationId, NotificationError> {
-            self.notifications.borrow_mut().push(notification.clone());
+    impl UpdateNotificationHandoff for RecordingNotifier {
+        fn show_update_notification(
+            &self,
+            request: &UpdateNotificationRequest,
+        ) -> Result<UpdateNotificationOutcome, UpdateNotificationError> {
+            self.notifications.borrow_mut().push(request.clone());
             self.result.clone()
         }
     }
@@ -1412,6 +1425,47 @@ mod tests {
         assert_eq!(entry.etag.as_deref(), Some("\"next-etag\""));
         assert_eq!(entry.last_checked_at_unix_seconds, TEST_NOW);
         assert_eq!(entry.latest.version, "1.2.0");
+    }
+
+    #[test]
+    fn ureq_client_maps_not_modified_status_to_cached_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind local test server");
+        let address = listener.local_addr().expect("read local test address");
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept client connection");
+            let mut buffer = [0; 2048];
+            let length = stream.read(&mut buffer).expect("read request");
+            let request = String::from_utf8_lossy(&buffer[..length]);
+
+            assert!(request.starts_with("GET /releases?per_page=20 "));
+            assert!(request.contains("If-None-Match: \"cached-etag\""));
+
+            stream
+                .write_all(
+                    b"HTTP/1.1 304 Not Modified\r\nETag: \"cached-etag\"\r\nContent-Length: 0\r\n\r\n",
+                )
+                .expect("write response");
+        });
+        let base_url = Box::leak(format!("http://{address}/releases").into_boxed_str());
+        let client = UreqGitHubReleasesClient {
+            base_url,
+            agent: ureq::AgentBuilder::new()
+                .timeout(Duration::from_secs(5))
+                .build(),
+        };
+
+        let response = client
+            .get(
+                ReleaseEndpoint::ReleasesList {
+                    per_page: PRERELEASE_PAGE_SIZE,
+                },
+                "lg-buddy/1.1.0-alpha.0",
+                Some("\"cached-etag\""),
+            )
+            .expect("304 response should succeed");
+
+        assert_eq!(response, GitHubReleaseResponse::NotModified);
+        server.join().expect("server thread should finish");
     }
 
     #[test]
@@ -1923,10 +1977,16 @@ mod tests {
         assert!(rendered(&output).contains("status: update available"));
         let notifications = notifier.notifications();
         assert_eq!(notifications.len(), 1);
-        assert_eq!(notifications[0].summary, "LG Buddy update available");
         assert_eq!(
-            notifications[0].body,
-            "LG Buddy 1.1.1 (stable) is available.\nCurrent: 1.1.0 (stable)\nhttps://github.test/releases/tag/v1.1.1"
+            notifications[0].to_dbus_fields(),
+            (
+                "stable".to_string(),
+                "1.1.0".to_string(),
+                "stable".to_string(),
+                "1.1.1".to_string(),
+                "stable".to_string(),
+                "https://github.test/releases/tag/v1.1.1".to_string()
+            )
         );
     }
 
@@ -1982,7 +2042,7 @@ mod tests {
         ));
         assert_eq!(
             err.to_string(),
-            "update check completed with deferred failure: desktop notification failed: desktop notification service error: bus unavailable"
+            "update check completed with deferred failure: desktop notification failed: could not request update notification from LG Buddy session service: bus unavailable"
         );
     }
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -91,6 +91,7 @@ flowchart LR
         EVENTS["events.rs<br/>canonical runtime events"]
         POLICY["policy.rs<br/>action / no-action / state trail"]
         NOTIFICATIONS["notifications.rs<br/>native desktop notifications"]
+        SESSIONNOTIFY["session_notifications.rs<br/>session D-Bus surface / update notifications"]
         SCREEN["screen.rs<br/>session screen policy"]
         LIFECYCLE["lifecycle.rs<br/>machine lifecycle policy"]
         PHASE["runtime_phase.rs<br/>machine sleep phase provider"]
@@ -143,6 +144,7 @@ flowchart LR
     COMMANDS --> EVENTS
     COMMANDS --> NMGATE
     COMMANDS --> NOTIFICATIONS
+    COMMANDS --> SESSIONNOTIFY
     COMMANDS --> SCREEN
     COMMANDS --> LIFECYCLE
     SCREEN --> POLICY
@@ -155,6 +157,9 @@ flowchart LR
     INPUT --> GAMEPAD
     GAMEPAD -->|"UserActivity"| RUNNER
     NOTIFICATIONS --> FDO_NOTIFY
+    SESSIONNOTIFY --> FDO_NOTIFY
+    SESSIONNOTIFY --> BUS
+    RUNNER --> SESSIONNOTIFY
     SESSIONMODEL --> RUNNER
 
     RUNNER -->|"Idle / Active / WakeRequested /<br/>UserActivity"| SCREEN
@@ -190,7 +195,12 @@ The intended split is:
 - `notifications.rs`
   - native desktop notification dispatch through
     `org.freedesktop.Notifications`
-  - passive notification delivery for brightness and explicit update checks
+  - passive notification delivery for brightness
+- `session_notifications.rs`
+  - LG Buddy-owned user-session D-Bus surface for update notification handoff
+  - session-owned update notification dispatch through
+    `org.freedesktop.Notifications`
+  - update notification action handling for `View Release`
 - `screen.rs`
   - pure session screen blank and restore policy decisions over already-read
     observations
@@ -320,11 +330,13 @@ the runtime command handlers in `commands.rs` and `session/runner.rs`.
 `commands.rs` then delegates screen and lifecycle decisions to their domain
 modules and delegates platform ingestion to `sources/`. The on-demand
 `updates check` command consumes the GitHub Releases API without entering the
-screen, lifecycle, settings, or scheduling paths. It enters notification
-dispatch only when `--notify` is passed and an update is available. It owns an
-operational cache under the user cache directory for GitHub ETag and latest
-release metadata; that cache is not user configuration and is not part of the
-settings API.
+screen, lifecycle, settings, or scheduling paths. When `--notify` is passed and
+an update is available, the one-shot CLI process hands the resolved update facts
+to the LG Buddy-owned user-session D-Bus surface. The running session process
+then owns desktop notification dispatch, notification ids, and the `View
+Release` action. `updates check` owns an operational cache under the user cache
+directory for GitHub ETag and latest release metadata; that cache is not user
+configuration and is not part of the settings API.
 The `brightness get` and `brightness set` commands use the TV picture
 abstraction in `tv.rs` for typed OLED brightness validation and live TV
 read/write operations. The interactive brightness dialog delegates its TV

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,7 +55,12 @@ prerelease builds check the prerelease channel, which includes both prerelease
 and stable releases. Use `--channel stable` or `--channel prerelease` to choose
 the channel explicitly. The command may cache GitHub response metadata to reduce
 repeated API downloads. Add `--notify` to send a desktop notification when the
-check finds an available update.
+check finds an available update. Notification delivery is handled by the
+running user-session LG Buddy process; if that process is not running,
+`--notify` reports a notification failure after printing the update result. When
+the desktop notification service supports actions, the notification includes a
+`View Release` button that opens the GitHub release page through the system
+opener.
 
 `lifecycle`, `nm-pre-down`, `sleep-pre`, and `startup wake` are normally
 service-owned system lifecycle commands. They are documented for

--- a/tmp/actionable-update-notifications-plan.md
+++ b/tmp/actionable-update-notifications-plan.md
@@ -1,0 +1,383 @@
+# Actionable Update Notifications Plan
+
+Temporary working plan for the update-notification button branch.
+
+## Goal
+
+Make manual update notifications session-owned and actionable.
+
+`lg-buddy updates check --notify` should remain an on-demand CLI check, but the
+desktop notification lifecycle should be owned by the already-running
+user-session LG Buddy process. That process should send the notification, keep
+the notification id and update payload in memory, listen for notification action
+signals, and handle user actions.
+
+This avoids a one-shot CLI process waiting around for one notification and
+avoids an out-of-band filesystem handoff.
+
+## Current State
+
+- `LG_Buddy_screen.service` runs the long-lived user-session process as
+  `lg-buddy monitor`.
+- That process already connects to D-Bus as a client/subscriber for desktop
+  session integrations.
+- LG Buddy does not currently own a well-known session D-Bus name or export an
+  LG Buddy object/interface.
+- `lg-buddy updates check --notify` is a one-shot CLI command:
+  - checks GitHub releases
+  - prints the update result
+  - sends a passive desktop notification when an update is available
+  - keeps no notification state after `Notify` returns
+- `notifications.rs` can send passive notifications and serialize action
+  buttons, but nothing handles `ActionInvoked` or `NotificationClosed`.
+
+## Locked Design Direction
+
+- Use D-Bus for the CLI-to-session handoff.
+- The long-running user-session LG Buddy process owns actionable notification
+  lifecycle.
+- Do not use a filesystem handoff for pending notification data.
+- Do not introduce a per-notification waiter process.
+- Keep this branch focused on manual `updates check --notify`; no scheduling or
+  timers yet.
+- Do not add notification settings, opt-out actions, or repeat-notification
+  suppression in this slice.
+
+## Target State Spec
+
+### User-Facing Behavior
+
+`lg-buddy updates check`
+
+- Checks GitHub releases on demand.
+- Prints the same update status as today.
+- Does not send a desktop notification.
+
+`lg-buddy updates check --notify`
+
+- Checks GitHub releases on demand.
+- Prints the same update status as today.
+- If no update is available, does not contact the session notification surface.
+- If an update is available, asks the running LG Buddy session process to show
+  and manage the update notification.
+- If the session notification surface is unavailable, fails loudly after printing
+  the update result.
+
+The running session process owns delivery:
+
+- If notification actions are supported, send an actionable notification with a
+  `View Release` button.
+- If notification actions are not supported, send a passive notification with
+  the release URL in the body.
+
+### Button Behavior
+
+Actionable notification buttons:
+
+- `View Release`
+  - opens the release URL through the system opener
+  - clears the pending in-memory notification mapping
+
+Close, expire, or dismiss:
+
+- clears the pending in-memory notification mapping
+
+Notification dispatch failure:
+
+- does not store a pending notification mapping
+- returns a clear notification failure to the CLI handoff caller
+
+### Session D-Bus Surface
+
+Tentative naming:
+
+```text
+bus name:   io.github.Staphylococcus.LGBuddy
+object:     /io/github/Staphylococcus/LGBuddy/Session
+interface:  io.github.Staphylococcus.LGBuddy.Session1
+method:     ShowUpdateNotification
+```
+
+The exact names can change before implementation, but the shape should be:
+
+- one small LG Buddy-owned session interface
+- one method for this slice
+- typed Rust request/response structs at the internal boundary
+- D-Bus serialization kept at the edge
+
+The request should include enough release facts for the session process to own
+the notification:
+
+- update check channel: `stable` or `prerelease`
+- current version and channel
+- latest version and channel
+- release URL
+
+The response should distinguish:
+
+- notification sent
+- failed, with an explicit error
+
+### Update Cache
+
+No cache shape changes are required in this slice.
+
+The existing update cache remains responsible for GitHub ETag and latest-release
+metadata only. Repeat-notification suppression and last-notified metadata should
+be introduced with scheduled notifications or notification preferences, not with
+manual `updates check --notify`.
+
+### Failure Semantics
+
+- API/check failures stop before notification handoff.
+- Result rendering happens before deferred notification/cache failures are
+  returned.
+- Missing session D-Bus owner for `--notify` is a notification failure, not a
+  successful no-op.
+- Notification delivery failure is loud and does not store pending notification
+  state.
+- Release opener failure during `View Release` is loud and should preserve the
+  underlying opener error.
+- Existing update-cache failures should keep the current update-check semantics:
+  they should not prevent notification handoff, but they should still be
+  reported loudly after useful work is attempted.
+
+## Non-Goals
+
+- No automatic update installation.
+- No scheduled update checks.
+- No systemd timer in this branch.
+- No release-note rendering.
+- No notification settings or opt-out button.
+- No repeat-notification suppression.
+- No update cache shape change.
+- No general daemon/session-process refactor beyond the minimum session D-Bus
+  surface needed for update notifications.
+- No filesystem handoff for notification request state.
+- No per-notification waiter process.
+
+## Deliverable Slices By Subsystem
+
+Each slice should extend behavior without weakening existing behavior. Keep
+commits scoped to the subsystem boundary named by the slice.
+
+### Slice 1: Session D-Bus Service Foundation
+
+Boundary: session D-Bus service hosting inside the long-running user-session LG
+Buddy process.
+
+Deliverables:
+
+- Add a production LG Buddy session D-Bus service surface.
+- Own a well-known session bus name while the user-session process is running.
+- Export a minimal session object/interface.
+- Add a method dispatch loop that can run as a component of the session process
+  without blocking screen monitoring.
+- Prefer reusing existing D-Bus infrastructure where practical.
+- If `dbus-crossroads` is the cleanest production service implementation,
+  promote it from dev-dependency to dependency deliberately.
+
+Tests:
+
+- session service claims the expected well-known bus name on a private bus
+- `ShowUpdateNotification` method can be called on a private bus
+- malformed request payloads are rejected with clear D-Bus errors
+- service startup failure is reported clearly
+- existing monitor behavior still starts and processes session events
+
+Acceptance criteria:
+
+- `lg-buddy monitor` remains the installed user service entrypoint for this
+  branch.
+- There is one LG Buddy-owned session D-Bus surface.
+- No update notification logic is required in this slice beyond a stub handler.
+
+### Slice 2: Update Notification Handoff Contract
+
+Boundary: typed request/response contract and CLI-side D-Bus client.
+
+Deliverables:
+
+- Add an internal `UpdateNotificationRequest` containing:
+  - selected update check channel
+  - current version
+  - current release channel
+  - latest version
+  - latest release channel
+  - release URL
+- Add an internal `UpdateNotificationOutcome` containing:
+  - sent
+  - failed
+- Serialize the request over the LG Buddy session D-Bus method.
+- Parse the response into typed outcomes.
+- Keep D-Bus-specific strings and signatures at the edge.
+
+Tests:
+
+- valid request serializes and round-trips through the session method boundary
+- invalid channel values are rejected
+- invalid semver strings are rejected before the session owner stores state
+- invalid or empty URL is rejected
+- CLI client reports missing session owner as a clear notification handoff error
+
+Acceptance criteria:
+
+- `updates.rs` can depend on a trait-like notification handoff boundary in
+  tests, not on a real session bus.
+
+### Slice 3: Notification Action Signal Handling
+
+Boundary: `notifications.rs` plus D-Bus signal parsing support.
+
+Deliverables:
+
+- Parse Freedesktop notification action signals:
+  - `ActionInvoked(notification_id, action_key)`
+  - `NotificationClosed(notification_id, reason)`
+- Extend bus value support for the D-Bus value shapes used by notification
+  signals, especially `u32`.
+- Keep action-signal parsing generic; do not hard-code update behavior into
+  transport parsing.
+- Add a session-owned registry:
+  - `notification_id -> pending update notification payload`
+
+Tests:
+
+- parses `ActionInvoked` with id and action key
+- parses `NotificationClosed` with id and close reason
+- ignores unrelated signals
+- ignores unknown notification ids
+- close/expire/dismiss removes pending notification state
+- handles duplicate/late signals deterministically
+
+Acceptance criteria:
+
+- Passive notification delivery still works.
+- Action signal parsing can be tested without a real desktop notification
+  server.
+
+### Slice 4: Session-Owned Update Notification Dispatcher
+
+Boundary: session notification owner/orchestrator.
+
+Deliverables:
+
+- Implement `ShowUpdateNotification` in the session process.
+- Query notification capabilities.
+- If actions are supported, send notification with:
+  - `view-release`
+- If actions are not supported, send passive body text with the release URL.
+- Store the notification id and payload in memory after successful dispatch.
+- Handle action outcomes:
+  - `view-release` opens the URL
+  - close/expire/dismiss removes pending state
+- Remove pending notification state after terminal outcome.
+
+Tests:
+
+- supported actions attach the `View Release` button
+- unsupported actions send passive body with release URL
+- notification send failure returns failure and does not store pending state
+- `view-release` invokes opener and clears pending state
+- opener failure returns a clear failure
+- close/expire/dismiss clears pending state
+
+Acceptance criteria:
+
+- The session process owns notification id mapping.
+- No one-shot process waits for notification signals.
+- No pending notification state is stored in filesystem handoff files.
+
+### Slice 5: Updates CLI Integration
+
+Boundary: `updates.rs` command orchestration.
+
+Deliverables:
+
+- Keep the public CLI shape:
+  - `updates check [--channel stable|prerelease] [--notify]`
+- On update available with `--notify`, call the LG Buddy session handoff client.
+- Do not call the session surface when no update is available.
+- Preserve result output before deferred failures.
+- Return nonzero when handoff fails.
+
+Tests:
+
+- plain `updates check` does not hand off
+- `--notify` with no update does not hand off
+- `--notify` with available update sends one handoff request
+- handoff request contains current/latest versions, channels, URL, and selected
+  update check channel
+- missing session owner returns deferred notification failure after result output
+- handoff failure preserves clear error text
+
+Acceptance criteria:
+
+- Existing update API/channel/cache behavior is unchanged.
+- Manual check remains useful even when notification delivery fails.
+
+### Slice 6: Documentation And Architecture
+
+Boundary: user-facing docs and architecture docs.
+
+Deliverables:
+
+- Update `docs/user-guide.md` for:
+  - `updates check --notify`
+  - `View Release` notification action
+- Update `docs/architecture-overview.md` for:
+  - LG Buddy-owned session D-Bus surface
+  - session-owned notification lifecycle
+  - update CLI as producer, session process as notification owner
+- Keep implementation minutiae out of the main README unless the README already
+  references the affected CLI behavior.
+
+Tests:
+
+- documentation examples match actual CLI keys and command shape
+- no stale references to passive-only update notifications remain
+
+Acceptance criteria:
+
+- Docs match the implemented behavior.
+
+### Slice 7: End-To-End Validation
+
+Boundary: integration/cucumber coverage where practical.
+
+Deliverables:
+
+- Add private D-Bus test coverage for the session method if practical.
+- Add runtime entrypoint coverage for `updates check --notify` handoff behavior.
+- Keep tests deterministic; no reliance on the real desktop notification
+  daemon, real GitHub API, or real user config/cache.
+
+Validation:
+
+- `cargo fmt --all --check`
+- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
+- `cargo test -p lg-buddy`
+- targeted cucumber/runtime tests for the new behavior
+
+Acceptance criteria:
+
+- The branch can be reviewed as a complete manual `View Release` notification
+  feature, with scheduling, preferences, and opt-out left as deliberate
+  follow-ups.
+
+## Follow-Up Candidates
+
+- `Never Notify Again` action.
+- `updates.notifications` setting.
+- Repeat-notification suppression with last-notified cache metadata.
+- Scheduled update checks.
+
+## Open Decisions To Lock Before Implementation
+
+- Exact D-Bus bus/object/interface names.
+- Whether to promote `dbus-crossroads` to a production dependency or implement
+  the small method surface directly with `dbus`.
+- Whether `View Release` uses `xdg-open` specifically and, if so, how we declare
+  that runtime dependency.
+- Whether successful notification handoff should print an extra CLI line or
+  remain silent after the normal update result.


### PR DESCRIPTION
## Summary

Adds a session-owned update notification surface so `lg-buddy updates check --notify` can hand update facts to the long-running user-session process instead of emitting fire-and-forget notifications directly.

This PR also adds a `View Release` notification action, routes action handling through the session process, and updates the user guide and architecture overview to describe the new flow.

Part of #27.

## Review Follow-Ups

- Avoids blocking monitor startup after session notification service startup timeout.
- Rejects spoofed notification action/close signals by requiring the sender to match the current owner of `org.freedesktop.Notifications`.
- Handles GitHub `304 Not Modified` responses before body decoding so cached update checks do not fail on bodyless 304 responses.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo test -p lg-buddy`
- Rebuilt `target/release/lg-buddy` as `1.1.0-alpha.0` and confirmed cached prerelease update checks report `1.1.0-alpha.1` correctly.