### PR TITLE
Centralize system suspend rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ chmod +x ./install.sh
 ./install.sh
 ```
 
-The installer will prompt for your TV IP, MAC address, HDMI input, and session idle blanking details, then install the required services. System sleep/wake handling uses the default lifecycle service plus NetworkManager pre-down gate unless you opt out in `config.env`.
+The installer will prompt for your TV IP, MAC address, HDMI input, and session idle blanking details, then install the required services. System sleep/wake handling uses the lifecycle service plus NetworkManager pre-down gate as cooperating suspend sources unless you opt out in `config.env`.
 
 On first use, you may need to accept a pairing prompt on the TV:
 

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -9,10 +9,13 @@ use std::time::Duration;
 
 use crate::auth::resolve_bscpylgtv_auth_context_from_env;
 use crate::config::{load_config, resolve_config_path_from_env, Config};
+use crate::events::RuntimeEvent;
 use crate::lifecycle::ThreadSleeper;
 use crate::lifecycle::{self, JournalctlSleepDetector, NmOnlineNetworkWaiter};
 use crate::notifications::{FreedesktopNotifier, Notification, NotificationError, Notifier};
-use crate::state::{ScreenOwnershipMarker, StateScope, SystemSleepAttemptState};
+use crate::state::{
+    ScreenOwnershipMarker, StateScope, SystemSleepAttemptState, SystemSleepCycleState,
+};
 use crate::tv::{
     BscpylgtvCommandClient, OledBrightness, TvClient, TvDevice, UserScopedBscpylgtvCommandLauncher,
 };
@@ -245,11 +248,22 @@ pub fn run_sleep_pre<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
     let config = load_config(&config_path).map_err(RunError::Config)?;
     let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
+    let cycle_state =
+        SystemSleepCycleState::from_env(StateScope::System).map_err(RunError::StateDir)?;
     let tv_client =
         build_tv_client(&config_path)?.with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT);
     let sleeper = ThreadSleeper;
 
-    lifecycle::attempt_system_sleep_power_off_with(writer, &config, &marker, &tv_client, &sleeper)
+    lifecycle::handle_system_suspend_with(
+        writer,
+        &config,
+        &marker,
+        &cycle_state,
+        &tv_client,
+        &sleeper,
+        RuntimeEvent::from_command(crate::Command::SleepPre)
+            .expect("sleep-pre should map to a runtime event"),
+    )
 }
 
 pub fn run_sleep<W: Write>(writer: &mut W) -> Result<(), RunError> {

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -384,12 +384,28 @@ pub fn run_system_resume<W: Write>(writer: &mut W) -> Result<(), RunError> {
         &network_waiter,
     );
 
+    let mut cleanup_error = None;
+
     if let Err(err) = attempt_state.clear() {
         writeln!(
             writer,
             "LG Buddy System Resume: could not clear system sleep attempt marker after resume. {err}"
         )?;
-        if result.is_ok() {
+        cleanup_error = Some(err);
+    }
+
+    if let Err(err) = attempt_state.clear_outcome() {
+        writeln!(
+            writer,
+            "LG Buddy System Resume: could not clear system sleep cycle state after resume. {err}"
+        )?;
+        if cleanup_error.is_none() {
+            cleanup_error = Some(err);
+        }
+    }
+
+    if result.is_ok() {
+        if let Some(err) = cleanup_error {
             return Err(RunError::Io(err));
         }
     }

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -245,6 +245,17 @@ pub fn run_screen_off<W: Write>(writer: &mut W) -> Result<(), RunError> {
 }
 
 pub fn run_sleep_pre<W: Write>(writer: &mut W) -> Result<(), RunError> {
+    run_sleep_pre_for_event(
+        writer,
+        RuntimeEvent::from_command(crate::Command::SleepPre)
+            .expect("sleep-pre should map to a runtime event"),
+    )
+}
+
+pub fn run_sleep_pre_for_event<W: Write>(
+    writer: &mut W,
+    event: RuntimeEvent,
+) -> Result<(), RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
     let config = load_config(&config_path).map_err(RunError::Config)?;
     let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
@@ -261,8 +272,7 @@ pub fn run_sleep_pre<W: Write>(writer: &mut W) -> Result<(), RunError> {
         &cycle_state,
         &tv_client,
         &sleeper,
-        RuntimeEvent::from_command(crate::Command::SleepPre)
-            .expect("sleep-pre should map to a runtime event"),
+        event,
     )
 }
 

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -236,12 +236,6 @@ pub(crate) enum SuspendRailDisposition {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SystemSleepCycleWait {
-    Terminal(SystemSleepCycleOutcome),
-    TimedOut,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NetworkTeardownNext {
     AttemptPreSleep,
     ClearAttempt,
@@ -1126,18 +1120,18 @@ fn handle_network_teardown_rail_disposition<W: Write, C: TvClient, Sl: Sleeper>(
         return Ok(());
     }
 
-    match wait_for_system_sleep_cycle_terminal(
+    match wait_for_system_sleep_cycle_outcome(
         deps.attempt_state,
         deps.sleeper,
         system_sleep_rail_deadline(),
     )? {
-        SystemSleepCycleWait::Terminal(SystemSleepCycleOutcome::Completed) => {
+        SystemSleepCycleOutcome::Completed => {
             writeln!(
                 writer,
                 "LG Buddy NetworkManager: suspend rail completed; releasing network teardown."
             )?;
         }
-        SystemSleepCycleWait::Terminal(SystemSleepCycleOutcome::RetryableTransportFailure) => {
+        SystemSleepCycleOutcome::RetryableTransportFailure => {
             writeln!(
                 writer,
                 "LG Buddy NetworkManager: suspend rail reported retryable transport failure; retrying before network teardown."
@@ -1153,8 +1147,7 @@ fn handle_network_teardown_rail_disposition<W: Write, C: TvClient, Sl: Sleeper>(
             )?;
             outcome.merge(retry_outcome);
         }
-        SystemSleepCycleWait::Terminal(SystemSleepCycleOutcome::InProgress)
-        | SystemSleepCycleWait::TimedOut => {
+        SystemSleepCycleOutcome::InProgress => {
             writeln!(
                 writer,
                 "LG Buddy NetworkManager: suspend rail did not finish before deadline; releasing network teardown."
@@ -1168,35 +1161,30 @@ fn handle_network_teardown_rail_disposition<W: Write, C: TvClient, Sl: Sleeper>(
     Ok(())
 }
 
-fn wait_for_system_sleep_cycle_terminal<Sl: Sleeper>(
+fn wait_for_system_sleep_cycle_outcome<Sl: Sleeper>(
     cycle_state: &SystemSleepAttemptState,
     sleeper: &Sl,
     deadline: Duration,
-) -> Result<SystemSleepCycleWait, RunError> {
+) -> Result<SystemSleepCycleOutcome, RunError> {
     let mut waited = Duration::ZERO;
-    let poll = system_sleep_rail_wait_poll();
 
     loop {
         match cycle_state.read_outcome()? {
-            Some(SystemSleepCycleOutcome::Completed) => {
-                return Ok(SystemSleepCycleWait::Terminal(
-                    SystemSleepCycleOutcome::Completed,
-                ));
-            }
-            Some(SystemSleepCycleOutcome::RetryableTransportFailure) => {
-                return Ok(SystemSleepCycleWait::Terminal(
-                    SystemSleepCycleOutcome::RetryableTransportFailure,
-                ));
+            Some(
+                outcome @ (SystemSleepCycleOutcome::Completed
+                | SystemSleepCycleOutcome::RetryableTransportFailure),
+            ) => {
+                return Ok(outcome);
             }
             Some(SystemSleepCycleOutcome::InProgress) | None => {}
         }
 
         if waited >= deadline {
-            return Ok(SystemSleepCycleWait::TimedOut);
+            return Ok(SystemSleepCycleOutcome::InProgress);
         }
 
         let remaining = deadline.saturating_sub(waited);
-        let sleep_for = poll.min(remaining);
+        let sleep_for = SYSTEM_SLEEP_RAIL_WAIT_POLL.min(remaining);
         sleeper.sleep(sleep_for);
         waited += sleep_for;
     }
@@ -1733,15 +1721,6 @@ pub(crate) fn system_sleep_rail_deadline() -> Duration {
         "LG_BUDDY_SYSTEM_SLEEP_RAIL_DEADLINE_SECS",
         SYSTEM_SLEEP_RAIL_DEADLINE,
     )
-}
-
-fn system_sleep_rail_wait_poll() -> Duration {
-    env::var("LG_BUDDY_SYSTEM_SLEEP_RAIL_WAIT_POLL_MS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|millis| *millis > 0)
-        .map(Duration::from_millis)
-        .unwrap_or(SYSTEM_SLEEP_RAIL_WAIT_POLL)
 }
 
 fn tv_route_wait_attempts() -> u32 {

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -13,7 +13,8 @@ use crate::policy::{
     StateTransition, TransitionReason, TransitionReasonCode,
 };
 use crate::state::{
-    ScreenOwnershipMarker, SystemSleepAttemptState, SystemSleepCycleOutcome, SystemSleepCycleState,
+    ScreenOwnershipMarker, SystemSleepAttemptLock, SystemSleepAttemptState,
+    SystemSleepCycleOutcome, SystemSleepCycleState,
 };
 use crate::tv::{CurrentInput, TvClient, TvDevice};
 use crate::wol::{WakeOnLanSender, DEFAULT_WOL_PORT};
@@ -233,6 +234,12 @@ pub(crate) enum SuspendRailDisposition {
     JoinedInProgress,
     DuplicateCompleted,
     RetryableFailure,
+}
+
+enum SystemSleepCycleObservation {
+    Completed,
+    RetryableTransportFailure(SystemSleepAttemptLock),
+    InProgress,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -924,16 +931,35 @@ pub(crate) fn handle_system_suspend_with_outcome<W: Write, C: TvClient, Sl: Slee
         ));
         let disposition = match cycle_state.read_outcome()? {
             Some(SystemSleepCycleOutcome::Completed) => SuspendRailDisposition::DuplicateCompleted,
-            Some(SystemSleepCycleOutcome::RetryableTransportFailure) => {
-                SuspendRailDisposition::RetryableFailure
-            }
-            Some(SystemSleepCycleOutcome::InProgress) | None => {
-                SuspendRailDisposition::JoinedInProgress
-            }
+            Some(
+                SystemSleepCycleOutcome::RetryableTransportFailure
+                | SystemSleepCycleOutcome::InProgress,
+            )
+            | None => SuspendRailDisposition::JoinedInProgress,
         };
         return Ok((outcome, disposition));
     };
 
+    handle_system_suspend_owner_with_outcome(
+        writer,
+        config,
+        marker,
+        cycle_state,
+        tv_client,
+        sleeper,
+        _guard,
+    )
+}
+
+fn handle_system_suspend_owner_with_outcome<W: Write, C: TvClient, Sl: Sleeper>(
+    writer: &mut W,
+    config: &Config,
+    marker: &ScreenOwnershipMarker,
+    cycle_state: &SystemSleepCycleState,
+    tv_client: &C,
+    sleeper: &Sl,
+    _guard: SystemSleepAttemptLock,
+) -> Result<(PolicyOutcome, SuspendRailDisposition), RunError> {
     if matches!(
         cycle_state.read_outcome()?,
         Some(SystemSleepCycleOutcome::Completed)
@@ -1078,7 +1104,6 @@ pub(crate) fn handle_network_teardown_with_outcome<W: Write, C: TvClient, Sl: Sl
                 writer,
                 config,
                 deps,
-                event,
                 rail_disposition,
                 &mut outcome,
             )?;
@@ -1112,7 +1137,6 @@ fn handle_network_teardown_rail_disposition<W: Write, C: TvClient, Sl: Sleeper>(
     writer: &mut W,
     config: &Config,
     deps: NetworkTeardownDeps<'_, C, Sl>,
-    event: RuntimeEvent,
     disposition: SuspendRailDisposition,
     outcome: &mut PolicyOutcome,
 ) -> Result<(), RunError> {
@@ -1120,34 +1144,34 @@ fn handle_network_teardown_rail_disposition<W: Write, C: TvClient, Sl: Sleeper>(
         return Ok(());
     }
 
-    match wait_for_system_sleep_cycle_outcome(
+    match wait_for_system_sleep_cycle_observation(
         deps.attempt_state,
         deps.sleeper,
         system_sleep_rail_deadline(),
     )? {
-        SystemSleepCycleOutcome::Completed => {
+        SystemSleepCycleObservation::Completed => {
             writeln!(
                 writer,
                 "LG Buddy NetworkManager: suspend rail completed; releasing network teardown."
             )?;
         }
-        SystemSleepCycleOutcome::RetryableTransportFailure => {
+        SystemSleepCycleObservation::RetryableTransportFailure(guard) => {
             writeln!(
                 writer,
                 "LG Buddy NetworkManager: suspend rail reported retryable transport failure; retrying before network teardown."
             )?;
-            let (retry_outcome, _) = handle_system_suspend_with_outcome(
+            let (retry_outcome, _) = handle_system_suspend_owner_with_outcome(
                 writer,
                 config,
                 deps.marker,
                 deps.attempt_state,
                 deps.tv_client,
                 deps.sleeper,
-                event,
+                guard,
             )?;
             outcome.merge(retry_outcome);
         }
-        SystemSleepCycleOutcome::InProgress => {
+        SystemSleepCycleObservation::InProgress => {
             writeln!(
                 writer,
                 "LG Buddy NetworkManager: suspend rail did not finish before deadline; releasing network teardown."
@@ -1161,26 +1185,30 @@ fn handle_network_teardown_rail_disposition<W: Write, C: TvClient, Sl: Sleeper>(
     Ok(())
 }
 
-fn wait_for_system_sleep_cycle_outcome<Sl: Sleeper>(
+fn wait_for_system_sleep_cycle_observation<Sl: Sleeper>(
     cycle_state: &SystemSleepAttemptState,
     sleeper: &Sl,
     deadline: Duration,
-) -> Result<SystemSleepCycleOutcome, RunError> {
+) -> Result<SystemSleepCycleObservation, RunError> {
     let mut waited = Duration::ZERO;
 
     loop {
         match cycle_state.read_outcome()? {
-            Some(
-                outcome @ (SystemSleepCycleOutcome::Completed
-                | SystemSleepCycleOutcome::RetryableTransportFailure),
-            ) => {
-                return Ok(outcome);
+            Some(SystemSleepCycleOutcome::Completed) => {
+                return Ok(SystemSleepCycleObservation::Completed);
+            }
+            Some(SystemSleepCycleOutcome::RetryableTransportFailure) => {
+                if let Some(guard) = cycle_state.try_lock()? {
+                    return Ok(SystemSleepCycleObservation::RetryableTransportFailure(
+                        guard,
+                    ));
+                }
             }
             Some(SystemSleepCycleOutcome::InProgress) | None => {}
         }
 
         if waited >= deadline {
-            return Ok(SystemSleepCycleOutcome::InProgress);
+            return Ok(SystemSleepCycleObservation::InProgress);
         }
 
         let remaining = deadline.saturating_sub(waited);
@@ -1808,8 +1836,8 @@ mod tests {
         TransitionReasonCode,
     };
     use crate::state::{
-        ScreenOwnershipMarker, SystemSleepAttemptState, SystemSleepCycleOutcome,
-        SystemSleepCycleState,
+        ScreenOwnershipMarker, SystemSleepAttemptLock, SystemSleepAttemptState,
+        SystemSleepCycleOutcome, SystemSleepCycleState,
     };
     use crate::tv::{BscpylgtvCommandClient, CurrentInput};
     use crate::wol::{WakeOnLanError, WakeOnLanSender};
@@ -2451,6 +2479,59 @@ mod tests {
     }
 
     #[test]
+    fn network_teardown_waits_for_retryable_owner_before_retrying() {
+        let temp_dir = TestDir::new("lifecycle-nm-retryable-owner");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let attempt_state = SystemSleepAttemptState::new(temp_dir.path().to_path_buf());
+        let owner = attempt_state
+            .try_lock()
+            .expect("acquire owner lock")
+            .expect("owner lock should be available");
+        attempt_state
+            .write_outcome(SystemSleepCycleOutcome::RetryableTransportFailure)
+            .expect("write retryable outcome");
+        let mock = MockBscpylgtv::new("lifecycle-nm-retryable-owner-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let sleeper = ReleasingSleeper::new(owner);
+
+        let mut output = Vec::new();
+        let outcome = handle_network_teardown_with_outcome(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            NetworkTeardownDeps {
+                marker: &marker,
+                attempt_state: &attempt_state,
+                tv_client: &client,
+                sleeper: &sleeper,
+            },
+            RuntimeEvent::network_teardown_imminent(Some(true)),
+            None,
+        )
+        .expect("pending sleep teardown should wait and retry");
+
+        assert!(!sleeper.durations().is_empty());
+        assert_eq!(
+            outcome
+                .actions
+                .iter()
+                .map(|action| action.kind)
+                .collect::<Vec<_>>(),
+            vec![ActionKind::TvSystemSleepPowerOff]
+        );
+        assert_eq!(
+            attempt_state
+                .read_outcome()
+                .expect("read completed outcome"),
+            Some(SystemSleepCycleOutcome::Completed)
+        );
+        assert!(marker.exists());
+        assert!(!attempt_state.exists());
+        assert_call_commands(&mock, &["get_input", "power_off"]);
+        assert!(rendered(&output).contains("retrying before network teardown"));
+    }
+
+    #[test]
     fn network_teardown_ordinary_disconnect_records_no_action_and_clears_attempt() {
         let temp_dir = TestDir::new("lifecycle-nm-not-sleeping");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
@@ -2804,6 +2885,31 @@ mod tests {
     impl Sleeper for RecordingSleeper {
         fn sleep(&self, duration: Duration) {
             self.durations.borrow_mut().push(duration);
+        }
+    }
+
+    struct ReleasingSleeper {
+        durations: RefCell<Vec<Duration>>,
+        owner: RefCell<Option<SystemSleepAttemptLock>>,
+    }
+
+    impl ReleasingSleeper {
+        fn new(owner: SystemSleepAttemptLock) -> Self {
+            Self {
+                durations: RefCell::new(Vec::new()),
+                owner: RefCell::new(Some(owner)),
+            }
+        }
+
+        fn durations(&self) -> Vec<Duration> {
+            self.durations.borrow().clone()
+        }
+    }
+
+    impl Sleeper for ReleasingSleeper {
+        fn sleep(&self, duration: Duration) {
+            self.durations.borrow_mut().push(duration);
+            drop(self.owner.borrow_mut().take());
         }
     }
 

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -28,6 +28,7 @@ const SYSTEM_PRE_SLEEP_POWER_OFF_ATTEMPTS: u32 = 1;
 const SYSTEM_SLEEP_GET_INPUT_RETRIES: u32 = 3;
 const SYSTEM_SLEEP_POWER_OFF_RETRIES: u32 = 4;
 const SYSTEM_SLEEP_RAIL_DEADLINE: Duration = Duration::from_secs(4);
+const SYSTEM_SLEEP_RAIL_WAIT_POLL: Duration = Duration::from_millis(50);
 
 pub(crate) trait Sleeper {
     fn sleep(&self, duration: Duration);
@@ -232,6 +233,12 @@ pub(crate) enum SuspendRailDisposition {
     JoinedInProgress,
     DuplicateCompleted,
     RetryableFailure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SystemSleepCycleWait {
+    Terminal(SystemSleepCycleOutcome),
+    TimedOut,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -988,6 +995,7 @@ pub(crate) fn handle_system_suspend_with<W: Write, C: TvClient, Sl: Sleeper>(
     .map(|_| ())
 }
 
+#[cfg(test)]
 pub(crate) fn attempt_system_sleep_power_off_once_with_outcome<
     W: Write,
     C: TvClient,
@@ -1062,14 +1070,24 @@ pub(crate) fn handle_network_teardown_with_outcome<W: Write, C: TvClient, Sl: Sl
                 "LG Buddy NetworkManager: logind is preparing for sleep; running pre-sleep TV handling before network teardown."
             )?;
             outcome.merge(decision.outcome);
-            outcome.merge(attempt_system_sleep_power_off_once_with_outcome(
+            let (rail_outcome, rail_disposition) = handle_system_suspend_with_outcome(
                 writer,
                 config,
                 deps.marker,
                 deps.attempt_state,
                 deps.tv_client,
                 deps.sleeper,
-            )?);
+                event,
+            )?;
+            outcome.merge(rail_outcome);
+            handle_network_teardown_rail_disposition(
+                writer,
+                config,
+                deps,
+                event,
+                rail_disposition,
+                &mut outcome,
+            )?;
         }
         NetworkTeardownNext::ClearAttempt => {
             outcome.merge(decision.outcome);
@@ -1094,6 +1112,94 @@ pub(crate) fn handle_network_teardown_with_outcome<W: Write, C: TvClient, Sl: Sl
     }
 
     Ok(outcome)
+}
+
+fn handle_network_teardown_rail_disposition<W: Write, C: TvClient, Sl: Sleeper>(
+    writer: &mut W,
+    config: &Config,
+    deps: NetworkTeardownDeps<'_, C, Sl>,
+    event: RuntimeEvent,
+    disposition: SuspendRailDisposition,
+    outcome: &mut PolicyOutcome,
+) -> Result<(), RunError> {
+    if disposition != SuspendRailDisposition::JoinedInProgress {
+        return Ok(());
+    }
+
+    match wait_for_system_sleep_cycle_terminal(
+        deps.attempt_state,
+        deps.sleeper,
+        system_sleep_rail_deadline(),
+    )? {
+        SystemSleepCycleWait::Terminal(SystemSleepCycleOutcome::Completed) => {
+            writeln!(
+                writer,
+                "LG Buddy NetworkManager: suspend rail completed; releasing network teardown."
+            )?;
+        }
+        SystemSleepCycleWait::Terminal(SystemSleepCycleOutcome::RetryableTransportFailure) => {
+            writeln!(
+                writer,
+                "LG Buddy NetworkManager: suspend rail reported retryable transport failure; retrying before network teardown."
+            )?;
+            let (retry_outcome, _) = handle_system_suspend_with_outcome(
+                writer,
+                config,
+                deps.marker,
+                deps.attempt_state,
+                deps.tv_client,
+                deps.sleeper,
+                event,
+            )?;
+            outcome.merge(retry_outcome);
+        }
+        SystemSleepCycleWait::Terminal(SystemSleepCycleOutcome::InProgress)
+        | SystemSleepCycleWait::TimedOut => {
+            writeln!(
+                writer,
+                "LG Buddy NetworkManager: suspend rail did not finish before deadline; releasing network teardown."
+            )?;
+            outcome.diagnostics.push(Diagnostic::warning(
+                "suspend rail did not finish before NetworkManager teardown deadline",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn wait_for_system_sleep_cycle_terminal<Sl: Sleeper>(
+    cycle_state: &SystemSleepAttemptState,
+    sleeper: &Sl,
+    deadline: Duration,
+) -> Result<SystemSleepCycleWait, RunError> {
+    let mut waited = Duration::ZERO;
+    let poll = system_sleep_rail_wait_poll();
+
+    loop {
+        match cycle_state.read_outcome()? {
+            Some(SystemSleepCycleOutcome::Completed) => {
+                return Ok(SystemSleepCycleWait::Terminal(
+                    SystemSleepCycleOutcome::Completed,
+                ));
+            }
+            Some(SystemSleepCycleOutcome::RetryableTransportFailure) => {
+                return Ok(SystemSleepCycleWait::Terminal(
+                    SystemSleepCycleOutcome::RetryableTransportFailure,
+                ));
+            }
+            Some(SystemSleepCycleOutcome::InProgress) | None => {}
+        }
+
+        if waited >= deadline {
+            return Ok(SystemSleepCycleWait::TimedOut);
+        }
+
+        let remaining = deadline.saturating_sub(waited);
+        let sleep_for = poll.min(remaining);
+        sleeper.sleep(sleep_for);
+        waited += sleep_for;
+    }
 }
 
 pub(crate) fn attempt_legacy_network_manager_sleep_with<
@@ -1627,6 +1733,15 @@ pub(crate) fn system_sleep_rail_deadline() -> Duration {
         "LG_BUDDY_SYSTEM_SLEEP_RAIL_DEADLINE_SECS",
         SYSTEM_SLEEP_RAIL_DEADLINE,
     )
+}
+
+fn system_sleep_rail_wait_poll() -> Duration {
+    env::var("LG_BUDDY_SYSTEM_SLEEP_RAIL_WAIT_POLL_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|millis| *millis > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(SYSTEM_SLEEP_RAIL_WAIT_POLL)
 }
 
 fn tv_route_wait_attempts() -> u32 {

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -12,7 +12,9 @@ use crate::policy::{
     ActionKind, DecisionReason, DecisionReasonCode, Diagnostic, PolicyOutcome, StateMarker,
     StateTransition, TransitionReason, TransitionReasonCode,
 };
-use crate::state::{ScreenOwnershipMarker, SystemSleepAttemptState};
+use crate::state::{
+    ScreenOwnershipMarker, SystemSleepAttemptState, SystemSleepCycleOutcome, SystemSleepCycleState,
+};
 use crate::tv::{CurrentInput, TvClient, TvDevice};
 use crate::wol::{WakeOnLanSender, DEFAULT_WOL_PORT};
 use crate::{RunError, StartupMode};
@@ -25,6 +27,7 @@ const SYSTEM_PRE_SLEEP_GET_INPUT_RETRIES: u32 = 0;
 const SYSTEM_PRE_SLEEP_POWER_OFF_ATTEMPTS: u32 = 1;
 const SYSTEM_SLEEP_GET_INPUT_RETRIES: u32 = 3;
 const SYSTEM_SLEEP_POWER_OFF_RETRIES: u32 = 4;
+const SYSTEM_SLEEP_RAIL_DEADLINE: Duration = Duration::from_secs(4);
 
 pub(crate) trait Sleeper {
     fn sleep(&self, duration: Duration);
@@ -221,6 +224,14 @@ enum SystemSleepPowerOffContext {
 enum SystemSleepAttemptNext {
     Continue,
     Stop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SuspendRailDisposition {
+    OwnerCompleted,
+    JoinedInProgress,
+    DuplicateCompleted,
+    RetryableFailure,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -790,6 +801,7 @@ pub(crate) fn run_shutdown_with_outcome<W: Write, C: TvClient, R: RebootDetector
     Ok(outcome)
 }
 
+#[cfg(test)]
 pub(crate) fn attempt_system_sleep_power_off_with<W: Write, C: TvClient, Sl: Sleeper>(
     writer: &mut W,
     config: &Config,
@@ -880,6 +892,100 @@ pub(crate) fn attempt_system_sleep_power_off_with_outcome<W: Write, C: TvClient,
     }
 
     Ok(outcome)
+}
+
+pub(crate) fn handle_system_suspend_with_outcome<W: Write, C: TvClient, Sl: Sleeper>(
+    writer: &mut W,
+    config: &Config,
+    marker: &ScreenOwnershipMarker,
+    cycle_state: &SystemSleepCycleState,
+    tv_client: &C,
+    sleeper: &Sl,
+    event: RuntimeEvent,
+) -> Result<(PolicyOutcome, SuspendRailDisposition), RunError> {
+    match LifecycleEvent::from_runtime_event(event) {
+        Some(
+            LifecycleEvent::MachinePreparingForSleep
+            | LifecycleEvent::NetworkTeardownImminent { .. },
+        ) => {}
+        Some(_) | None => {
+            return Err(RunError::Policy(
+                "system suspend rail received a non-suspend lifecycle event".to_string(),
+            ));
+        }
+    }
+
+    let guard = cycle_state.try_lock()?;
+    let Some(_guard) = guard else {
+        let outcome = duplicate_system_suspend_outcome(format!(
+            "another system suspend rail owner is already running within the {:?} rail deadline",
+            system_sleep_rail_deadline()
+        ));
+        let disposition = match cycle_state.read_outcome()? {
+            Some(SystemSleepCycleOutcome::Completed) => SuspendRailDisposition::DuplicateCompleted,
+            Some(SystemSleepCycleOutcome::RetryableTransportFailure) => {
+                SuspendRailDisposition::RetryableFailure
+            }
+            Some(SystemSleepCycleOutcome::InProgress) | None => {
+                SuspendRailDisposition::JoinedInProgress
+            }
+        };
+        return Ok((outcome, disposition));
+    };
+
+    if matches!(
+        cycle_state.read_outcome()?,
+        Some(SystemSleepCycleOutcome::Completed)
+    ) {
+        return Ok((
+            duplicate_system_suspend_outcome("system suspend cycle is already completed"),
+            SuspendRailDisposition::DuplicateCompleted,
+        ));
+    }
+
+    cycle_state.write_outcome(SystemSleepCycleOutcome::InProgress)?;
+
+    let mut outcome = PolicyOutcome::new();
+    let start_decision = decide_system_sleep_attempt_start(true);
+    apply_system_sleep_attempt_transitions(writer, cycle_state, &start_decision.outcome)?;
+    outcome.merge(start_decision.outcome);
+    outcome.merge(attempt_system_sleep_power_off_with_outcome(
+        writer, config, marker, tv_client, sleeper,
+    )?);
+
+    let cycle_outcome = decide_system_sleep_cycle_outcome(&outcome, marker.exists());
+    cycle_state.write_outcome(cycle_outcome)?;
+    let disposition = match cycle_outcome {
+        SystemSleepCycleOutcome::RetryableTransportFailure => {
+            SuspendRailDisposition::RetryableFailure
+        }
+        SystemSleepCycleOutcome::InProgress | SystemSleepCycleOutcome::Completed => {
+            SuspendRailDisposition::OwnerCompleted
+        }
+    };
+
+    Ok((outcome, disposition))
+}
+
+pub(crate) fn handle_system_suspend_with<W: Write, C: TvClient, Sl: Sleeper>(
+    writer: &mut W,
+    config: &Config,
+    marker: &ScreenOwnershipMarker,
+    cycle_state: &SystemSleepCycleState,
+    tv_client: &C,
+    sleeper: &Sl,
+    event: RuntimeEvent,
+) -> Result<(), RunError> {
+    handle_system_suspend_with_outcome(
+        writer,
+        config,
+        marker,
+        cycle_state,
+        tv_client,
+        sleeper,
+        event,
+    )
+    .map(|_| ())
 }
 
 pub(crate) fn attempt_system_sleep_power_off_once_with_outcome<
@@ -1339,6 +1445,29 @@ fn render_restore_after_system_sleep_start<W: Write>(
     Ok(())
 }
 
+fn duplicate_system_suspend_outcome(detail: impl Into<String>) -> PolicyOutcome {
+    PolicyOutcome::new().with_no_action(DecisionReason::with_detail(
+        DecisionReasonCode::DuplicateSystemSleepAttempt,
+        detail,
+    ))
+}
+
+fn decide_system_sleep_cycle_outcome(
+    outcome: &PolicyOutcome,
+    marker_exists: bool,
+) -> SystemSleepCycleOutcome {
+    let power_off_selected = outcome
+        .actions
+        .iter()
+        .any(|action| action.kind == ActionKind::TvSystemSleepPowerOff);
+
+    if power_off_selected && !marker_exists {
+        SystemSleepCycleOutcome::RetryableTransportFailure
+    } else {
+        SystemSleepCycleOutcome::Completed
+    }
+}
+
 fn apply_system_screen_marker_transitions(
     marker: &ScreenOwnershipMarker,
     outcome: &PolicyOutcome,
@@ -1493,6 +1622,13 @@ pub(crate) fn startup_retry_delay(attempt: u32) -> Duration {
     )
 }
 
+pub(crate) fn system_sleep_rail_deadline() -> Duration {
+    duration_override_secs(
+        "LG_BUDDY_SYSTEM_SLEEP_RAIL_DEADLINE_SECS",
+        SYSTEM_SLEEP_RAIL_DEADLINE,
+    )
+}
+
 fn tv_route_wait_attempts() -> u32 {
     env::var("LG_BUDDY_TV_ROUTE_WAIT_ATTEMPTS")
         .ok()
@@ -1558,13 +1694,15 @@ mod tests {
         attempt_system_sleep_power_off_with_outcome, decide_network_teardown,
         decide_restore_after_system_sleep_start, decide_shutdown_after_input,
         decide_shutdown_after_reboot, decide_startup_route, decide_system_sleep_after_input,
-        decide_system_sleep_attempt_start, decide_system_sleep_power_off_result,
-        handle_network_teardown_with_outcome, nm_online_status_result,
+        decide_system_sleep_attempt_start, decide_system_sleep_cycle_outcome,
+        decide_system_sleep_power_off_result, handle_network_teardown_with_outcome,
+        handle_system_suspend_with_outcome, nm_online_status_result,
         restore_after_system_sleep_with_outcome, run_shutdown_with_outcome,
         run_startup_with_outcome, LifecycleEvent, NetworkTeardownDeps, NetworkTeardownNext,
         NetworkTeardownPolicyInput, NetworkWaiter, RebootDetector, RebootObservation, RestoreNext,
-        ShutdownNext, Sleeper, StartupDeps, StartupRoute, SystemSleepAttemptNext, SystemSleepNext,
-        SystemSleepPowerOffContext, TvEffectObservation, TvInputObservation,
+        ShutdownNext, Sleeper, StartupDeps, StartupRoute, SuspendRailDisposition,
+        SystemSleepAttemptNext, SystemSleepNext, SystemSleepPowerOffContext, TvEffectObservation,
+        TvInputObservation,
     };
     use crate::config::{
         Config, HdmiInput, MacAddress, ScreenBackend, ScreenIdleBlankPolicy, ScreenRestorePolicy,
@@ -1575,7 +1713,10 @@ mod tests {
         ActionKind, DecisionReasonCode, StateMarker, StateTransition, TransitionReason,
         TransitionReasonCode,
     };
-    use crate::state::{ScreenOwnershipMarker, SystemSleepAttemptState};
+    use crate::state::{
+        ScreenOwnershipMarker, SystemSleepAttemptState, SystemSleepCycleOutcome,
+        SystemSleepCycleState,
+    };
     use crate::tv::{BscpylgtvCommandClient, CurrentInput};
     use crate::wol::{WakeOnLanError, WakeOnLanSender};
     use crate::StartupMode;
@@ -1587,7 +1728,7 @@ mod tests {
     use std::process::{self, ExitStatus};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{Duration, UNIX_EPOCH};
-    use support::MockBscpylgtv;
+    use support::{MockBscpylgtv, TestEnv};
 
     #[test]
     fn pure_startup_policy_routes_from_mode_and_marker_observation() {
@@ -1981,6 +2122,183 @@ mod tests {
         assert!(marker.exists());
         assert!(!attempt_state.exists());
         assert_call_commands(&mock, &["get_input", "power_off"]);
+    }
+
+    #[test]
+    fn system_suspend_rail_owner_completes_cycle_and_duplicate_skips_tv_work() {
+        let temp_dir = TestDir::new("lifecycle-suspend-rail-completed");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let cycle_state = SystemSleepCycleState::new(temp_dir.path().to_path_buf());
+        let mock = MockBscpylgtv::new("lifecycle-suspend-rail-completed-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let sleeper = RecordingSleeper::default();
+        let event =
+            RuntimeEvent::from_command(crate::Command::SleepPre).expect("sleep-pre runtime event");
+
+        let mut first_output = Vec::new();
+        let (first_outcome, first_disposition) = handle_system_suspend_with_outcome(
+            &mut first_output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &cycle_state,
+            &client,
+            &sleeper,
+            event,
+        )
+        .expect("first rail owner should complete");
+
+        assert_eq!(first_disposition, SuspendRailDisposition::OwnerCompleted);
+        assert_eq!(
+            cycle_state.read_outcome().expect("read completed outcome"),
+            Some(SystemSleepCycleOutcome::Completed)
+        );
+        assert!(marker.exists());
+        assert_eq!(
+            first_outcome
+                .actions
+                .iter()
+                .map(|action| action.kind)
+                .collect::<Vec<_>>(),
+            vec![ActionKind::TvSystemSleepPowerOff]
+        );
+        assert_call_commands(&mock, &["get_input", "power_off"]);
+        assert!(!cycle_state.exists());
+
+        let mut second_output = Vec::new();
+        let (second_outcome, second_disposition) = handle_system_suspend_with_outcome(
+            &mut second_output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &cycle_state,
+            &client,
+            &sleeper,
+            event,
+        )
+        .expect("duplicate rail caller should skip");
+
+        assert_eq!(
+            second_disposition,
+            SuspendRailDisposition::DuplicateCompleted
+        );
+        assert!(second_outcome.actions.is_empty());
+        assert_eq!(
+            second_outcome.no_actions[0].reason.code,
+            DecisionReasonCode::DuplicateSystemSleepAttempt
+        );
+        assert_call_commands(&mock, &["get_input", "power_off"]);
+    }
+
+    #[test]
+    fn system_suspend_rail_duplicate_observes_in_progress_owner() {
+        let temp_dir = TestDir::new("lifecycle-suspend-rail-in-progress");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let cycle_state = SystemSleepCycleState::new(temp_dir.path().to_path_buf());
+        let _owner = cycle_state
+            .try_lock()
+            .expect("acquire owner lock")
+            .expect("owner lock should be available");
+        cycle_state
+            .write_outcome(SystemSleepCycleOutcome::InProgress)
+            .expect("write in-progress outcome");
+        let mock = MockBscpylgtv::new("lifecycle-suspend-rail-in-progress-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let sleeper = RecordingSleeper::default();
+
+        let mut output = Vec::new();
+        let (outcome, disposition) = handle_system_suspend_with_outcome(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &cycle_state,
+            &client,
+            &sleeper,
+            RuntimeEvent::from_logind_prepare_for_sleep(true),
+        )
+        .expect("duplicate rail caller should observe in-progress owner");
+
+        assert_eq!(disposition, SuspendRailDisposition::JoinedInProgress);
+        assert!(outcome.actions.is_empty());
+        assert_eq!(
+            outcome.no_actions[0].reason.code,
+            DecisionReasonCode::DuplicateSystemSleepAttempt
+        );
+        assert_call_commands(&mock, &[]);
+    }
+
+    #[test]
+    fn system_suspend_rail_records_retryable_transport_failure() {
+        let temp_dir = TestDir::new("lifecycle-suspend-rail-retryable");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let cycle_state = SystemSleepCycleState::new(temp_dir.path().to_path_buf());
+        let mock = MockBscpylgtv::new("lifecycle-suspend-rail-retryable-tv");
+        mock.set_input("HDMI_2");
+        mock.queue_error("power_off", 1, "offline");
+        let client = client_for_mock(&mock);
+        let sleeper = RecordingSleeper::default();
+
+        let mut output = Vec::new();
+        let (outcome, disposition) = handle_system_suspend_with_outcome(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &cycle_state,
+            &client,
+            &sleeper,
+            RuntimeEvent::from_logind_prepare_for_sleep(true),
+        )
+        .expect("rail owner should record retryable failure");
+
+        assert_eq!(disposition, SuspendRailDisposition::RetryableFailure);
+        assert_eq!(
+            cycle_state.read_outcome().expect("read retryable outcome"),
+            Some(SystemSleepCycleOutcome::RetryableTransportFailure)
+        );
+        assert!(!marker.exists());
+        assert_eq!(
+            outcome
+                .actions
+                .iter()
+                .map(|action| action.kind)
+                .collect::<Vec<_>>(),
+            vec![ActionKind::TvSystemSleepPowerOff]
+        );
+        assert_call_commands(&mock, &["get_input", "power_off"]);
+    }
+
+    #[test]
+    fn system_sleep_cycle_outcome_treats_noop_as_completed_and_failed_action_as_retryable() {
+        let noop = crate::policy::PolicyOutcome::new().with_no_action(
+            crate::policy::DecisionReason::new(DecisionReasonCode::InputMismatch),
+        );
+        assert_eq!(
+            decide_system_sleep_cycle_outcome(&noop, false),
+            SystemSleepCycleOutcome::Completed
+        );
+
+        let failed_action = crate::policy::PolicyOutcome::new().with_action(
+            ActionKind::TvSystemSleepPowerOff,
+            crate::policy::DecisionReason::new(DecisionReasonCode::RuntimeEvent),
+        );
+        assert_eq!(
+            decide_system_sleep_cycle_outcome(&failed_action, false),
+            SystemSleepCycleOutcome::RetryableTransportFailure
+        );
+        assert_eq!(
+            decide_system_sleep_cycle_outcome(&failed_action, true),
+            SystemSleepCycleOutcome::Completed
+        );
+    }
+
+    #[test]
+    fn system_sleep_rail_deadline_has_default_and_env_override() {
+        let mut env = TestEnv::new();
+        env.remove("LG_BUDDY_SYSTEM_SLEEP_RAIL_DEADLINE_SECS");
+        assert_eq!(super::system_sleep_rail_deadline(), Duration::from_secs(4));
+
+        env.set("LG_BUDDY_SYSTEM_SLEEP_RAIL_DEADLINE_SECS", "9");
+        assert_eq!(super::system_sleep_rail_deadline(), Duration::from_secs(9));
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -352,11 +352,13 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
     )?;
 
     let mut sleep_inhibitor = None;
-    acquire_lifecycle_sleep_delay_inhibitor_if_enabled(
+    let mut waiting_for_resume = false;
+    sync_lifecycle_sleep_delay_inhibitor_if_idle(
         writer,
         bus,
         config_path,
         &mut sleep_inhibitor,
+        waiting_for_resume,
     )?;
 
     let started = Instant::now();
@@ -378,6 +380,14 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
                 .min(timeout.saturating_sub(started.elapsed()));
         }
 
+        sync_lifecycle_sleep_delay_inhibitor_if_idle(
+            writer,
+            bus,
+            config_path,
+            &mut sleep_inhibitor,
+            waiting_for_resume,
+        )?;
+
         let Some(signal) =
             bus.process(process_timeout)
                 .map_err(|err| SessionRunnerError::Failed {
@@ -393,6 +403,12 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
         };
 
         let event_kind = LifecycleEvent::from_runtime_event(event);
+        match event_kind {
+            Some(LifecycleEvent::MachinePreparingForSleep) => waiting_for_resume = true,
+            Some(LifecycleEvent::MachineResumed) => waiting_for_resume = false,
+            _ => {}
+        }
+
         if !lifecycle_policy_enabled_from_config(config_path)? {
             release_lifecycle_sleep_delay_inhibitor(writer, &mut sleep_inhibitor)?;
             writeln!(
@@ -409,11 +425,12 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
         match event_kind {
             Some(LifecycleEvent::MachineResumed) => {
                 dispatcher.dispatch_lifecycle_event(writer, event)?;
-                acquire_lifecycle_sleep_delay_inhibitor_if_enabled(
+                sync_lifecycle_sleep_delay_inhibitor_if_idle(
                     writer,
                     bus,
                     config_path,
                     &mut sleep_inhibitor,
+                    waiting_for_resume,
                 )?;
             }
             Some(LifecycleEvent::MachinePreparingForSleep) => {
@@ -436,13 +453,19 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
     }
 }
 
-fn acquire_lifecycle_sleep_delay_inhibitor_if_enabled<W: Write>(
+fn sync_lifecycle_sleep_delay_inhibitor_if_idle<W: Write>(
     writer: &mut W,
     bus: &mut impl SessionBusClient,
     config_path: &Path,
     sleep_inhibitor: &mut Option<OwnedFd>,
+    waiting_for_resume: bool,
 ) -> Result<(), SessionRunnerError> {
-    if sleep_inhibitor.is_some() || !lifecycle_policy_enabled_from_config(config_path)? {
+    if !lifecycle_policy_enabled_from_config(config_path)? {
+        release_lifecycle_sleep_delay_inhibitor(writer, sleep_inhibitor)?;
+        return Ok(());
+    }
+
+    if waiting_for_resume || sleep_inhibitor.is_some() {
         return Ok(());
     }
 
@@ -1572,6 +1595,7 @@ mod tests {
         method_calls: Vec<(String, String, String, String)>,
         inhibitor_write_fds: Vec<i32>,
         disable_config_after_signals: Option<PathBuf>,
+        enable_config_after_idle: Option<PathBuf>,
     }
 
     impl SessionBusClient for FakeSessionBus {
@@ -1635,6 +1659,9 @@ mod tests {
 
             if let Some(config_path) = self.disable_config_after_signals.take() {
                 write_lifecycle_config(&config_path, "disabled");
+            }
+            if let Some(config_path) = self.enable_config_after_idle.take() {
+                write_lifecycle_config(&config_path, "enabled");
             }
 
             Ok(None)
@@ -1806,6 +1833,7 @@ system_sleep_wake_policy={policy}
             method_calls: Vec::new(),
             inhibitor_write_fds: Vec::new(),
             disable_config_after_signals: Some(config_path.clone()),
+            enable_config_after_idle: None,
         };
         let mut output = Vec::new();
 
@@ -1854,6 +1882,7 @@ system_sleep_wake_policy={policy}
             method_calls: Vec::new(),
             inhibitor_write_fds: Vec::new(),
             disable_config_after_signals: None,
+            enable_config_after_idle: None,
         };
         let mut output = Vec::new();
 
@@ -1869,6 +1898,45 @@ system_sleep_wake_policy={policy}
         assert!(bus.method_calls.is_empty());
         fs::remove_file(config_path).expect("remove lifecycle test config");
         std::env::remove_var(super::LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV);
+    }
+
+    #[test]
+    fn lifecycle_monitor_reacquires_inhibitor_when_policy_is_reenabled_while_idle() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::env::set_var(super::LIFECYCLE_MONITOR_TEST_TIMEOUT_SECS_ENV, "0.2");
+
+        let config_path = unique_config_path("lifecycle-reenabled");
+        write_lifecycle_config(&config_path, "disabled");
+        let executor = FakeActionExecutor::default();
+        let mut bus = FakeLifecycleBus {
+            signals: VecDeque::new(),
+            signal_match_count: 0,
+            method_calls: Vec::new(),
+            inhibitor_write_fds: Vec::new(),
+            disable_config_after_signals: None,
+            enable_config_after_idle: Some(config_path.clone()),
+        };
+        let mut output = Vec::new();
+
+        run_lifecycle_monitor_with_bus(&mut output, executor, &config_path, &mut bus)
+            .expect("lifecycle loop exits cleanly after test timeout");
+
+        let output = String::from_utf8(output).expect("utf8");
+        assert!(output.contains("Using logind system lifecycle source"));
+        assert!(output.contains("Acquired logind sleep delay inhibitor"));
+        assert_eq!(bus.signal_match_count, 1);
+        assert_eq!(
+            bus.method_calls
+                .iter()
+                .map(|(_, _, _, member)| member.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Inhibit"]
+        );
+        assert!(bus.enable_config_after_idle.is_none());
+        fs::remove_file(config_path).expect("remove lifecycle test config");
+        std::env::remove_var(super::LIFECYCLE_MONITOR_TEST_TIMEOUT_SECS_ENV);
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::fmt;
 use std::fs;
 use std::io::{self, Write};
+use std::os::fd::OwnedFd;
 use std::path::Path;
 use std::process::Command as ProcessCommand;
 use std::sync::{
@@ -16,7 +17,7 @@ use crate::backend::{
     configured_backend_from_env_or_config, detect_backend_from_system, BackendDetectionError,
     BackendSelectionError,
 };
-use crate::commands::run_system_resume;
+use crate::commands::{run_sleep_pre_for_event, run_system_resume};
 use crate::config::{
     load_config, normalize_idle_timeout_secs, parse_config_entries, parse_idle_timeout_secs,
     resolve_config_path_from_env, ConfigPathError, ScreenBackend, ScreenIdleBlankPolicy,
@@ -42,7 +43,9 @@ use crate::sources::desktop::gnome::{
     screen_saver_owner_changed, GnomeBackend, SystemGnomeProbe, GNOME_SCREEN_SAVER_INTERFACE,
     GNOME_SCREEN_SAVER_PATH, GNOME_SHELL_NAME,
 };
-use crate::sources::linux::logind::{add_logind_signal_match, map_prepare_for_sleep_signal};
+use crate::sources::linux::logind::{
+    acquire_sleep_delay_inhibitor, add_logind_signal_match, map_prepare_for_sleep_signal,
+};
 use crate::RunError;
 
 const GNOME_WAIT_TIMEOUT_SECS: u64 = 15;
@@ -93,8 +96,8 @@ impl SessionActionExecutor for RuntimeActionExecutor {
         run_action(|writer| crate::screen::run_screen_on_from_env_for_event(writer, event))
     }
 
-    fn before_sleep(&mut self, _event: RuntimeEvent) -> Result<String, RunError> {
-        run_action(crate::commands::run_sleep_pre)
+    fn before_sleep(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
+        run_action(|writer| run_sleep_pre_for_event(writer, event))
     }
 
     fn after_resume(&mut self, _event: RuntimeEvent) -> Result<String, RunError> {
@@ -283,8 +286,15 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
                 writeln!(writer, "LG Buddy Lifecycle: System is preparing for sleep.")?;
                 writeln!(
                     writer,
-                    "LG Buddy Lifecycle: logind pre-sleep is diagnostic only; NetworkManager pre-down owns TV power-off."
+                    "LG Buddy Lifecycle: logind pre-sleep requests TV power-off before suspend."
                 )?;
+                writer.flush()?;
+                match self.executor.before_sleep(event) {
+                    Ok(output) => write_command_output(writer, &output)?,
+                    Err(err) => {
+                        writeln!(writer, "LG Buddy Lifecycle: pre-sleep action failed. {err}")?
+                    }
+                }
             }
             Some(_) | None => {}
         }
@@ -341,6 +351,14 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
         "LG Buddy Lifecycle: Using logind system lifecycle source."
     )?;
 
+    let mut sleep_inhibitor = None;
+    acquire_lifecycle_sleep_delay_inhibitor_if_enabled(
+        writer,
+        bus,
+        config_path,
+        &mut sleep_inhibitor,
+    )?;
+
     let started = Instant::now();
     let test_timeout = resolve_lifecycle_monitor_test_timeout();
     let test_event_limit = resolve_lifecycle_monitor_test_event_limit();
@@ -374,7 +392,9 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
             continue;
         };
 
+        let event_kind = LifecycleEvent::from_runtime_event(event);
         if !lifecycle_policy_enabled_from_config(config_path)? {
+            release_lifecycle_sleep_delay_inhibitor(writer, &mut sleep_inhibitor)?;
             writeln!(
                 writer,
                 "LG Buddy Lifecycle: system sleep/wake handling is disabled by config; skipping lifecycle event."
@@ -386,16 +406,22 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
             continue;
         }
 
-        match LifecycleEvent::from_runtime_event(event) {
+        match event_kind {
             Some(LifecycleEvent::MachineResumed) => {
-                if lifecycle_policy_enabled_from_config(config_path)? {
-                    dispatcher.dispatch_lifecycle_event(writer, event)?;
-                } else {
-                    writeln!(
-                        writer,
-                        "LG Buddy Lifecycle: system sleep/wake handling is disabled by config; skipping lifecycle event."
-                    )?;
-                }
+                dispatcher.dispatch_lifecycle_event(writer, event)?;
+                acquire_lifecycle_sleep_delay_inhibitor_if_enabled(
+                    writer,
+                    bus,
+                    config_path,
+                    &mut sleep_inhibitor,
+                )?;
+            }
+            Some(LifecycleEvent::MachinePreparingForSleep) => {
+                let dispatch_result = dispatcher.dispatch_lifecycle_event(writer, event);
+                let release_result =
+                    release_lifecycle_sleep_delay_inhibitor(writer, &mut sleep_inhibitor);
+                dispatch_result?;
+                release_result?;
             }
             Some(_) => {
                 dispatcher.dispatch_lifecycle_event(writer, event)?;
@@ -408,6 +434,43 @@ fn run_lifecycle_monitor_with_bus<W: Write, E: SessionActionExecutor>(
             return Ok(());
         }
     }
+}
+
+fn acquire_lifecycle_sleep_delay_inhibitor_if_enabled<W: Write>(
+    writer: &mut W,
+    bus: &mut impl SessionBusClient,
+    config_path: &Path,
+    sleep_inhibitor: &mut Option<OwnedFd>,
+) -> Result<(), SessionRunnerError> {
+    if sleep_inhibitor.is_some() || !lifecycle_policy_enabled_from_config(config_path)? {
+        return Ok(());
+    }
+
+    let inhibitor =
+        acquire_sleep_delay_inhibitor(bus).map_err(|err| SessionRunnerError::Failed {
+            backend: ScreenBackend::Auto,
+            message: format!("failed to acquire logind sleep delay inhibitor: {err}"),
+        })?;
+    *sleep_inhibitor = Some(inhibitor);
+    writeln!(
+        writer,
+        "LG Buddy Lifecycle: Acquired logind sleep delay inhibitor."
+    )?;
+    Ok(())
+}
+
+fn release_lifecycle_sleep_delay_inhibitor<W: Write>(
+    writer: &mut W,
+    sleep_inhibitor: &mut Option<OwnedFd>,
+) -> Result<(), SessionRunnerError> {
+    if sleep_inhibitor.take().is_some() {
+        writeln!(
+            writer,
+            "LG Buddy Lifecycle: Released logind sleep delay inhibitor."
+        )?;
+    }
+
+    Ok(())
 }
 
 fn lifecycle_policy_enabled_from_config(config_path: &Path) -> Result<bool, SessionRunnerError> {
@@ -1506,6 +1569,8 @@ mod tests {
     struct FakeLifecycleBus {
         signals: VecDeque<BusSignal>,
         signal_match_count: usize,
+        method_calls: Vec<(String, String, String, String)>,
+        inhibitor_write_fds: Vec<i32>,
         disable_config_after_signals: Option<PathBuf>,
     }
 
@@ -1544,8 +1609,18 @@ mod tests {
             unreachable!("name probing is not used in lifecycle loop tests")
         }
 
-        fn call_method(&mut self, _call: BusMethodCall<'_>) -> Result<BusReply, SessionBusError> {
-            unreachable!("method calls are not used in lifecycle loop tests")
+        fn call_method(&mut self, call: BusMethodCall<'_>) -> Result<BusReply, SessionBusError> {
+            self.method_calls.push((
+                call.destination.to_string(),
+                call.path.to_string(),
+                call.interface.to_string(),
+                call.member.to_string(),
+            ));
+            let mut pipe_fds = [0; 2];
+            let pipe_result = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
+            assert_eq!(pipe_result, 0, "test pipe should be created");
+            self.inhibitor_write_fds.push(pipe_fds[1]);
+            Ok(BusReply::new(vec![BusValue::UnixFd(pipe_fds[0])]))
         }
 
         fn add_signal_match(&mut self, _rule: BusSignalMatch<'_>) -> Result<(), SessionBusError> {
@@ -1563,6 +1638,16 @@ mod tests {
             }
 
             Ok(None)
+        }
+    }
+
+    impl Drop for FakeLifecycleBus {
+        fn drop(&mut self) {
+            for fd in self.inhibitor_write_fds.drain(..) {
+                unsafe {
+                    libc::close(fd);
+                }
+            }
         }
     }
 
@@ -1699,7 +1784,7 @@ system_sleep_wake_policy={policy}
     }
 
     #[test]
-    fn lifecycle_monitor_treats_logind_sleep_as_diagnostic_and_dispatches_resume() {
+    fn lifecycle_monitor_dispatches_logind_sleep_and_reacquires_inhibitor_after_resume() {
         let _guard = env_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -1718,6 +1803,8 @@ system_sleep_wake_policy={policy}
                 prepare_for_sleep_signal(false),
             ]),
             signal_match_count: 0,
+            method_calls: Vec::new(),
+            inhibitor_write_fds: Vec::new(),
             disable_config_after_signals: Some(config_path.clone()),
         };
         let mut output = Vec::new();
@@ -1727,12 +1814,22 @@ system_sleep_wake_policy={policy}
 
         let output = String::from_utf8(output).expect("utf8");
         assert!(output.contains("Using logind system lifecycle source"));
+        assert!(output.contains("Acquired logind sleep delay inhibitor"));
         assert!(output.contains("System is preparing for sleep"));
-        assert!(output.contains("diagnostic only"));
+        assert!(output.contains("before-sleep output"));
+        assert!(output.contains("Released logind sleep delay inhibitor"));
         assert!(output.contains("System resumed from sleep"));
         assert!(output.contains("after-resume output"));
+        assert!(!output.contains("diagnostic only"));
         assert!(!output.contains("stopping lifecycle monitor"));
         assert_eq!(bus.signal_match_count, 1);
+        assert_eq!(
+            bus.method_calls
+                .iter()
+                .map(|(_, _, _, member)| member.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Inhibit", "Inhibit"]
+        );
         assert!(bus.disable_config_after_signals.is_some());
         fs::remove_file(config_path).expect("remove lifecycle test config");
         std::env::remove_var(super::LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV);
@@ -1754,6 +1851,8 @@ system_sleep_wake_policy={policy}
         let mut bus = FakeLifecycleBus {
             signals: VecDeque::from([prepare_for_sleep_signal(false)]),
             signal_match_count: 0,
+            method_calls: Vec::new(),
+            inhibitor_write_fds: Vec::new(),
             disable_config_after_signals: None,
         };
         let mut output = Vec::new();
@@ -1767,6 +1866,7 @@ system_sleep_wake_policy={policy}
         assert!(!output.contains("System resumed from sleep"));
         assert!(!output.contains("after-resume output"));
         assert_eq!(bus.signal_match_count, 1);
+        assert!(bus.method_calls.is_empty());
         fs::remove_file(config_path).expect("remove lifecycle test config");
         std::env::remove_var(super::LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV);
     }

--- a/crates/lg-buddy/src/sources/linux/network_manager.rs
+++ b/crates/lg-buddy/src/sources/linux/network_manager.rs
@@ -161,18 +161,24 @@ mod tests {
         }
     }
 
-    struct CompletingSleeper {
+    struct StateWritingSleeper {
         durations: RefCell<Vec<Duration>>,
         attempt_state: SystemSleepAttemptState,
         outcome: SystemSleepCycleOutcome,
+        owner: RefCell<Option<SystemSleepAttemptLock>>,
     }
 
-    impl CompletingSleeper {
-        fn new(attempt_state: SystemSleepAttemptState, outcome: SystemSleepCycleOutcome) -> Self {
+    impl StateWritingSleeper {
+        fn new(
+            attempt_state: SystemSleepAttemptState,
+            outcome: SystemSleepCycleOutcome,
+            owner: Option<SystemSleepAttemptLock>,
+        ) -> Self {
             Self {
                 durations: RefCell::new(Vec::new()),
                 attempt_state,
                 outcome,
+                owner: RefCell::new(owner),
             }
         }
 
@@ -181,41 +187,12 @@ mod tests {
         }
     }
 
-    impl Sleeper for CompletingSleeper {
+    impl Sleeper for StateWritingSleeper {
         fn sleep(&self, duration: Duration) {
             self.durations.borrow_mut().push(duration);
             self.attempt_state
                 .write_outcome(self.outcome)
                 .expect("write terminal outcome during wait");
-        }
-    }
-
-    struct RetryableReleasingSleeper {
-        durations: RefCell<Vec<Duration>>,
-        attempt_state: SystemSleepAttemptState,
-        owner: RefCell<Option<SystemSleepAttemptLock>>,
-    }
-
-    impl RetryableReleasingSleeper {
-        fn new(attempt_state: SystemSleepAttemptState, owner: SystemSleepAttemptLock) -> Self {
-            Self {
-                durations: RefCell::new(Vec::new()),
-                attempt_state,
-                owner: RefCell::new(Some(owner)),
-            }
-        }
-
-        fn durations(&self) -> Vec<Duration> {
-            self.durations.borrow().clone()
-        }
-    }
-
-    impl Sleeper for RetryableReleasingSleeper {
-        fn sleep(&self, duration: Duration) {
-            self.durations.borrow_mut().push(duration);
-            self.attempt_state
-                .write_outcome(SystemSleepCycleOutcome::RetryableTransportFailure)
-                .expect("write retryable outcome during wait");
             drop(self.owner.borrow_mut().take());
         }
     }
@@ -401,8 +378,11 @@ mod tests {
         let mock = MockBscpylgtv::new("nm-pre-down-waits-in-progress-tv");
         mock.set_input("HDMI_2");
         let client = client_for_mock(&mock);
-        let sleeper =
-            CompletingSleeper::new(attempt_state.clone(), SystemSleepCycleOutcome::Completed);
+        let sleeper = StateWritingSleeper::new(
+            attempt_state.clone(),
+            SystemSleepCycleOutcome::Completed,
+            None,
+        );
         let mut bus = FakeBus::preparing_for_sleep(true);
         let mut output = Vec::new();
 
@@ -479,7 +459,11 @@ mod tests {
         let mock = MockBscpylgtv::new("nm-pre-down-in-progress-retryable-tv");
         mock.set_input("HDMI_2");
         let client = client_for_mock(&mock);
-        let sleeper = RetryableReleasingSleeper::new(attempt_state.clone(), owner);
+        let sleeper = StateWritingSleeper::new(
+            attempt_state.clone(),
+            SystemSleepCycleOutcome::RetryableTransportFailure,
+            Some(owner),
+        );
         let mut bus = FakeBus::preparing_for_sleep(true);
         let mut output = Vec::new();
 

--- a/crates/lg-buddy/src/sources/linux/network_manager.rs
+++ b/crates/lg-buddy/src/sources/linux/network_manager.rs
@@ -80,7 +80,10 @@ mod tests {
         BusMethodCall, BusReply, BusSignal, BusSignalMatch, BusValue, SessionBusClient,
         SessionBusError,
     };
-    use crate::state::{ScreenOwnershipMarker, SystemSleepAttemptState};
+    use crate::state::{
+        ScreenOwnershipMarker, SystemSleepAttemptLock, SystemSleepAttemptState,
+        SystemSleepCycleOutcome,
+    };
     use crate::tv::BscpylgtvCommandClient;
     use std::cell::RefCell;
     use std::collections::VecDeque;
@@ -155,6 +158,65 @@ mod tests {
     impl Sleeper for RecordingSleeper {
         fn sleep(&self, duration: Duration) {
             self.durations.borrow_mut().push(duration);
+        }
+    }
+
+    struct CompletingSleeper {
+        durations: RefCell<Vec<Duration>>,
+        attempt_state: SystemSleepAttemptState,
+        outcome: SystemSleepCycleOutcome,
+    }
+
+    impl CompletingSleeper {
+        fn new(attempt_state: SystemSleepAttemptState, outcome: SystemSleepCycleOutcome) -> Self {
+            Self {
+                durations: RefCell::new(Vec::new()),
+                attempt_state,
+                outcome,
+            }
+        }
+
+        fn durations(&self) -> Vec<Duration> {
+            self.durations.borrow().clone()
+        }
+    }
+
+    impl Sleeper for CompletingSleeper {
+        fn sleep(&self, duration: Duration) {
+            self.durations.borrow_mut().push(duration);
+            self.attempt_state
+                .write_outcome(self.outcome)
+                .expect("write terminal outcome during wait");
+        }
+    }
+
+    struct RetryableReleasingSleeper {
+        durations: RefCell<Vec<Duration>>,
+        attempt_state: SystemSleepAttemptState,
+        owner: RefCell<Option<SystemSleepAttemptLock>>,
+    }
+
+    impl RetryableReleasingSleeper {
+        fn new(attempt_state: SystemSleepAttemptState, owner: SystemSleepAttemptLock) -> Self {
+            Self {
+                durations: RefCell::new(Vec::new()),
+                attempt_state,
+                owner: RefCell::new(Some(owner)),
+            }
+        }
+
+        fn durations(&self) -> Vec<Duration> {
+            self.durations.borrow().clone()
+        }
+    }
+
+    impl Sleeper for RetryableReleasingSleeper {
+        fn sleep(&self, duration: Duration) {
+            self.durations.borrow_mut().push(duration);
+            self.attempt_state
+                .write_outcome(SystemSleepCycleOutcome::RetryableTransportFailure)
+                .expect("write retryable outcome during wait");
+            drop(self.owner.borrow_mut().take());
         }
     }
 
@@ -320,8 +382,126 @@ mod tests {
 
         assert!(marker.exists());
         assert!(!attempt_state.exists());
-        assert_call_commands(&mock, &["get_input", "power_off", "get_input", "power_off"]);
-        assert!(rendered(&output).contains("Could not query TV input"));
+        assert_call_commands(&mock, &["get_input", "power_off"]);
+        assert!(rendered(&output).contains("preparing for sleep"));
+    }
+
+    #[test]
+    fn pre_down_waits_when_logind_owned_cycle_is_in_progress() {
+        let temp_dir = TestDir::new("nm-pre-down-waits-in-progress");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let attempt_state = SystemSleepAttemptState::new(temp_dir.path().to_path_buf());
+        let _owner = attempt_state
+            .try_lock()
+            .expect("acquire logind owner lock")
+            .expect("logind owner lock should be available");
+        attempt_state
+            .write_outcome(SystemSleepCycleOutcome::InProgress)
+            .expect("write in-progress outcome");
+        let mock = MockBscpylgtv::new("nm-pre-down-waits-in-progress-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let sleeper =
+            CompletingSleeper::new(attempt_state.clone(), SystemSleepCycleOutcome::Completed);
+        let mut bus = FakeBus::preparing_for_sleep(true);
+        let mut output = Vec::new();
+
+        handle_pre_down_with(
+            &mut output,
+            &sample_config(SystemSleepWakePolicy::Enabled),
+            &marker,
+            &attempt_state,
+            &client,
+            &sleeper,
+            &mut bus,
+        )
+        .expect("pre-down should wait for in-progress rail");
+
+        assert!(sleeper.durations().len() >= 1);
+        assert_eq!(
+            attempt_state.read_outcome().expect("read cycle outcome"),
+            Some(SystemSleepCycleOutcome::Completed)
+        );
+        assert_call_commands(&mock, &[]);
+        assert!(rendered(&output).contains("suspend rail completed"));
+    }
+
+    #[test]
+    fn pre_down_releases_teardown_when_in_progress_cycle_times_out() {
+        let temp_dir = TestDir::new("nm-pre-down-in-progress-timeout");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let attempt_state = SystemSleepAttemptState::new(temp_dir.path().to_path_buf());
+        let _owner = attempt_state
+            .try_lock()
+            .expect("acquire logind owner lock")
+            .expect("logind owner lock should be available");
+        attempt_state
+            .write_outcome(SystemSleepCycleOutcome::InProgress)
+            .expect("write in-progress outcome");
+        let mock = MockBscpylgtv::new("nm-pre-down-in-progress-timeout-tv");
+        let client = client_for_mock(&mock);
+        let sleeper = RecordingSleeper::default();
+        let mut bus = FakeBus::preparing_for_sleep(true);
+        let mut output = Vec::new();
+
+        handle_pre_down_with(
+            &mut output,
+            &sample_config(SystemSleepWakePolicy::Enabled),
+            &marker,
+            &attempt_state,
+            &client,
+            &sleeper,
+            &mut bus,
+        )
+        .expect("pre-down should release teardown after bounded wait");
+
+        assert!(!sleeper.durations().is_empty());
+        assert_eq!(
+            attempt_state.read_outcome().expect("read cycle outcome"),
+            Some(SystemSleepCycleOutcome::InProgress)
+        );
+        assert_call_commands(&mock, &[]);
+        assert!(rendered(&output).contains("did not finish before deadline"));
+    }
+
+    #[test]
+    fn pre_down_retries_when_waiting_cycle_reports_retryable_failure() {
+        let temp_dir = TestDir::new("nm-pre-down-in-progress-retryable");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let attempt_state = SystemSleepAttemptState::new(temp_dir.path().to_path_buf());
+        let owner = attempt_state
+            .try_lock()
+            .expect("acquire logind owner lock")
+            .expect("logind owner lock should be available");
+        attempt_state
+            .write_outcome(SystemSleepCycleOutcome::InProgress)
+            .expect("write in-progress outcome");
+        let mock = MockBscpylgtv::new("nm-pre-down-in-progress-retryable-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let sleeper = RetryableReleasingSleeper::new(attempt_state.clone(), owner);
+        let mut bus = FakeBus::preparing_for_sleep(true);
+        let mut output = Vec::new();
+
+        handle_pre_down_with(
+            &mut output,
+            &sample_config(SystemSleepWakePolicy::Enabled),
+            &marker,
+            &attempt_state,
+            &client,
+            &sleeper,
+            &mut bus,
+        )
+        .expect("pre-down should retry retryable rail failure");
+
+        assert!(!sleeper.durations().is_empty());
+        assert_eq!(
+            attempt_state.read_outcome().expect("read cycle outcome"),
+            Some(SystemSleepCycleOutcome::Completed)
+        );
+        assert!(marker.exists());
+        assert_call_commands(&mock, &["get_input", "power_off"]);
+        assert!(rendered(&output).contains("retrying before network teardown"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/sources/linux/network_manager.rs
+++ b/crates/lg-buddy/src/sources/linux/network_manager.rs
@@ -397,7 +397,7 @@ mod tests {
         )
         .expect("pre-down should wait for in-progress rail");
 
-        assert!(sleeper.durations().len() >= 1);
+        assert!(!sleeper.durations().is_empty());
         assert_eq!(
             attempt_state.read_outcome().expect("read cycle outcome"),
             Some(SystemSleepCycleOutcome::Completed)

--- a/crates/lg-buddy/src/state.rs
+++ b/crates/lg-buddy/src/state.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fmt;
 use std::fs::File;
 use std::fs::{self, OpenOptions};
-use std::io;
+use std::io::{self, Write};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(unix)]
@@ -15,6 +15,7 @@ const STATE_DIR_NAME: &str = "lg_buddy";
 pub const SCREEN_OFF_BY_US_MARKER: &str = "screen_off_by_us";
 pub const SYSTEM_SLEEP_ATTEMPTED_MARKER: &str = "system_sleep_attempted";
 pub const SYSTEM_SLEEP_ATTEMPT_LOCK: &str = "system_sleep_attempt.lock";
+pub const SYSTEM_SLEEP_CYCLE_STATE: &str = "system_sleep_cycle";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StateScope {
@@ -95,13 +96,42 @@ pub fn resolve_state_dir_from_env(scope: StateScope) -> Result<PathBuf, StateDir
     )
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SystemSleepAttemptState {
-    marker_path: PathBuf,
-    lock_path: PathBuf,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemSleepCycleOutcome {
+    InProgress,
+    Completed,
+    RetryableTransportFailure,
 }
 
-impl SystemSleepAttemptState {
+impl SystemSleepCycleOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+            Self::RetryableTransportFailure => "retryable_transport_failure",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "in_progress" => Some(Self::InProgress),
+            "completed" => Some(Self::Completed),
+            "retryable_transport_failure" => Some(Self::RetryableTransportFailure),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemSleepCycleState {
+    marker_path: PathBuf,
+    lock_path: PathBuf,
+    cycle_path: PathBuf,
+}
+
+pub type SystemSleepAttemptState = SystemSleepCycleState;
+
+impl SystemSleepCycleState {
     pub fn for_scope(
         scope: StateScope,
         sources: RuntimeDirSources<'_>,
@@ -119,6 +149,7 @@ impl SystemSleepAttemptState {
         Self {
             marker_path: state_dir.join(SYSTEM_SLEEP_ATTEMPTED_MARKER),
             lock_path: state_dir.join(SYSTEM_SLEEP_ATTEMPT_LOCK),
+            cycle_path: state_dir.join(SYSTEM_SLEEP_CYCLE_STATE),
         }
     }
 
@@ -128,6 +159,10 @@ impl SystemSleepAttemptState {
 
     pub fn lock_path(&self) -> &Path {
         &self.lock_path
+    }
+
+    pub fn cycle_path(&self) -> &Path {
+        &self.cycle_path
     }
 
     pub fn state_dir(&self) -> &Path {
@@ -153,18 +188,55 @@ impl SystemSleepAttemptState {
         self.marker_path.is_file()
     }
 
-    pub fn try_lock(&self) -> io::Result<Option<SystemSleepAttemptLock>> {
+    pub fn read_outcome(&self) -> io::Result<Option<SystemSleepCycleOutcome>> {
+        let content = match fs::read_to_string(&self.cycle_path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err),
+        };
+
+        let value = content
+            .lines()
+            .find_map(|line| line.strip_prefix("outcome="))
+            .unwrap_or_else(|| content.trim());
+
+        SystemSleepCycleOutcome::from_str(value)
+            .map(Some)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unknown system sleep cycle outcome `{value}`"),
+                )
+            })
+    }
+
+    pub fn write_outcome(&self, outcome: SystemSleepCycleOutcome) -> io::Result<()> {
+        fs::create_dir_all(self.state_dir())?;
+        write_state_file(&self.cycle_path, &format!("outcome={}\n", outcome.as_str()))
+    }
+
+    pub fn clear_outcome(&self) -> io::Result<()> {
+        match fs::remove_file(&self.cycle_path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn try_lock(&self) -> io::Result<Option<SystemSleepCycleLock>> {
         fs::create_dir_all(self.state_dir())?;
         let file = open_lock_file(&self.lock_path)?;
-        try_lock_file(file).map(|file| file.map(SystemSleepAttemptLock))
+        try_lock_file(file).map(|file| file.map(SystemSleepCycleLock))
     }
 }
 
 #[derive(Debug)]
-pub struct SystemSleepAttemptLock(File);
+pub struct SystemSleepCycleLock(File);
+
+pub type SystemSleepAttemptLock = SystemSleepCycleLock;
 
 #[cfg(unix)]
-impl Drop for SystemSleepAttemptLock {
+impl Drop for SystemSleepCycleLock {
     fn drop(&mut self) {
         let _ = unsafe { libc::flock(self.0.as_raw_fd(), libc::LOCK_UN) };
     }
@@ -293,6 +365,22 @@ fn create_marker_file(path: &Path) -> io::Result<()> {
 }
 
 #[cfg(unix)]
+fn write_state_file(path: &Path, content: &str) -> io::Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    file.write_all(content.as_bytes())
+}
+
+#[cfg(not(unix))]
+fn write_state_file(path: &Path, content: &str) -> io::Result<()> {
+    fs::write(path, content)
+}
+
+#[cfg(unix)]
 fn current_uid() -> Option<u32> {
     unsafe extern "C" {
         fn geteuid() -> u32;
@@ -310,8 +398,9 @@ fn current_uid() -> Option<u32> {
 mod tests {
     use super::{
         resolve_state_dir, RuntimeDirSources, ScreenOwnershipMarker, StateDirError, StateScope,
-        SystemSleepAttemptState, SCREEN_OFF_BY_US_MARKER, SYSTEM_SLEEP_ATTEMPTED_MARKER,
-        SYSTEM_SLEEP_ATTEMPT_LOCK,
+        SystemSleepAttemptState, SystemSleepCycleOutcome, SystemSleepCycleState,
+        SCREEN_OFF_BY_US_MARKER, SYSTEM_SLEEP_ATTEMPTED_MARKER, SYSTEM_SLEEP_ATTEMPT_LOCK,
+        SYSTEM_SLEEP_CYCLE_STATE,
     };
     use std::fs;
     #[cfg(unix)]
@@ -416,7 +505,7 @@ mod tests {
 
     #[test]
     fn system_sleep_attempt_state_uses_expected_files() {
-        let state = SystemSleepAttemptState::new(PathBuf::from("/tmp/lg-buddy-state"));
+        let state = SystemSleepCycleState::new(PathBuf::from("/tmp/lg-buddy-state"));
 
         assert_eq!(
             state.marker_path(),
@@ -425,6 +514,10 @@ mod tests {
         assert_eq!(
             state.lock_path(),
             Path::new("/tmp/lg-buddy-state").join(SYSTEM_SLEEP_ATTEMPT_LOCK)
+        );
+        assert_eq!(
+            state.cycle_path(),
+            Path::new("/tmp/lg-buddy-state").join(SYSTEM_SLEEP_CYCLE_STATE)
         );
     }
 
@@ -439,6 +532,50 @@ mod tests {
         state.clear().expect("clear attempted");
         assert!(!state.exists());
         state.clear().expect("clear missing attempted marker");
+    }
+
+    #[test]
+    fn system_sleep_cycle_outcome_round_trips_through_state_file() {
+        let temp_dir = TestDir::new("system-sleep-cycle-outcome");
+        let state = SystemSleepCycleState::new(temp_dir.path().to_path_buf());
+
+        assert_eq!(state.read_outcome().expect("read missing outcome"), None);
+
+        state
+            .write_outcome(SystemSleepCycleOutcome::InProgress)
+            .expect("write in-progress outcome");
+        assert_eq!(
+            fs::read_to_string(state.cycle_path()).expect("read outcome file"),
+            "outcome=in_progress\n"
+        );
+        assert_eq!(
+            state.read_outcome().expect("read in-progress outcome"),
+            Some(SystemSleepCycleOutcome::InProgress)
+        );
+
+        state
+            .write_outcome(SystemSleepCycleOutcome::Completed)
+            .expect("write completed outcome");
+        assert_eq!(
+            state.read_outcome().expect("read completed outcome"),
+            Some(SystemSleepCycleOutcome::Completed)
+        );
+
+        state.clear_outcome().expect("clear outcome");
+        assert_eq!(state.read_outcome().expect("read cleared outcome"), None);
+    }
+
+    #[test]
+    fn system_sleep_cycle_outcome_rejects_unknown_value() {
+        let temp_dir = TestDir::new("system-sleep-cycle-bad-outcome");
+        let state = SystemSleepCycleState::new(temp_dir.path().to_path_buf());
+        fs::write(state.cycle_path(), "outcome=maybe\n").expect("write bad outcome");
+
+        let err = state
+            .read_outcome()
+            .expect_err("bad cycle outcome should fail");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/lg-buddy/src/state.rs
+++ b/crates/lg-buddy/src/state.rs
@@ -9,6 +9,7 @@ use std::os::fd::AsRawFd;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::time::{Duration, SystemTime};
 
 const STATE_DIR_NAME: &str = "lg_buddy";
@@ -364,20 +365,54 @@ fn create_marker_file(path: &Path) -> io::Result<()> {
     fs::write(path, [])
 }
 
-#[cfg(unix)]
 fn write_state_file(path: &Path, content: &str) -> io::Result<()> {
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)?;
-    file.write_all(content.as_bytes())
+    let mut last_error = None;
+    for attempt in 0..100 {
+        let temp_path = state_temp_path(path, attempt);
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_NOFOLLOW);
+
+        let mut file = match options.open(&temp_path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                last_error = Some(err);
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
+
+        let result = (|| {
+            file.write_all(content.as_bytes())?;
+            file.flush()?;
+            file.sync_all()?;
+            drop(file);
+            fs::rename(&temp_path, path)
+        })();
+
+        if let Err(err) = result {
+            let _ = fs::remove_file(&temp_path);
+            return Err(err);
+        }
+
+        return Ok(());
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not create unique state temporary file",
+        )
+    }))
 }
 
-#[cfg(not(unix))]
-fn write_state_file(path: &Path, content: &str) -> io::Result<()> {
-    fs::write(path, content)
+fn state_temp_path(path: &Path, attempt: u8) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("state");
+    path.with_file_name(format!(".{file_name}.{}.{}.tmp", process::id(), attempt))
 }
 
 #[cfg(unix)]
@@ -397,10 +432,10 @@ fn current_uid() -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_state_dir, RuntimeDirSources, ScreenOwnershipMarker, StateDirError, StateScope,
-        SystemSleepAttemptState, SystemSleepCycleOutcome, SystemSleepCycleState,
-        SCREEN_OFF_BY_US_MARKER, SYSTEM_SLEEP_ATTEMPTED_MARKER, SYSTEM_SLEEP_ATTEMPT_LOCK,
-        SYSTEM_SLEEP_CYCLE_STATE,
+        resolve_state_dir, state_temp_path, RuntimeDirSources, ScreenOwnershipMarker,
+        StateDirError, StateScope, SystemSleepAttemptState, SystemSleepCycleOutcome,
+        SystemSleepCycleState, SCREEN_OFF_BY_US_MARKER, SYSTEM_SLEEP_ATTEMPTED_MARKER,
+        SYSTEM_SLEEP_ATTEMPT_LOCK, SYSTEM_SLEEP_CYCLE_STATE,
     };
     use std::fs;
     #[cfg(unix)]
@@ -563,6 +598,34 @@ mod tests {
 
         state.clear_outcome().expect("clear outcome");
         assert_eq!(state.read_outcome().expect("read cleared outcome"), None);
+    }
+
+    #[test]
+    fn system_sleep_cycle_outcome_failed_atomic_write_preserves_existing_file() {
+        let temp_dir = TestDir::new("system-sleep-cycle-atomic-failure");
+        let state = SystemSleepCycleState::new(temp_dir.path().to_path_buf());
+
+        state
+            .write_outcome(SystemSleepCycleOutcome::InProgress)
+            .expect("write initial outcome");
+        for attempt in 0..100 {
+            fs::write(state_temp_path(state.cycle_path(), attempt), "occupied")
+                .expect("occupy atomic temp path");
+        }
+
+        let err = state
+            .write_outcome(SystemSleepCycleOutcome::Completed)
+            .expect_err("colliding temp paths should fail");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            fs::read_to_string(state.cycle_path()).expect("read preserved outcome file"),
+            "outcome=in_progress\n"
+        );
+        assert_eq!(
+            state.read_outcome().expect("read preserved outcome"),
+            Some(SystemSleepCycleOutcome::InProgress)
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -290,7 +290,7 @@ fn settings_set_lifecycle_policy_updates_config_without_systemd_apply() {
 }
 
 #[test]
-fn run_system_resume_loads_config_and_clears_system_sleep_attempt() {
+fn run_system_resume_clears_sleep_cycle_state_and_preserves_session_marker() {
     let mock = MockBscpylgtv::new("entrypoint-system-resume-tv");
     let wrapper = mock.command_wrapper("entrypoint-system-resume-wrapper");
     let nm_online = MockNmOnline::new("entrypoint-system-resume-nm-online");
@@ -300,9 +300,12 @@ fn run_system_resume_loads_config_and_clears_system_sleep_attempt() {
     config.write_sample("HDMI_4");
 
     let runtime = RuntimeStateLayout::new("entrypoint-system-resume-runtime");
+    runtime.create_session_marker();
     runtime.create_system_marker();
     let attempt_marker = runtime.system_dir().join("system_sleep_attempted");
+    let cycle_state = runtime.system_dir().join("system_sleep_cycle");
     fs::write(&attempt_marker, "").expect("create attempt marker");
+    fs::write(&cycle_state, "outcome=completed\n").expect("create cycle state");
 
     let mut env = TestEnv::new();
     env.set("LG_BUDDY_CONFIG", config.path());
@@ -317,7 +320,9 @@ fn run_system_resume_loads_config_and_clears_system_sleep_attempt() {
     run_system_resume(&mut output).expect("system resume should succeed");
 
     runtime.assert_system_marker_absent();
+    runtime.assert_session_marker_exists();
     assert!(!attempt_marker.exists());
+    assert!(!cycle_state.exists());
     assert_eq!(
         mock.calls()
             .into_iter()
@@ -329,6 +334,50 @@ fn run_system_resume_loads_config_and_clears_system_sleep_attempt() {
     assert!(String::from_utf8(output)
         .expect("utf8 output")
         .contains("Wake from sleep: LG Buddy turned TV off. Restoring."));
+}
+
+#[test]
+fn run_system_resume_aggressive_policy_restores_without_system_marker() {
+    let mock = MockBscpylgtv::new("entrypoint-system-resume-aggressive-tv");
+    let wrapper = mock.command_wrapper("entrypoint-system-resume-aggressive-wrapper");
+    let nm_online = MockNmOnline::new("entrypoint-system-resume-aggressive-nm-online");
+    let nm_online_wrapper =
+        nm_online.command_wrapper("entrypoint-system-resume-aggressive-nm-online-wrapper");
+
+    let config = TestConfigFile::new("entrypoint-system-resume-aggressive-config");
+    config.write_sample("HDMI_4");
+    config.append_line("screen_restore_policy=aggressive");
+
+    let runtime = RuntimeStateLayout::new("entrypoint-system-resume-aggressive-runtime");
+    let cycle_state = runtime.system_dir().join("system_sleep_cycle");
+    fs::create_dir_all(runtime.system_dir()).expect("create system runtime dir");
+    fs::write(&cycle_state, "outcome=completed\n").expect("create cycle state");
+
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_BSCPYLGTV_COMMAND", wrapper.path());
+    env.set("LG_BUDDY_SYSTEM_RUNTIME_DIR", runtime.system_dir());
+    env.set("LG_BUDDY_NM_ONLINE", nm_online_wrapper.path());
+    env.set("LG_BUDDY_STARTUP_INITIAL_WAKE_DELAY_SECS", "0");
+    env.set("LG_BUDDY_TV_ROUTE_WAIT_ATTEMPTS", "1");
+    env.set("LG_BUDDY_TV_ROUTE_WAIT_DELAY_MS", "0");
+
+    let mut output = Vec::new();
+    run_system_resume(&mut output).expect("aggressive system resume should succeed");
+
+    runtime.assert_system_marker_absent();
+    assert!(!cycle_state.exists());
+    assert_eq!(
+        mock.calls()
+            .into_iter()
+            .map(|call| call.command)
+            .collect::<Vec<_>>(),
+        vec!["set_input".to_string()]
+    );
+    assert_eq!(nm_online.invocations().len(), 1);
+    let output = String::from_utf8(output).expect("utf8 output");
+    assert!(output.contains("State file not found. Aggressive restore policy is enabled"));
+    assert!(output.contains("Wake from sleep: Restoring display state."));
 }
 
 #[test]

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -584,6 +584,74 @@ fn run_lifecycle_monitor_uses_logind_resume_signal_and_runtime_restore() {
     assert!(!output.contains("stopping lifecycle monitor"));
 }
 
+#[test]
+fn run_lifecycle_monitor_uses_logind_sleep_signal_for_pre_sleep_power_off() {
+    let mut env = TestEnv::new();
+    let logind = MockSystemLogind::new("entrypoint-lifecycle-logind-sleep");
+    logind.reset();
+    let mock = MockBscpylgtv::new("entrypoint-lifecycle-sleep-tv");
+    mock.set_input("HDMI_2");
+    let wrapper = mock.command_wrapper("entrypoint-lifecycle-sleep-wrapper");
+
+    let config = TestConfigFile::new("entrypoint-lifecycle-sleep-config");
+    config.write_sample("HDMI_2");
+
+    let runtime = RuntimeStateLayout::new("entrypoint-lifecycle-sleep-runtime");
+
+    env.set("DBUS_SYSTEM_BUS_ADDRESS", logind.address());
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_BSCPYLGTV_COMMAND", wrapper.path());
+    env.set("LG_BUDDY_SYSTEM_RUNTIME_DIR", runtime.system_dir());
+    env.set("LG_BUDDY_LIFECYCLE_MONITOR_TEST_EVENT_LIMIT", "1");
+
+    let (done_tx, done_rx) = mpsc::channel();
+    let lifecycle_thread = thread::spawn(move || {
+        let mut output = Vec::new();
+        let result = run_command(Command::Lifecycle, &mut output).map_err(|err| err.to_string());
+        done_tx
+            .send((result, output))
+            .expect("send lifecycle result");
+    });
+
+    wait_until(Duration::from_secs(4), || {
+        let calls = mock.calls();
+        let power_off_count = calls
+            .iter()
+            .filter(|call| call.command == "power_off")
+            .count();
+
+        if power_off_count == 0 {
+            logind.queue_prepare_for_sleep_signal(true);
+        }
+
+        power_off_count == 1 && runtime.system_marker_path().exists()
+    });
+
+    assert_eq!(
+        mock.calls()
+            .iter()
+            .map(|call| call.command.as_str())
+            .collect::<Vec<_>>(),
+        vec!["get_input", "power_off"]
+    );
+    runtime.assert_system_marker_exists();
+
+    let (result, output) = done_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("lifecycle monitor should exit after test event limit");
+    lifecycle_thread
+        .join()
+        .expect("join lifecycle monitor thread");
+    result.expect("lifecycle monitor should succeed");
+
+    let output = String::from_utf8(output).expect("utf8 output");
+    assert!(output.contains("Using logind system lifecycle source"));
+    assert!(output.contains("System is preparing for sleep"));
+    assert!(output.contains("logind pre-sleep requests TV power-off"));
+    assert!(output.contains("Turning off for sleep"));
+    assert!(output.contains("Released logind sleep delay inhibitor"));
+}
+
 fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) {
     let deadline = Instant::now() + timeout;
     loop {

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -379,13 +379,13 @@ fn run_nm_pre_down_uses_logind_property_and_retries_idempotently() {
             .iter()
             .map(|call| call.command.as_str())
             .collect::<Vec<_>>(),
-        vec!["get_input", "power_off", "get_input", "power_off"]
+        vec!["get_input", "power_off"]
     );
     runtime.assert_system_marker_exists();
     runtime.assert_system_sleep_attempt_marker_absent();
     assert!(String::from_utf8(second_output)
         .expect("utf8 output")
-        .contains("Could not query TV input"));
+        .contains("logind is preparing for sleep"));
 }
 
 #[test]

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -9,6 +9,7 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::ErrorKind;
+use std::os::fd::FromRawFd;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command as ProcessCommand};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -765,7 +766,31 @@ fn spawn_mock_logind_service(
                     },
                 );
             });
-        crossroads.insert("/org/freedesktop/login1", &[properties_iface], ());
+        let manager_iface = crossroads.register("org.freedesktop.login1.Manager", move |builder| {
+            builder.method(
+                "Inhibit",
+                ("what", "who", "why", "mode"),
+                ("fd",),
+                move |_, _, (_what, _who, _why, _mode): (String, String, String, String)| {
+                    let mut pipe_fds = [0; 2];
+                    let pipe_result = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
+                    if pipe_result != 0 {
+                        return Err(MethodErr::failed("mock logind could not create pipe"));
+                    }
+
+                    unsafe {
+                        libc::close(pipe_fds[1]);
+                    }
+                    let fd = unsafe { dbus::arg::OwnedFd::from_raw_fd(pipe_fds[0]) };
+                    Ok((fd,))
+                },
+            );
+        });
+        crossroads.insert(
+            "/org/freedesktop/login1",
+            &[properties_iface, manager_iface],
+            (),
+        );
 
         let shared_crossroads = Arc::new(Mutex::new(crossroads));
         let crossroads_receiver = Arc::clone(&shared_crossroads);

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -436,8 +436,9 @@ Flow:
 
 ### `lifecycle`
 
-`lifecycle` is the system sleep/wake resume event loop. Linux pre-sleep TV
-power-off is owned by the NetworkManager pre-down gate.
+`lifecycle` is the system sleep/wake event loop. Linux pre-sleep TV power-off is
+owned by one cooperative suspend rail that accepts both logind
+`PrepareForSleep(true)` and NetworkManager `pre-down` opportunities.
 
 Flow:
 
@@ -446,18 +447,20 @@ Flow:
 2. Open the system bus.
 3. Subscribe to logind `PrepareForSleep` signals.
 4. On `PrepareForSleep(true)`:
-   - log the diagnostic event
-   - do not run TV network I/O
+   - enter the central suspend rail under the logind delay inhibitor
+   - run one bounded pre-sleep TV decision unless another source already owns
+     or completed the cycle
 5. On `PrepareForSleep(false)`:
    - run wake restore policy from the canonical logind resume event
-   - clear stale legacy system sleep attempt state
+   - clear sleep-cycle coordination state
 6. If config is changed to disable lifecycle handling while the service is
    running, stop the lifecycle monitor cleanly.
 
 The NetworkManager pre-down gate runs `lg-buddy nm-pre-down`. That command reads
 logind `PreparingForSleep`; false or read failure returns quickly, true runs an
-idempotent pre-sleep power-off policy under a process lock before NetworkManager
-tears down the interface.
+idempotent pre-sleep rail before NetworkManager tears down the interface. If
+logind already owns the cycle, NetworkManager waits for a terminal rail outcome
+or bounded timeout before releasing teardown.
 
 ### `detect-backend`
 
@@ -544,10 +547,10 @@ There are two scopes:
 
 This is a direct replacement for the earlier ad hoc script coordination pattern.
 
-The NetworkManager pre-down path also uses a system-scope lock file to prevent
-concurrent pre-sleep handlers from racing each other. It does not use persisted
-attempt state to skip later hooks; repeated hooks are expected to be safe through
-idempotent TV policy.
+The cooperative suspend rail uses system-scope lock and cycle state files to
+prevent concurrent pre-sleep handlers from racing each other. Repeated hooks are
+expected to be safe through idempotent TV policy and persisted terminal cycle
+outcomes.
 
 ## Desktop Backend Strategy
 
@@ -682,8 +685,8 @@ The Rust runtime currently owns:
 - backend detection
 - startup
 - shutdown
-- system lifecycle handling through the NetworkManager pre-down gate plus
-  logind resume monitor
+- system lifecycle handling through the cooperative logind/NetworkManager
+  suspend rail plus logind resume monitor
 - screen-off
 - screen-on
 - brightness control

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -21,7 +21,7 @@ with `v` followed by a digit, such as `v1.0.0` or `v1.0.0-beta.1`.
    - `docs/`
    - `README.md`
    - `LICENSE`
-4. Smoke tests the generated release bundle by unpacking it, running a non-interactive install into a temporary root, and then uninstalling from that temporary install.
+4. Smoke tests the generated release bundle by unpacking it, running a non-interactive install into a temporary root, checking the lifecycle service plus NetworkManager pre-down hook topology, and then uninstalling from that temporary install.
 5. Generates and verifies `sha256sums.txt` for the release archive.
 6. Publishes the release assets through `scripts/publish-release-assets.sh`.
 

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -38,9 +38,9 @@ same normalized inactivity observations.
 | --- | --- | --- | --- |
 | system boot / service start | `lg-buddy startup boot` | `commands` -> `lifecycle` | Send Wake-on-LAN and restore the configured input. |
 | system shutdown / service stop | `lg-buddy shutdown` | `commands` -> `lifecycle` | Power off the TV when the configured input is active, unless a reboot is pending. |
-| NetworkManager `pre-down` while logind `PreparingForSleep=true` | `lg-buddy nm-pre-down` | `sources::linux::network_manager` -> `lifecycle` | Run pre-sleep TV power-off under a process lock before network teardown. |
-| logind `PrepareForSleep(true)` | `lg-buddy lifecycle` | `session::runner` | Log diagnostic sleep intent; do not run TV network I/O. |
-| logind `PrepareForSleep(false)` | `lg-buddy lifecycle` | `sources::linux::logind` -> `session::runner` -> `lifecycle` | Run wake restore policy and clear stale legacy system sleep attempt state. |
+| NetworkManager `pre-down` while logind `PreparingForSleep=true` | `lg-buddy nm-pre-down` | `sources::linux::network_manager` -> `lifecycle` | Join the central suspend rail before network teardown; wait for an in-progress logind rail or run the pre-sleep TV decision. |
+| logind `PrepareForSleep(true)` | `lg-buddy lifecycle` | `sources::linux::logind` -> `session::runner` -> `lifecycle` | Enter the central suspend rail under the logind delay inhibitor so systems without a NetworkManager `pre-down` hook still get bounded pre-sleep TV handling. |
+| logind `PrepareForSleep(false)` | `lg-buddy lifecycle` | `sources::linux::logind` -> `session::runner` -> `lifecycle` | Run wake restore policy and clear sleep-cycle coordination state. |
 | user graphical session start | `lg-buddy monitor` | `session::runner::run_monitor` | Detect the session backend and run the selected monitor path. |
 | manual screen blank | `lg-buddy screen-off` | `commands` -> `screen` | Blank or power off the TV if LG Buddy owns the configured input. |
 | manual screen restore | `lg-buddy screen-on` | `commands` -> `screen` | Restore the screen when marker and restore-policy rules allow it. |
@@ -165,7 +165,12 @@ cooperating Linux event sources:
 NetworkManager pre-down
   -> lg-buddy nm-pre-down
   -> logind PreparingForSleep property read
-  -> lifecycle policy
+  -> cooperative suspend rail
+  -> TV action executor
+
+org.freedesktop.login1 PrepareForSleep(true)
+  -> lg-buddy lifecycle
+  -> cooperative suspend rail
   -> TV action executor
 
 org.freedesktop.login1 PrepareForSleep(false)
@@ -175,17 +180,21 @@ org.freedesktop.login1 PrepareForSleep(false)
   -> TV action executor
 ```
 
-The NetworkManager pre-down gate is the only default pre-sleep TV power-off
-owner. It reads logind `PreparingForSleep` synchronously; false or read failure
-returns quickly, true runs the idempotent pre-sleep policy under a process lock
-while NetworkManager is still holding interface teardown.
+NetworkManager and logind cooperate through one suspend rail. NetworkManager
+`pre-down` remains the strongest network-up opportunity: it reads logind
+`PreparingForSleep` synchronously; false or read failure returns quickly, true
+enters the rail while NetworkManager is still holding interface teardown. If
+logind already owns the rail, NetworkManager waits for a terminal outcome or a
+bounded timeout before releasing teardown.
 
-The lifecycle service subscribes to logind manager signals on the system bus.
-`PrepareForSleep(true)` is diagnostic only. `PrepareForSleep(false)` runs wake
-restore policy and clears stale legacy system sleep attempt state.
+The lifecycle service subscribes to logind manager signals on the system bus and
+holds a sleep delay inhibitor while idle. `PrepareForSleep(true)` enters the
+same suspend rail so systems without a NetworkManager `pre-down` hook still get
+a bounded pre-sleep TV decision. `PrepareForSleep(false)` runs wake restore
+policy and clears per-cycle coordination state.
 
-The installer must not leave a second lifecycle owner active. It removes or
-disables these legacy artifacts during install and uninstall:
+The installer must not leave old lifecycle owners active. It removes or disables
+these legacy artifacts during install and uninstall:
 
 - `LG_Buddy_sleep.service`
 - `LG_Buddy_wake.service`
@@ -198,7 +207,7 @@ Current lifecycle signal mapping:
 | logind surface | Canonical event | Runtime action |
 | --- | --- | --- |
 | `PreparingForSleep` property | `NetworkTeardownImminent { machine_sleep_pending }` in the NetworkManager source path; `RuntimePhaseRead` in screen eligibility | Gate pre-sleep policy and block session screen TV I/O during pending machine sleep. |
-| `PrepareForSleep(true)` | `MachinePreparingForSleep` | Diagnostic log only. |
+| `PrepareForSleep(true)` | `MachinePreparingForSleep` | `run_sleep_pre_for_event` through the central suspend rail. |
 | `PrepareForSleep(false)` | `MachineResumed` | `run_system_resume` |
 
 The current `SessionEventDispatcher` handles these session events when a
@@ -234,10 +243,9 @@ lifecycle path:
 - users who do not want automatic sleep/wake TV control opt out through
   `system_sleep_wake_policy=disabled`
 - default installs do not ask whether lifecycle automation should run
-- the NetworkManager pre-down gate is the only default pre-sleep TV power-off
-  owner
-- logind `PrepareForSleep(true)` is diagnostic; logind
-  `PrepareForSleep(false)` owns resume restore
+- NetworkManager `pre-down` and logind `PrepareForSleep(true)` cooperate through
+  one central suspend rail
+- logind `PrepareForSleep(false)` owns resume restore and per-cycle cleanup
 - legacy systemd and old NetworkManager sleep/wake handlers are cleanup targets,
   not parallel runtime handlers
 - legacy cleanup honors a persisted opt-out config value

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -246,11 +246,16 @@ Secondary concern:
 
 These should not dominate the Rust test suite, but they still matter because installation and service wiring remain part of the real user path.
 
+The release-bundle smoke test covers the current installed lifecycle topology:
+the logind lifecycle service remains installed, the NetworkManager pre-down hook
+remains installed, and legacy systemd sleep hooks are absent.
+
 ## Current Practical Gaps
 
 The most important remaining gaps are:
 
-- host-level validation for installer and service wiring
+- real-host validation for installer and service wiring beyond the release-bundle
+  temporary-root smoke test
 - broader validation of the remaining shell setup surface
 - any future coverage needed for richer `swayidle` hooks beyond `timeout` and `resume`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -142,31 +142,25 @@ For backend semantics and implementation details, see [session-backend-model.md]
 
 ## System Sleep And Wake
 
-Default installs enable system sleep/wake TV control through:
+Default installs enable system sleep/wake TV control. To inspect the installed
+lifecycle service:
 
 ```bash
 systemctl status LG_Buddy_lifecycle.service
 ```
 
-The installed lifecycle path has two Linux event sources:
-
-- a NetworkManager `pre-down` dispatcher hook gates network teardown and checks
-  logind `PreparingForSleep`
-- `LG_Buddy_lifecycle.service` listens to logind `PrepareForSleep(false)` for
-  resume restore
-
-When NetworkManager reports `pre-down` and logind says the system is preparing
-for sleep, LG Buddy runs pre-sleep TV power-off before the interface is torn
-down. Ordinary network disconnects return quickly. After resume, the lifecycle
-service runs wake restore policy and clears the sleep-attempt marker.
+When Linux reports that the machine is going to sleep, LG Buddy runs one
+pre-sleep TV power-off attempt while the TV can still be reached.
+Ordinary network disconnects return quickly. After wake, LG Buddy runs wake
+restore policy and clears temporary sleep state.
 
 While system sleep is pending, session idle/activity events do not run screen
 blank or restore TV commands. This avoids racing session-level TV control
 against the lifecycle sleep path.
 
-LG Buddy does not install the old sleep and wake systemd oneshot handlers or the
-old NetworkManager sleep hook. The installer and uninstaller remove those legacy
-artifacts from existing installs so there is only one system lifecycle owner.
+LG Buddy does not leave old sleep and wake handlers active. The installer and
+uninstaller remove legacy artifacts from existing installs so there is only one
+system lifecycle owner.
 
 ## Configuration
 
@@ -276,15 +270,15 @@ Values above 86400 seconds are capped at 86400 seconds.
 
 `system_sleep_wake_policy` controls automatic system sleep/wake TV handling:
 
-- `enabled`: default behavior, let the installed NetworkManager pre-down gate
-  and logind lifecycle service control the TV around system sleep and wake
+- `enabled`: default behavior, let the installed lifecycle integration control
+  the TV around system sleep and wake
 - `disabled`: leave lifecycle integration installed, but make those commands
   no-op for sleep/wake TV handling
 
-The running lifecycle service rereads config and suppresses actions while this
-value is `disabled`. The NetworkManager pre-down hook also reads config on each
-invocation, so `lg-buddy settings set system.sleep_wake_policy <value>` changes
-runtime policy without reinstalling services.
+The installed lifecycle integration rereads config and suppresses sleep/wake TV
+actions while this value is `disabled`, so
+`lg-buddy settings set system.sleep_wake_policy <value>` changes runtime policy
+without reinstalling services.
 
 `updates_auto_check` controls automatic background update checks:
 

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -25,6 +25,36 @@ assert_executable() {
     fi
 }
 
+assert_lifecycle_topology_installed() {
+    assert_file "$SYSTEM_SERVICE"
+    assert_file "$LIFECYCLE_SERVICE"
+    grep -q 'ExecStart=/usr/bin/lg-buddy lifecycle' "$LIFECYCLE_SERVICE"
+    assert_file "$USER_SCREEN_SERVICE"
+    assert_file "$USER_UPDATE_CHECK_SERVICE"
+    assert_file "$USER_UPDATE_CHECK_TIMER"
+    assert_file "$USER_UPDATE_CHECK_OVERRIDE"
+    grep -q '^OnCalendar=weekly$' "$USER_UPDATE_CHECK_TIMER"
+    grep -q '^WantedBy=graphical-session.target$' "$USER_UPDATE_CHECK_TIMER"
+    [ ! -e "$LEGACY_SLEEP_SERVICE" ] || {
+        echo "Legacy sleep service installed unexpectedly: $LEGACY_SLEEP_SERVICE"
+        exit 1
+    }
+    [ ! -e "$LEGACY_WAKE_SERVICE" ] || {
+        echo "Legacy wake service installed unexpectedly: $LEGACY_WAKE_SERVICE"
+        exit 1
+    }
+    [ ! -e "$NM_SLEEP_HOOK" ] || {
+        echo "NetworkManager sleep hook installed unexpectedly: $NM_SLEEP_HOOK"
+        exit 1
+    }
+    [ ! -e "$SYSTEM_SLEEP_HOOK" ] || {
+        echo "Legacy systemd sleep hook installed unexpectedly: $SYSTEM_SLEEP_HOOK"
+        exit 1
+    }
+    assert_executable "$NM_LIFECYCLE_HOOK"
+    grep -q 'lg-buddy nm-pre-down' "$NM_LIFECYCLE_HOOK"
+}
+
 validate_archive_paths() {
     local archive="$1"
     local entry=""
@@ -186,34 +216,8 @@ assert_file "$CONFIG_FILE"
 assert_executable "$INSTALLED_BINARY"
 assert_executable "$INSTALLED_VENV_PIP"
 assert_file "$INSTALLED_POINTER"
-assert_file "$SYSTEM_SERVICE"
-assert_file "$LIFECYCLE_SERVICE"
-grep -q 'ExecStart=/usr/bin/lg-buddy lifecycle' "$LIFECYCLE_SERVICE"
-assert_file "$USER_SCREEN_SERVICE"
-assert_file "$USER_UPDATE_CHECK_SERVICE"
-assert_file "$USER_UPDATE_CHECK_TIMER"
-assert_file "$USER_UPDATE_CHECK_OVERRIDE"
-grep -q '^OnCalendar=weekly$' "$USER_UPDATE_CHECK_TIMER"
-grep -q '^WantedBy=graphical-session.target$' "$USER_UPDATE_CHECK_TIMER"
+assert_lifecycle_topology_installed
 assert_file "$DESKTOP_ENTRY"
-[ ! -e "$LEGACY_SLEEP_SERVICE" ] || {
-    echo "Legacy sleep service installed unexpectedly: $LEGACY_SLEEP_SERVICE"
-    exit 1
-}
-[ ! -e "$LEGACY_WAKE_SERVICE" ] || {
-    echo "Legacy wake service installed unexpectedly: $LEGACY_WAKE_SERVICE"
-    exit 1
-}
-[ ! -e "$NM_SLEEP_HOOK" ] || {
-    echo "NetworkManager sleep hook installed unexpectedly: $NM_SLEEP_HOOK"
-    exit 1
-}
-[ ! -e "$SYSTEM_SLEEP_HOOK" ] || {
-    echo "Legacy systemd sleep hook installed unexpectedly: $SYSTEM_SLEEP_HOOK"
-    exit 1
-}
-assert_executable "$NM_LIFECYCLE_HOOK"
-grep -q 'lg-buddy nm-pre-down' "$NM_LIFECYCLE_HOOK"
 if grep -q 'LG_BUDDY_CONFIG' "$NM_LIFECYCLE_HOOK"; then
     echo "NetworkManager lifecycle hook should rely on installed config pointer, not embed LG_BUDDY_CONFIG."
     exit 1
@@ -371,33 +375,7 @@ assert_executable "$INSTALLED_BINARY"
     echo "Installer left stale virtualenv contents in place: $STALE_VENV_MARKER"
     exit 1
 }
-assert_file "$SYSTEM_SERVICE"
-assert_file "$LIFECYCLE_SERVICE"
-grep -q 'ExecStart=/usr/bin/lg-buddy lifecycle' "$LIFECYCLE_SERVICE"
-assert_file "$USER_SCREEN_SERVICE"
-assert_file "$USER_UPDATE_CHECK_SERVICE"
-assert_file "$USER_UPDATE_CHECK_TIMER"
-assert_file "$USER_UPDATE_CHECK_OVERRIDE"
-grep -q '^OnCalendar=weekly$' "$USER_UPDATE_CHECK_TIMER"
-grep -q '^WantedBy=graphical-session.target$' "$USER_UPDATE_CHECK_TIMER"
-[ ! -e "$LEGACY_SLEEP_SERVICE" ] || {
-    echo "Legacy sleep service installed unexpectedly: $LEGACY_SLEEP_SERVICE"
-    exit 1
-}
-[ ! -e "$LEGACY_WAKE_SERVICE" ] || {
-    echo "Legacy wake service installed unexpectedly: $LEGACY_WAKE_SERVICE"
-    exit 1
-}
-[ ! -e "$NM_SLEEP_HOOK" ] || {
-    echo "NetworkManager sleep hook installed unexpectedly: $NM_SLEEP_HOOK"
-    exit 1
-}
-[ ! -e "$SYSTEM_SLEEP_HOOK" ] || {
-    echo "Legacy systemd sleep hook installed unexpectedly: $SYSTEM_SLEEP_HOOK"
-    exit 1
-}
-assert_executable "$NM_LIFECYCLE_HOOK"
-grep -q 'lg-buddy nm-pre-down' "$NM_LIFECYCLE_HOOK"
+assert_lifecycle_topology_installed
 grep -q '^screen_idle_blank=enabled$' "$CONFIG_FILE"
 grep -q '^system_sleep_wake_policy=disabled$' "$CONFIG_FILE"
 

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -112,6 +112,8 @@ assert_executable "$BUNDLE_DIR/bin/LG_Buddy_Common"
 assert_file "$BUNDLE_DIR/LG_Buddy_Brightness.desktop"
 assert_file "$BUNDLE_DIR/README.md"
 assert_file "$BUNDLE_DIR/LICENSE"
+assert_file "$BUNDLE_DIR/docs/architecture-overview.md"
+assert_file "$BUNDLE_DIR/docs/runtime-event-handler-map.md"
 assert_file "$BUNDLE_DIR/docs/user-guide.md"
 assert_file "$BUNDLE_DIR/docs/development.md"
 assert_file "$BUNDLE_DIR/docs/release-process.md"
@@ -167,6 +169,7 @@ SYSTEM_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy.service"
 LIFECYCLE_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_lifecycle.service"
 LEGACY_SLEEP_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_sleep.service"
 LEGACY_WAKE_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_wake.service"
+SYSTEM_SLEEP_HOOK="$INSTALL_ROOT/usr/lib/systemd/system-sleep/LG_Buddy_sleep_hook"
 USER_SCREEN_SERVICE="$HOME/.config/systemd/user/LG_Buddy_screen.service"
 USER_UPDATE_CHECK_SERVICE="$HOME/.config/systemd/user/LG_Buddy_update_check.service"
 USER_UPDATE_CHECK_TIMER="$HOME/.config/systemd/user/LG_Buddy_update_check.timer"
@@ -185,6 +188,7 @@ assert_executable "$INSTALLED_VENV_PIP"
 assert_file "$INSTALLED_POINTER"
 assert_file "$SYSTEM_SERVICE"
 assert_file "$LIFECYCLE_SERVICE"
+grep -q 'ExecStart=/usr/bin/lg-buddy lifecycle' "$LIFECYCLE_SERVICE"
 assert_file "$USER_SCREEN_SERVICE"
 assert_file "$USER_UPDATE_CHECK_SERVICE"
 assert_file "$USER_UPDATE_CHECK_TIMER"
@@ -204,6 +208,10 @@ assert_file "$DESKTOP_ENTRY"
     echo "NetworkManager sleep hook installed unexpectedly: $NM_SLEEP_HOOK"
     exit 1
 }
+[ ! -e "$SYSTEM_SLEEP_HOOK" ] || {
+    echo "Legacy systemd sleep hook installed unexpectedly: $SYSTEM_SLEEP_HOOK"
+    exit 1
+}
 assert_executable "$NM_LIFECYCLE_HOOK"
 grep -q 'lg-buddy nm-pre-down' "$NM_LIFECYCLE_HOOK"
 if grep -q 'LG_BUDDY_CONFIG' "$NM_LIFECYCLE_HOOK"; then
@@ -218,6 +226,9 @@ grep -q '^screen_idle_blank=enabled$' "$CONFIG_FILE"
 grep -q '^screen_backend=auto$' "$CONFIG_FILE"
 grep -q '^system_sleep_wake_policy=enabled$' "$CONFIG_FILE"
 grep -q "$CONFIG_FILE" "$INSTALLED_POINTER"
+grep -q 'cooperating suspend sources' "$BUNDLE_DIR/README.md"
+grep -q 'cooperative suspend rail' "$BUNDLE_DIR/docs/architecture-overview.md"
+grep -q 'NetworkManager and logind cooperate through one suspend rail' "$BUNDLE_DIR/docs/runtime-event-handler-map.md"
 
 if [ "$SKIP_PIP_INSTALL" -eq 0 ]; then
     assert_executable "$INSTALLED_BSCPYLGTV"
@@ -332,6 +343,10 @@ export LG_BUDDY_REMOVE_CONFIG="1"
     echo "NetworkManager sleep hook still present after uninstall: $NM_SLEEP_HOOK"
     exit 1
 }
+[ ! -e "$SYSTEM_SLEEP_HOOK" ] || {
+    echo "Legacy systemd sleep hook still present after uninstall: $SYSTEM_SLEEP_HOOK"
+    exit 1
+}
 [ ! -e "$NM_LIFECYCLE_HOOK" ] || {
     echo "NetworkManager lifecycle hook still present after uninstall: $NM_LIFECYCLE_HOOK"
     exit 1
@@ -358,6 +373,7 @@ assert_executable "$INSTALLED_BINARY"
 }
 assert_file "$SYSTEM_SERVICE"
 assert_file "$LIFECYCLE_SERVICE"
+grep -q 'ExecStart=/usr/bin/lg-buddy lifecycle' "$LIFECYCLE_SERVICE"
 assert_file "$USER_SCREEN_SERVICE"
 assert_file "$USER_UPDATE_CHECK_SERVICE"
 assert_file "$USER_UPDATE_CHECK_TIMER"
@@ -374,6 +390,10 @@ grep -q '^WantedBy=graphical-session.target$' "$USER_UPDATE_CHECK_TIMER"
 }
 [ ! -e "$NM_SLEEP_HOOK" ] || {
     echo "NetworkManager sleep hook installed unexpectedly: $NM_SLEEP_HOOK"
+    exit 1
+}
+[ ! -e "$SYSTEM_SLEEP_HOOK" ] || {
+    echo "Legacy systemd sleep hook installed unexpectedly: $SYSTEM_SLEEP_HOOK"
     exit 1
 }
 assert_executable "$NM_LIFECYCLE_HOOK"


### PR DESCRIPTION
## Summary

- add a centralized system suspend rail so logind and NetworkManager suspend signals coordinate through lifecycle state
- clear suspend rail state on resume and preserve the existing screen ownership marker behavior
- document the cooperative install topology and keep the user guide focused on observable behavior
- simplify cleanup around the suspend rail retry path and guard the retryable terminal state with the rail lock

## Validation

- `cargo fmt --all`
- `cargo test -p lg-buddy --lib network_teardown_waits_for_retryable_owner_before_retrying -- --nocapture`
- `cargo test -p lg-buddy --lib pre_down_ -- --nocapture`
- `cargo test -p lg-buddy --lib system_suspend_rail -- --nocapture`
- `cargo test -p lg-buddy --lib network_teardown_ -- --nocapture`
- `cargo test -p lg-buddy --lib`
- `cargo test -p lg-buddy --test runtime_entrypoints`