### PR TITLE
feat(webos): add authenticated client foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,11 @@ jobs:
       - name: Run Rust test suite
         run: cargo test -p lg-buddy
 
-      - name: Verify root-scoped TV helper launcher
+      - name: Verify root-scoped ownership behavior
         run: |
           sudo_target_dir="$(mktemp -d)"
           sudo env "PATH=$PATH" "CARGO_HOME=$CARGO_HOME" "RUSTUP_HOME=$RUSTUP_HOME" "RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-stable}" "CARGO_TARGET_DIR=$sudo_target_dir" cargo test -p lg-buddy --lib tv::tests::user_scoped_launcher_drops_privileges_to_sudo_user_when_running_as_root -- --exact
+          sudo env "PATH=$PATH" "CARGO_HOME=$CARGO_HOME" "RUSTUP_HOME=$RUSTUP_HOME" "RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-stable}" "CARGO_TARGET_DIR=$sudo_target_dir" cargo test -p lg-buddy --lib platform_access_token::tests::persist_assigns_requested_owner_when_running_as_root -- --exact
 
       - name: Run clippy
         run: cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +121,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -134,6 +149,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "clap"
@@ -195,12 +221,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -236,6 +277,15 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "cucumber"
@@ -295,6 +345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +391,17 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -513,6 +580,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+]
+
+[[package]]
 name = "gherkin"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,10 +639,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -724,15 +828,18 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 name = "lg-buddy"
 version = "1.1.0"
 dependencies = [
+ "base64",
  "cucumber",
  "dbus",
  "dbus-crossroads",
  "evdev",
  "libc",
+ "rustls",
  "semver",
  "serde",
  "serde_json",
  "tokio",
+ "tungstenite",
  "ureq",
 ]
 
@@ -929,10 +1036,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ref-cast"
@@ -991,7 +1121,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1127,6 +1257,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1322,6 +1463,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1500,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -9,9 +9,11 @@ dbus = { version = "0.9.11", features = ["vendored"] }
 dbus-crossroads = "0.5.3"
 evdev = "0.13.2"
 libc = "0.2"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
 ureq = "2"
 
 [lib]
@@ -22,6 +24,7 @@ name = "lg-buddy"
 path = "src/main.rs"
 
 [dev-dependencies]
+base64 = "0.22"
 cucumber = "0.22.1"
 tokio = { version = "1", features = ["macros", "rt"] }
 

--- a/crates/lg-buddy/src/auth.rs
+++ b/crates/lg-buddy/src/auth.rs
@@ -160,6 +160,11 @@ pub fn resolve_bscpylgtv_auth_context_from_env(
         .with_key_file_path(key_file_path))
 }
 
+pub fn resolve_config_owner(config_path: &Path) -> Result<SystemUser, AuthContextError> {
+    let passwd = fs::read_to_string("/etc/passwd").map_err(AuthContextError::PasswdRead)?;
+    resolve_config_owner_from_passwd(config_path, &passwd)
+}
+
 fn default_key_file_path(config_path: &Path) -> Result<PathBuf, AuthContextError> {
     let parent = config_path
         .parent()

--- a/crates/lg-buddy/src/dev.rs
+++ b/crates/lg-buddy/src/dev.rs
@@ -1,0 +1,347 @@
+use crate::auth::{resolve_config_owner, AuthContextError, SystemUser};
+use crate::config::{load_config, resolve_config_path_from_env, ConfigError, ConfigPathError};
+use crate::platform_access_token::{PlatformAccessTokenStore, PlatformAccessTokenStoreError};
+use crate::web_os::{
+    WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsEndpoint,
+    WebOsPowerState, WebOsPowerStateError,
+};
+use std::error::Error;
+use std::fmt;
+use std::io::{self, Write};
+use std::net::Ipv4Addr;
+use std::path::Path;
+use std::time::Duration;
+
+const WEBOS_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const WEBOS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
+const WEBOS_AUTH_PROBE_PREFIX: &str = "LG Buddy WebOS Auth Probe";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DevCommand {
+    WebOsAuthProbe,
+}
+
+impl DevCommand {
+    pub(crate) fn parse<I, S>(args: I) -> Result<Self, DevParseError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut args = args.into_iter();
+        let subcommand = args.next().ok_or(DevParseError::MissingSubcommand)?;
+        if subcommand.as_ref() != "webos-auth-probe" {
+            return Err(DevParseError::UnknownSubcommand(
+                subcommand.as_ref().to_string(),
+            ));
+        }
+
+        let arguments: Vec<String> = args.map(|arg| arg.as_ref().to_string()).collect();
+        if !arguments.is_empty() {
+            return Err(DevParseError::UnexpectedArguments { arguments });
+        }
+
+        Ok(Self::WebOsAuthProbe)
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::WebOsAuthProbe => "dev webos-auth-probe",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DevParseError {
+    MissingSubcommand,
+    UnknownSubcommand(String),
+    UnexpectedArguments { arguments: Vec<String> },
+}
+
+impl fmt::Display for DevParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingSubcommand => write!(f, "missing temporary `dev` subcommand"),
+            Self::UnknownSubcommand(subcommand) => {
+                write!(f, "unknown temporary dev command `{subcommand}`")
+            }
+            Self::UnexpectedArguments { arguments } => write!(
+                f,
+                "unexpected arguments for `dev webos-auth-probe`: {}",
+                arguments.join(" ")
+            ),
+        }
+    }
+}
+
+impl Error for DevParseError {}
+
+#[derive(Debug)]
+pub enum DevError {
+    Io(io::Error),
+    ConfigPath(ConfigPathError),
+    Config(ConfigError),
+    ConfigOwner(AuthContextError),
+    TokenStore(PlatformAccessTokenStoreError),
+    Authentication(WebOsAuthenticatedClientError),
+    PowerState(WebOsPowerStateError),
+}
+
+impl fmt::Display for DevError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(source) => write!(f, "could not write webOS auth probe output: {source}"),
+            Self::ConfigPath(source) => write!(f, "could not resolve probe config: {source}"),
+            Self::Config(source) => write!(f, "could not load probe config: {source}"),
+            Self::ConfigOwner(source) => {
+                write!(f, "could not resolve probe config owner: {source}")
+            }
+            Self::TokenStore(source) => {
+                write!(f, "could not construct probe access-token store: {source}")
+            }
+            Self::Authentication(source) => {
+                write!(f, "webOS auth probe authentication failed: {source}")
+            }
+            Self::PowerState(source) => write!(f, "webOS auth probe state read failed: {source}"),
+        }
+    }
+}
+
+impl Error for DevError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(source) => Some(source),
+            Self::ConfigPath(source) => Some(source),
+            Self::Config(source) => Some(source),
+            Self::ConfigOwner(source) => Some(source),
+            Self::TokenStore(source) => Some(source),
+            Self::Authentication(source) => Some(source),
+            Self::PowerState(source) => Some(source),
+        }
+    }
+}
+
+pub(crate) fn run_dev_command<W: Write>(
+    command: DevCommand,
+    writer: &mut W,
+) -> Result<(), DevError> {
+    match command {
+        DevCommand::WebOsAuthProbe => run_webos_auth_probe(writer),
+    }
+}
+
+fn run_webos_auth_probe<W: Write>(writer: &mut W) -> Result<(), DevError> {
+    let config_path = resolve_config_path_from_env().map_err(DevError::ConfigPath)?;
+    let config = load_config(&config_path).map_err(DevError::Config)?;
+    let owner = resolve_config_owner(&config_path).map_err(DevError::ConfigOwner)?;
+    let context = WebOsAuthProbeContext::new(&config_path, config.tv_ip, owner)?;
+
+    run_webos_auth_probe_with(writer, &context, |endpoint, token_store, on_auth_event| {
+        let mut client = WebOsClient::connect_authenticated(
+            endpoint,
+            WEBOS_CONNECT_TIMEOUT,
+            WEBOS_RESPONSE_TIMEOUT,
+            token_store,
+            on_auth_event,
+        )
+        .map_err(DevError::Authentication)?;
+        client.power_state().map_err(DevError::PowerState)
+    })
+}
+
+struct WebOsAuthProbeContext {
+    endpoint: WebOsEndpoint,
+    token_store: PlatformAccessTokenStore,
+}
+
+impl WebOsAuthProbeContext {
+    fn new(config_path: &Path, tv_ip: Ipv4Addr, owner: SystemUser) -> Result<Self, DevError> {
+        let token_store = PlatformAccessTokenStore::for_primary_profile(config_path, owner)
+            .map_err(DevError::TokenStore)?;
+        Ok(Self {
+            endpoint: WebOsEndpoint::wss(tv_ip),
+            token_store,
+        })
+    }
+}
+
+fn run_webos_auth_probe_with<W, F>(
+    writer: &mut W,
+    context: &WebOsAuthProbeContext,
+    probe: F,
+) -> Result<(), DevError>
+where
+    W: Write,
+    F: FnOnce(
+        WebOsEndpoint,
+        &PlatformAccessTokenStore,
+        &mut dyn FnMut(WebOsAuthenticationEvent),
+    ) -> Result<WebOsPowerState, DevError>,
+{
+    let mut progress_error = None;
+    let probe_result = {
+        let mut on_auth_event = |event| {
+            if progress_error.is_none() {
+                progress_error =
+                    write_auth_event(writer, context.token_store.token_path(), event).err();
+            }
+        };
+        probe(context.endpoint, &context.token_store, &mut on_auth_event)
+    };
+
+    if let Some(source) = progress_error {
+        return Err(DevError::Io(source));
+    }
+
+    let power_state = probe_result?;
+    writeln!(
+        writer,
+        "{WEBOS_AUTH_PROBE_PREFIX}: power_state={power_state}"
+    )
+    .map_err(DevError::Io)
+}
+
+fn write_auth_event<W: Write>(
+    writer: &mut W,
+    token_path: &Path,
+    event: WebOsAuthenticationEvent,
+) -> io::Result<()> {
+    match event {
+        WebOsAuthenticationEvent::UsingStoredAccessToken => {
+            writeln!(
+                writer,
+                "{WEBOS_AUTH_PROBE_PREFIX}: using stored access token."
+            )?;
+        }
+        WebOsAuthenticationEvent::PairingPrompt => {
+            writeln!(
+                writer,
+                "{WEBOS_AUTH_PROBE_PREFIX}: pairing required; accept the prompt on the TV."
+            )?;
+        }
+        WebOsAuthenticationEvent::AccessTokenPersisted => {
+            writeln!(
+                writer,
+                "{WEBOS_AUTH_PROBE_PREFIX}: stored access token at {}",
+                token_path.display()
+            )?;
+        }
+    }
+    writer.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        run_webos_auth_probe_with, DevCommand, DevError, DevParseError, WebOsAuthProbeContext,
+    };
+    use crate::auth::SystemUser;
+    use crate::web_os::{WebOsAuthenticationEvent, WebOsPowerState, WebOsPowerStateError};
+    use std::net::Ipv4Addr;
+    use std::path::Path;
+
+    fn probe_context() -> WebOsAuthProbeContext {
+        WebOsAuthProbeContext::new(
+            Path::new("/tmp/lg-buddy-dev-probe/config.env"),
+            Ipv4Addr::new(192, 0, 2, 42),
+            SystemUser::new("test-user", 1000, 1000, "/tmp"),
+        )
+        .expect("construct probe context")
+    }
+
+    #[test]
+    fn parser_accepts_only_webos_auth_probe() {
+        assert_eq!(
+            DevCommand::parse(["webos-auth-probe"]),
+            Ok(DevCommand::WebOsAuthProbe)
+        );
+        assert_eq!(
+            DevCommand::parse(Vec::<String>::new()),
+            Err(DevParseError::MissingSubcommand)
+        );
+        assert_eq!(
+            DevCommand::parse(["other"]),
+            Err(DevParseError::UnknownSubcommand("other".to_string()))
+        );
+        assert_eq!(
+            DevCommand::parse(["webos-auth-probe", "extra"]),
+            Err(DevParseError::UnexpectedArguments {
+                arguments: vec!["extra".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn stored_token_probe_reports_reuse_and_state() {
+        let context = probe_context();
+        let mut output = Vec::new();
+
+        run_webos_auth_probe_with(
+            &mut output,
+            &context,
+            |endpoint, token_store, on_auth_event| {
+                assert_eq!(endpoint.to_string(), "wss://192.0.2.42:3001/");
+                assert_eq!(
+                    token_store.token_path(),
+                    Path::new("/tmp/lg-buddy-dev-probe/tvs/primary/access-token.json")
+                );
+                on_auth_event(WebOsAuthenticationEvent::UsingStoredAccessToken);
+                Ok(WebOsPowerState::Active)
+            },
+        )
+        .expect("run stored-token probe");
+
+        assert_eq!(
+            String::from_utf8(output).expect("UTF-8 output"),
+            "LG Buddy WebOS Auth Probe: using stored access token.\n\
+LG Buddy WebOS Auth Probe: power_state=Active\n"
+        );
+    }
+
+    #[test]
+    fn first_pairing_probe_reports_prompt_persistence_and_state_without_token_value() {
+        let context = probe_context();
+        let mut output = Vec::new();
+
+        run_webos_auth_probe_with(
+            &mut output,
+            &context,
+            |_endpoint, _token_store, on_auth_event| {
+                on_auth_event(WebOsAuthenticationEvent::PairingPrompt);
+                on_auth_event(WebOsAuthenticationEvent::AccessTokenPersisted);
+                Ok(WebOsPowerState::ActiveStandby)
+            },
+        )
+        .expect("run first-pairing probe");
+
+        let output = String::from_utf8(output).expect("UTF-8 output");
+        assert_eq!(
+            output,
+            "LG Buddy WebOS Auth Probe: pairing required; accept the prompt on the TV.\n\
+LG Buddy WebOS Auth Probe: stored access token at /tmp/lg-buddy-dev-probe/tvs/primary/access-token.json\n\
+LG Buddy WebOS Auth Probe: power_state=Active Standby\n"
+        );
+        assert!(!output.contains("client-key"));
+    }
+
+    #[test]
+    fn typed_probe_failure_is_returned_without_success_output() {
+        let context = probe_context();
+        let mut output = Vec::new();
+
+        let error = run_webos_auth_probe_with(
+            &mut output,
+            &context,
+            |_endpoint, _token_store, on_auth_event| {
+                on_auth_event(WebOsAuthenticationEvent::UsingStoredAccessToken);
+                Err(DevError::PowerState(WebOsPowerStateError::MissingPayload))
+            },
+        )
+        .expect_err("probe failure should be returned");
+
+        assert!(error.to_string().contains("has no payload"));
+        assert_eq!(
+            String::from_utf8(output).expect("UTF-8 output"),
+            "LG Buddy WebOS Auth Probe: using stored access token.\n"
+        );
+    }
+}

--- a/crates/lg-buddy/src/events.rs
+++ b/crates/lg-buddy/src/events.rs
@@ -99,6 +99,7 @@ impl RuntimeEventKind {
             Command::Monitor
             | Command::Lifecycle
             | Command::DetectBackend
+            | Command::Dev(_)
             | Command::Settings(_)
             | Command::Updates(_) => None,
         }
@@ -180,6 +181,10 @@ mod tests {
         assert_eq!(RuntimeEvent::from_command(Command::Monitor), None);
         assert_eq!(RuntimeEvent::from_command(Command::Lifecycle), None);
         assert_eq!(RuntimeEvent::from_command(Command::DetectBackend), None);
+        assert_eq!(
+            RuntimeEvent::from_command(Command::Dev(crate::DevCommand::WebOsAuthProbe)),
+            None
+        );
         assert_eq!(
             RuntimeEvent::from_command(Command::Settings(crate::settings::SettingsCommand::List)),
             None

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -18,6 +18,7 @@ pub mod state;
 pub mod tv;
 pub mod updates;
 pub mod version;
+pub mod web_os;
 pub mod wol;
 
 pub use sources::desktop::{gnome, swayidle};

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -1,3 +1,5 @@
+mod dev;
+
 pub mod auth;
 pub mod backend;
 pub mod commands;
@@ -21,6 +23,7 @@ pub mod version;
 pub mod web_os;
 pub mod wol;
 
+pub use dev::{DevCommand, DevError, DevParseError};
 pub use sources::desktop::{gnome, swayidle};
 pub use sources::linux::{logind, network_manager};
 
@@ -34,6 +37,7 @@ use crate::commands::{
     run_sleep_pre,
 };
 use crate::config::{ConfigError, ConfigPathError};
+use crate::dev::run_dev_command;
 use crate::notifications::NotificationError;
 use crate::session::runner::{run_lifecycle_monitor, run_monitor};
 use crate::settings::{run_settings_command, SettingsCommand, SettingsError, SettingsParseError};
@@ -56,6 +60,7 @@ pub enum Command {
     Monitor,
     Lifecycle,
     DetectBackend,
+    Dev(DevCommand),
     Settings(SettingsCommand),
     Updates(UpdatesCommand),
 }
@@ -107,6 +112,7 @@ pub enum ParseError {
     UnknownBrightnessCommand(String),
     MissingBrightnessValue,
     InvalidBrightnessValue(OledBrightnessParseError),
+    Dev(DevParseError),
     Settings(SettingsParseError),
     Updates(UpdatesParseError),
     UnexpectedArguments {
@@ -131,6 +137,7 @@ impl fmt::Display for ParseError {
                 write!(f, "missing brightness value for `brightness set`")
             }
             Self::InvalidBrightnessValue(err) => write!(f, "{err}"),
+            Self::Dev(err) => write!(f, "{err}"),
             Self::Settings(err) => write!(f, "{err}"),
             Self::Updates(err) => write!(f, "{err}"),
             Self::UnexpectedArguments { command, arguments } => {
@@ -155,6 +162,7 @@ pub enum RunError {
     StateDir(StateDirError),
     BackendSelection(BackendSelectionError),
     BackendDetection(BackendDetectionError),
+    Dev(DevError),
     Settings(SettingsError),
     Updates(UpdatesError),
     NotificationAfterPrimary {
@@ -174,6 +182,7 @@ impl fmt::Display for RunError {
             Self::StateDir(err) => write!(f, "{err}"),
             Self::BackendSelection(err) => write!(f, "{err}"),
             Self::BackendDetection(err) => write!(f, "{err}"),
+            Self::Dev(err) => write!(f, "{err}"),
             Self::Settings(err) => write!(f, "{err}"),
             Self::Updates(err) => write!(f, "{err}"),
             Self::NotificationAfterPrimary {
@@ -198,6 +207,7 @@ impl std::error::Error for RunError {
             Self::StateDir(err) => Some(err),
             Self::BackendSelection(err) => Some(err),
             Self::BackendDetection(err) => Some(err),
+            Self::Dev(err) => Some(err),
             Self::Settings(err) => Some(err),
             Self::Updates(err) => Some(err),
             Self::NotificationAfterPrimary { primary, .. } => Some(primary.as_ref()),
@@ -225,6 +235,7 @@ impl Command {
             Self::Monitor => "monitor",
             Self::Lifecycle => "lifecycle",
             Self::DetectBackend => "detect-backend",
+            Self::Dev(command) => command.as_str(),
             Self::Settings(_) => "settings",
             Self::Updates(_) => "updates",
         }
@@ -243,6 +254,7 @@ impl Command {
             Self::Monitor => "TODO: implemented via command handler",
             Self::Lifecycle => "TODO: implemented via command handler",
             Self::DetectBackend => "TODO: implement detect-backend command",
+            Self::Dev(_) => "TODO: implemented via temporary dev command handler",
             Self::Settings(_) => "TODO: implemented via command handler",
             Self::Updates(_) => "TODO: implemented via command handler",
         }
@@ -345,6 +357,11 @@ where
                 .map(|command| ParseOutcome::Command(Command::Updates(command)))
                 .map_err(ParseError::Updates);
         }
+        "dev" => {
+            return DevCommand::parse(args)
+                .map(|command| ParseOutcome::Command(Command::Dev(command)))
+                .map_err(ParseError::Dev);
+        }
         "brightness" => return parse_brightness_command(args),
         "shutdown" => Command::Shutdown,
         "sleep-pre" => Command::SleepPre,
@@ -382,6 +399,7 @@ pub fn run_command<W: Write>(command: Command, writer: &mut W) -> Result<(), Run
         Command::ScreenOn => run_screen_on(writer),
         Command::Monitor => run_monitor(writer),
         Command::Lifecycle => run_lifecycle_monitor(writer),
+        Command::Dev(command) => run_dev_command(command, writer).map_err(RunError::Dev),
         Command::Settings(command) => {
             run_settings_command(command, writer).map_err(RunError::Settings)
         }
@@ -447,7 +465,8 @@ fn run_detect_backend<W: Write>(writer: &mut W) -> Result<(), RunError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_args, usage, BrightnessCommand, Command, ParseError, ParseOutcome, StartupMode,
+        parse_args, usage, BrightnessCommand, Command, DevCommand, DevParseError, ParseError,
+        ParseOutcome, StartupMode,
     };
     use crate::settings::{SettingsCommand, SettingsParseError};
     use crate::tv::OledBrightness;
@@ -541,6 +560,12 @@ mod tests {
         assert_eq!(
             parse_args(["detect-backend"]),
             Ok(ParseOutcome::Command(Command::DetectBackend))
+        );
+        assert_eq!(
+            parse_args(["dev", "webos-auth-probe"]),
+            Ok(ParseOutcome::Command(Command::Dev(
+                DevCommand::WebOsAuthProbe
+            )))
         );
         assert_eq!(
             parse_args(["settings", "list"]),
@@ -698,6 +723,26 @@ mod tests {
     }
 
     #[test]
+    fn invalid_dev_command_is_rejected() {
+        assert_eq!(
+            parse_args(["dev"]),
+            Err(ParseError::Dev(DevParseError::MissingSubcommand))
+        );
+        assert_eq!(
+            parse_args(["dev", "other"]),
+            Err(ParseError::Dev(DevParseError::UnknownSubcommand(
+                "other".to_string()
+            )))
+        );
+        assert_eq!(
+            parse_args(["dev", "webos-auth-probe", "extra"]),
+            Err(ParseError::Dev(DevParseError::UnexpectedArguments {
+                arguments: vec!["extra".to_string()],
+            }))
+        );
+    }
+
+    #[test]
     fn invalid_settings_command_is_rejected() {
         assert_eq!(
             parse_args(["settings"]),
@@ -790,6 +835,7 @@ mod tests {
                 "missing `{command}` from help output"
             );
         }
+        assert!(!help.contains("webos-auth-probe"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod events;
 pub mod lifecycle;
 pub mod notifications;
+pub mod platform_access_token;
 pub mod policy;
 pub mod runtime_phase;
 pub mod screen;

--- a/crates/lg-buddy/src/platform_access_token.rs
+++ b/crates/lg-buddy/src/platform_access_token.rs
@@ -1,6 +1,7 @@
 //! Profile-scoped platform access-token storage.
 
 use crate::auth::SystemUser;
+use crate::web_os::{WebOsClientRegistration, WebOsClientRegistrationError};
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::fmt;
@@ -154,6 +155,36 @@ impl Error for PlatformAccessTokenStoreError {
     }
 }
 
+#[derive(Debug)]
+pub enum PlatformAccessTokenAcquisitionError {
+    Store {
+        source: PlatformAccessTokenStoreError,
+    },
+    Registration {
+        source: WebOsClientRegistrationError,
+    },
+}
+
+impl fmt::Display for PlatformAccessTokenAcquisitionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Store { source } => write!(f, "platform access-token storage failed: {source}"),
+            Self::Registration { source } => {
+                write!(f, "platform access-token registration failed: {source}")
+            }
+        }
+    }
+}
+
+impl Error for PlatformAccessTokenAcquisitionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Store { source } => Some(source),
+            Self::Registration { source } => Some(source),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PlatformAccessTokenStore {
     token_path: PathBuf,
@@ -236,6 +267,31 @@ impl PlatformAccessTokenStore {
         ensure_private_directory(tvs_dir, &self.owner)?;
         ensure_private_directory(profile_dir, &self.owner)?;
         atomic_write_token(&self.token_path, &contents, &self.owner)
+    }
+
+    pub(crate) fn get_or_acquire(
+        &self,
+        registration: &mut WebOsClientRegistration<'_, '_>,
+    ) -> Result<PlatformAccessToken, PlatformAccessTokenAcquisitionError> {
+        match self
+            .load()
+            .map_err(|source| PlatformAccessTokenAcquisitionError::Store { source })?
+        {
+            Some(token) => {
+                registration.register(Some(&token)).map_err(|source| {
+                    PlatformAccessTokenAcquisitionError::Registration { source }
+                })?;
+                Ok(token)
+            }
+            None => {
+                let token = registration.register(None).map_err(|source| {
+                    PlatformAccessTokenAcquisitionError::Registration { source }
+                })?;
+                self.persist(&token)
+                    .map_err(|source| PlatformAccessTokenAcquisitionError::Store { source })?;
+                Ok(token)
+            }
+        }
     }
 }
 

--- a/crates/lg-buddy/src/platform_access_token.rs
+++ b/crates/lg-buddy/src/platform_access_token.rs
@@ -1,0 +1,737 @@
+//! Profile-scoped platform access-token storage.
+
+use crate::auth::SystemUser;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process;
+
+const TVS_DIR_NAME: &str = "tvs";
+const PRIMARY_TV_PROFILE_NAME: &str = "primary";
+const ACCESS_TOKEN_FILE_NAME: &str = "access-token.json";
+const TEMP_FILE_ATTEMPTS: u8 = 100;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PlatformAccessToken(String);
+
+impl PlatformAccessToken {
+    pub fn new(value: impl Into<String>) -> Result<Self, PlatformAccessTokenError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(PlatformAccessTokenError::Empty);
+        }
+
+        Ok(Self(value))
+    }
+
+    pub fn as_secret_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for PlatformAccessToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PlatformAccessToken")
+            .field(&"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformAccessTokenError {
+    Empty,
+}
+
+impl fmt::Display for PlatformAccessTokenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "platform access token cannot be empty"),
+        }
+    }
+}
+
+impl Error for PlatformAccessTokenError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformAccessTokenStoreOperation {
+    CreateDirectory,
+    InspectDirectory,
+    OpenDirectory,
+    SetPermissions,
+    SetOwner,
+    ReadToken,
+    CreateTemporaryFile,
+    WriteTemporaryFile,
+    SyncTemporaryFile,
+    ReplaceToken,
+}
+
+impl fmt::Display for PlatformAccessTokenStoreOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let description = match self {
+            Self::CreateDirectory => "create credential directory",
+            Self::InspectDirectory => "inspect credential directory",
+            Self::OpenDirectory => "open credential directory",
+            Self::SetPermissions => "set credential permissions",
+            Self::SetOwner => "set credential owner",
+            Self::ReadToken => "read platform access token",
+            Self::CreateTemporaryFile => "create temporary access-token file",
+            Self::WriteTemporaryFile => "write temporary access-token file",
+            Self::SyncTemporaryFile => "sync temporary access-token file",
+            Self::ReplaceToken => "replace platform access-token file",
+        };
+        write!(f, "{description}")
+    }
+}
+
+#[derive(Debug)]
+pub enum PlatformAccessTokenStoreError {
+    ConfigPathHasNoParent {
+        path: PathBuf,
+    },
+    Io {
+        operation: PlatformAccessTokenStoreOperation,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidJson {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    InvalidToken {
+        path: PathBuf,
+        source: PlatformAccessTokenError,
+    },
+    Serialize(serde_json::Error),
+}
+
+impl fmt::Display for PlatformAccessTokenStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConfigPathHasNoParent { path } => write!(
+                f,
+                "could not derive the platform access-token path because config path `{}` has no parent directory",
+                path.display()
+            ),
+            Self::Io {
+                operation,
+                path,
+                source,
+            } => write!(f, "could not {operation} at `{}`: {source}", path.display()),
+            Self::InvalidJson { path, source } => write!(
+                f,
+                "platform access-token file `{}` is malformed: {source}",
+                path.display()
+            ),
+            Self::InvalidToken { path, source } => write!(
+                f,
+                "platform access-token file `{}` is invalid: {source}",
+                path.display()
+            ),
+            Self::Serialize(source) => {
+                write!(f, "could not serialize platform access token: {source}")
+            }
+        }
+    }
+}
+
+impl Error for PlatformAccessTokenStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::InvalidJson { source, .. } => Some(source),
+            Self::InvalidToken { source, .. } => Some(source),
+            Self::Serialize(source) => Some(source),
+            Self::ConfigPathHasNoParent { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PlatformAccessTokenStore {
+    token_path: PathBuf,
+    owner: SystemUser,
+}
+
+impl PlatformAccessTokenStore {
+    pub fn for_primary_profile(
+        config_path: &Path,
+        owner: SystemUser,
+    ) -> Result<Self, PlatformAccessTokenStoreError> {
+        let config_dir = config_path
+            .parent()
+            .filter(|path| !path.as_os_str().is_empty())
+            .ok_or_else(|| PlatformAccessTokenStoreError::ConfigPathHasNoParent {
+                path: config_path.to_path_buf(),
+            })?;
+
+        Ok(Self {
+            token_path: config_dir
+                .join(TVS_DIR_NAME)
+                .join(PRIMARY_TV_PROFILE_NAME)
+                .join(ACCESS_TOKEN_FILE_NAME),
+            owner,
+        })
+    }
+
+    pub fn token_path(&self) -> &Path {
+        &self.token_path
+    }
+
+    pub fn load(&self) -> Result<Option<PlatformAccessToken>, PlatformAccessTokenStoreError> {
+        let contents = match read_token_file(&self.token_path) {
+            Ok(contents) => contents,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => {
+                return Err(store_io_error(
+                    PlatformAccessTokenStoreOperation::ReadToken,
+                    &self.token_path,
+                    source,
+                ))
+            }
+        };
+
+        let stored: StoredPlatformAccessToken =
+            serde_json::from_str(&contents).map_err(|source| {
+                PlatformAccessTokenStoreError::InvalidJson {
+                    path: self.token_path.clone(),
+                    source,
+                }
+            })?;
+        let token = PlatformAccessToken::new(stored.access_token).map_err(|source| {
+            PlatformAccessTokenStoreError::InvalidToken {
+                path: self.token_path.clone(),
+                source,
+            }
+        })?;
+
+        Ok(Some(token))
+    }
+
+    pub fn persist(
+        &self,
+        token: &PlatformAccessToken,
+    ) -> Result<(), PlatformAccessTokenStoreError> {
+        let mut contents = serde_json::to_vec_pretty(&StoredPlatformAccessToken {
+            access_token: token.as_secret_str().to_string(),
+        })
+        .map_err(PlatformAccessTokenStoreError::Serialize)?;
+        contents.push(b'\n');
+
+        let profile_dir = self
+            .token_path
+            .parent()
+            .expect("derived token path always has a profile directory");
+        let tvs_dir = profile_dir
+            .parent()
+            .expect("derived profile path always has a TVs directory");
+
+        ensure_private_directory(tvs_dir, &self.owner)?;
+        ensure_private_directory(profile_dir, &self.owner)?;
+        atomic_write_token(&self.token_path, &contents, &self.owner)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct StoredPlatformAccessToken {
+    access_token: String,
+}
+
+fn read_token_file(path: &Path) -> io::Result<String> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+
+    let mut contents = String::new();
+    options.open(path)?.read_to_string(&mut contents)?;
+    Ok(contents)
+}
+
+fn ensure_private_directory(
+    path: &Path,
+    owner: &SystemUser,
+) -> Result<(), PlatformAccessTokenStoreError> {
+    match fs::create_dir(path) {
+        Ok(()) => {}
+        Err(source) if source.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(source) => {
+            return Err(store_io_error(
+                PlatformAccessTokenStoreOperation::CreateDirectory,
+                path,
+                source,
+            ))
+        }
+    }
+
+    let metadata = fs::symlink_metadata(path).map_err(|source| {
+        store_io_error(
+            PlatformAccessTokenStoreOperation::InspectDirectory,
+            path,
+            source,
+        )
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(store_io_error(
+            PlatformAccessTokenStoreOperation::InspectDirectory,
+            path,
+            io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "credential path is not a directory",
+            ),
+        ));
+    }
+
+    secure_directory(path, owner)
+}
+
+fn atomic_write_token(
+    path: &Path,
+    contents: &[u8],
+    owner: &SystemUser,
+) -> Result<(), PlatformAccessTokenStoreError> {
+    let mut last_collision = None;
+
+    for attempt in 0..TEMP_FILE_ATTEMPTS {
+        let temp_path = token_temp_path(path, attempt);
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+
+        let mut file = match options.open(&temp_path) {
+            Ok(file) => file,
+            Err(source) if source.kind() == io::ErrorKind::AlreadyExists => {
+                last_collision = Some((temp_path, source));
+                continue;
+            }
+            Err(source) => {
+                return Err(store_io_error(
+                    PlatformAccessTokenStoreOperation::CreateTemporaryFile,
+                    &temp_path,
+                    source,
+                ))
+            }
+        };
+
+        let write_result = (|| {
+            file.write_all(contents).map_err(|source| {
+                store_io_error(
+                    PlatformAccessTokenStoreOperation::WriteTemporaryFile,
+                    &temp_path,
+                    source,
+                )
+            })?;
+            file.flush().map_err(|source| {
+                store_io_error(
+                    PlatformAccessTokenStoreOperation::WriteTemporaryFile,
+                    &temp_path,
+                    source,
+                )
+            })?;
+            secure_file(&file, &temp_path, owner)?;
+            file.sync_all().map_err(|source| {
+                store_io_error(
+                    PlatformAccessTokenStoreOperation::SyncTemporaryFile,
+                    &temp_path,
+                    source,
+                )
+            })?;
+            drop(file);
+            fs::rename(&temp_path, path).map_err(|source| {
+                store_io_error(
+                    PlatformAccessTokenStoreOperation::ReplaceToken,
+                    path,
+                    source,
+                )
+            })
+        })();
+
+        if let Err(error) = write_result {
+            let _ = fs::remove_file(&temp_path);
+            return Err(error);
+        }
+
+        return Ok(());
+    }
+
+    let (path, source) = last_collision.unwrap_or_else(|| {
+        (
+            path.to_path_buf(),
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "could not create a unique temporary access-token file",
+            ),
+        )
+    });
+    Err(store_io_error(
+        PlatformAccessTokenStoreOperation::CreateTemporaryFile,
+        &path,
+        source,
+    ))
+}
+
+fn token_temp_path(path: &Path, attempt: u8) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("access-token");
+    path.with_file_name(format!(".{file_name}.{}.{}.tmp", process::id(), attempt))
+}
+
+fn store_io_error(
+    operation: PlatformAccessTokenStoreOperation,
+    path: &Path,
+    source: io::Error,
+) -> PlatformAccessTokenStoreError {
+    PlatformAccessTokenStoreError::Io {
+        operation,
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+#[cfg(unix)]
+fn secure_directory(path: &Path, owner: &SystemUser) -> Result<(), PlatformAccessTokenStoreError> {
+    let directory = File::open(path).map_err(|source| {
+        store_io_error(
+            PlatformAccessTokenStoreOperation::OpenDirectory,
+            path,
+            source,
+        )
+    })?;
+    set_file_mode(&directory, path, 0o700)?;
+    set_file_owner(&directory, path, owner)
+}
+
+#[cfg(not(unix))]
+fn secure_directory(
+    _path: &Path,
+    _owner: &SystemUser,
+) -> Result<(), PlatformAccessTokenStoreError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_file(
+    file: &File,
+    path: &Path,
+    owner: &SystemUser,
+) -> Result<(), PlatformAccessTokenStoreError> {
+    set_file_mode(file, path, 0o600)?;
+    set_file_owner(file, path, owner)
+}
+
+#[cfg(not(unix))]
+fn secure_file(
+    _file: &File,
+    _path: &Path,
+    _owner: &SystemUser,
+) -> Result<(), PlatformAccessTokenStoreError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_file_mode(file: &File, path: &Path, mode: u32) -> Result<(), PlatformAccessTokenStoreError> {
+    file.set_permissions(fs::Permissions::from_mode(mode))
+        .map_err(|source| {
+            store_io_error(
+                PlatformAccessTokenStoreOperation::SetPermissions,
+                path,
+                source,
+            )
+        })
+}
+
+#[cfg(unix)]
+fn set_file_owner(
+    file: &File,
+    path: &Path,
+    owner: &SystemUser,
+) -> Result<(), PlatformAccessTokenStoreError> {
+    let metadata = file.metadata().map_err(|source| {
+        store_io_error(PlatformAccessTokenStoreOperation::SetOwner, path, source)
+    })?;
+    if metadata.uid() == owner.uid() && metadata.gid() == owner.gid() {
+        return Ok(());
+    }
+
+    let result = unsafe { libc::fchown(file.as_raw_fd(), owner.uid(), owner.gid()) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(store_io_error(
+            PlatformAccessTokenStoreOperation::SetOwner,
+            path,
+            io::Error::last_os_error(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        token_temp_path, PlatformAccessToken, PlatformAccessTokenError, PlatformAccessTokenStore,
+        PlatformAccessTokenStoreError, PlatformAccessTokenStoreOperation, TEMP_FILE_ATTEMPTS,
+    };
+    use crate::auth::SystemUser;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(label: &str) -> Self {
+            let sequence = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "lg-buddy-web-os-{label}-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        fn config_path(&self) -> PathBuf {
+            self.path().join("config.env")
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn current_user(home: &Path) -> SystemUser {
+        #[cfg(unix)]
+        {
+            SystemUser::new(
+                "test-user",
+                unsafe { libc::geteuid() },
+                unsafe { libc::getegid() },
+                home,
+            )
+        }
+
+        #[cfg(not(unix))]
+        {
+            SystemUser::new("test-user", 0, 0, home)
+        }
+    }
+
+    fn token(value: &str) -> PlatformAccessToken {
+        PlatformAccessToken::new(value).expect("valid platform access token")
+    }
+
+    #[test]
+    fn platform_access_token_rejects_empty_values_and_redacts_debug_output() {
+        assert_eq!(
+            PlatformAccessToken::new("  "),
+            Err(PlatformAccessTokenError::Empty)
+        );
+
+        let token = token("secret-client-key");
+        let debug = format!("{token:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains(token.as_secret_str()));
+    }
+
+    #[test]
+    fn primary_profile_token_path_is_derived_from_config_directory() {
+        let owner = SystemUser::new("vas", 1000, 1000, "/home/vas");
+        let store = PlatformAccessTokenStore::for_primary_profile(
+            Path::new("/home/vas/.config/lg-buddy/config.env"),
+            owner,
+        )
+        .expect("derive platform access-token store");
+
+        assert_eq!(
+            store.token_path(),
+            Path::new("/home/vas/.config/lg-buddy/tvs/primary/access-token.json")
+        );
+        assert!(!store.token_path().to_string_lossy().contains("webos"));
+    }
+
+    #[test]
+    fn primary_profile_token_path_requires_config_parent() {
+        let owner = SystemUser::new("vas", 1000, 1000, "/home/vas");
+        let error = PlatformAccessTokenStore::for_primary_profile(Path::new("config.env"), owner)
+            .expect_err("bare config filename should not have a parent directory");
+
+        assert!(matches!(
+            error,
+            PlatformAccessTokenStoreError::ConfigPathHasNoParent { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_token_file_returns_none() {
+        let dir = TestDir::new("missing-token");
+        let store = PlatformAccessTokenStore::for_primary_profile(
+            &dir.config_path(),
+            current_user(dir.path()),
+        )
+        .expect("derive platform access-token store");
+
+        assert_eq!(store.load().expect("load missing token"), None);
+    }
+
+    #[test]
+    fn persist_creates_private_profile_path_and_round_trips_token() {
+        let dir = TestDir::new("persist-token");
+        let owner = current_user(dir.path());
+        let store =
+            PlatformAccessTokenStore::for_primary_profile(&dir.config_path(), owner.clone())
+                .expect("derive platform access-token store");
+        let expected = token("stored-client-key");
+
+        store.persist(&expected).expect("persist access token");
+
+        assert_eq!(store.load().expect("load persisted token"), Some(expected));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+            let profile_dir = store.token_path().parent().expect("profile directory");
+            let tvs_dir = profile_dir.parent().expect("TVs directory");
+            for path in [tvs_dir, profile_dir] {
+                let metadata = fs::metadata(path).expect("credential directory metadata");
+                assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+                assert_eq!(metadata.uid(), owner.uid());
+                assert_eq!(metadata.gid(), owner.gid());
+            }
+
+            let metadata = fs::metadata(store.token_path()).expect("token file metadata");
+            assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+            assert_eq!(metadata.uid(), owner.uid());
+            assert_eq!(metadata.gid(), owner.gid());
+        }
+    }
+
+    #[test]
+    fn malformed_json_and_empty_token_are_distinct_typed_errors() {
+        let dir = TestDir::new("invalid-token");
+        let store = PlatformAccessTokenStore::for_primary_profile(
+            &dir.config_path(),
+            current_user(dir.path()),
+        )
+        .expect("derive platform access-token store");
+        fs::create_dir_all(store.token_path().parent().expect("profile directory"))
+            .expect("create profile directory");
+
+        fs::write(store.token_path(), "not-json\n").expect("write malformed token file");
+        assert!(matches!(
+            store.load().expect_err("malformed JSON should fail"),
+            PlatformAccessTokenStoreError::InvalidJson { .. }
+        ));
+
+        fs::write(store.token_path(), r#"{"access_token":" "}"#).expect("write empty token file");
+        assert!(matches!(
+            store.load().expect_err("empty token should fail"),
+            PlatformAccessTokenStoreError::InvalidToken {
+                source: PlatformAccessTokenError::Empty,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn unreadable_token_path_is_a_typed_read_error() {
+        let dir = TestDir::new("unreadable-token");
+        let store = PlatformAccessTokenStore::for_primary_profile(
+            &dir.config_path(),
+            current_user(dir.path()),
+        )
+        .expect("derive platform access-token store");
+        fs::create_dir_all(store.token_path()).expect("create directory at token path");
+
+        assert!(matches!(
+            store.load().expect_err("directory cannot be read as token"),
+            PlatformAccessTokenStoreError::Io {
+                operation: PlatformAccessTokenStoreOperation::ReadToken,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn temporary_file_exhaustion_does_not_replace_existing_token() {
+        let dir = TestDir::new("atomic-failure");
+        let store = PlatformAccessTokenStore::for_primary_profile(
+            &dir.config_path(),
+            current_user(dir.path()),
+        )
+        .expect("derive platform access-token store");
+        let original = token("original-client-key");
+        store.persist(&original).expect("persist original token");
+
+        for attempt in 0..TEMP_FILE_ATTEMPTS {
+            fs::write(token_temp_path(store.token_path(), attempt), [])
+                .expect("occupy temporary token path");
+        }
+
+        let error = store
+            .persist(&token("replacement-client-key"))
+            .expect_err("occupied temporary paths should fail persistence");
+        assert!(matches!(
+            error,
+            PlatformAccessTokenStoreError::Io {
+                operation: PlatformAccessTokenStoreOperation::CreateTemporaryFile,
+                ..
+            }
+        ));
+        assert_eq!(store.load().expect("load original token"), Some(original));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persist_assigns_requested_owner_when_running_as_root() {
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+
+        let dir = TestDir::new("root-owner");
+        let owner = SystemUser::new("non-root-owner", 65534, 65534, "/nonexistent");
+        let store =
+            PlatformAccessTokenStore::for_primary_profile(&dir.config_path(), owner.clone())
+                .expect("derive platform access-token store");
+
+        store
+            .persist(&token("root-written-client-key"))
+            .expect("persist token for requested non-root owner");
+
+        for path in [
+            store
+                .token_path()
+                .parent()
+                .expect("profile directory")
+                .parent()
+                .expect("TVs directory"),
+            store.token_path().parent().expect("profile directory"),
+            store.token_path(),
+        ] {
+            use std::os::unix::fs::MetadataExt;
+
+            let metadata = fs::metadata(path).expect("credential path metadata");
+            assert_eq!(metadata.uid(), owner.uid());
+            assert_eq!(metadata.gid(), owner.gid());
+        }
+    }
+}

--- a/crates/lg-buddy/src/platform_access_token.rs
+++ b/crates/lg-buddy/src/platform_access_token.rs
@@ -1,7 +1,9 @@
 //! Profile-scoped platform access-token storage.
 
 use crate::auth::SystemUser;
-use crate::web_os::{WebOsClientRegistration, WebOsClientRegistrationError};
+use crate::web_os::{
+    WebOsAuthenticationEvent, WebOsClientRegistration, WebOsClientRegistrationError,
+};
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::fmt;
@@ -269,26 +271,36 @@ impl PlatformAccessTokenStore {
         atomic_write_token(&self.token_path, &contents, &self.owner)
     }
 
-    pub(crate) fn get_or_acquire(
+    pub(crate) fn get_or_acquire<F>(
         &self,
-        registration: &mut WebOsClientRegistration<'_, '_>,
-    ) -> Result<PlatformAccessToken, PlatformAccessTokenAcquisitionError> {
+        registration: &mut WebOsClientRegistration<'_>,
+        on_auth_event: &mut F,
+    ) -> Result<PlatformAccessToken, PlatformAccessTokenAcquisitionError>
+    where
+        F: FnMut(WebOsAuthenticationEvent),
+    {
         match self
             .load()
             .map_err(|source| PlatformAccessTokenAcquisitionError::Store { source })?
         {
             Some(token) => {
-                registration.register(Some(&token)).map_err(|source| {
-                    PlatformAccessTokenAcquisitionError::Registration { source }
-                })?;
+                on_auth_event(WebOsAuthenticationEvent::UsingStoredAccessToken);
+                registration
+                    .register(Some(&token), on_auth_event)
+                    .map_err(|source| PlatformAccessTokenAcquisitionError::Registration {
+                        source,
+                    })?;
                 Ok(token)
             }
             None => {
-                let token = registration.register(None).map_err(|source| {
-                    PlatformAccessTokenAcquisitionError::Registration { source }
-                })?;
+                let token = registration
+                    .register(None, on_auth_event)
+                    .map_err(|source| PlatformAccessTokenAcquisitionError::Registration {
+                        source,
+                    })?;
                 self.persist(&token)
                     .map_err(|source| PlatformAccessTokenAcquisitionError::Store { source })?;
+                on_auth_event(WebOsAuthenticationEvent::AccessTokenPersisted);
                 Ok(token)
             }
         }

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -154,7 +154,11 @@ impl WebOsClient {
         }
     }
 
-    pub fn send_request(&mut self, uri: &str, payload: Value) -> Result<Value, WebOsClientError> {
+    pub(crate) fn send_request(
+        &mut self,
+        uri: &str,
+        payload: Value,
+    ) -> Result<Value, WebOsClientError> {
         let request_id = self.next_request_id()?;
         let request = json!({
             "id": request_id,
@@ -569,7 +573,7 @@ mod tests {
         PlatformAccessToken, PlatformAccessTokenAcquisitionError, PlatformAccessTokenStore,
         PlatformAccessTokenStoreError, PlatformAccessTokenStoreOperation,
     };
-    use crate::web_os::WebOsRegistrationError;
+    use crate::web_os::{WebOsPowerState, WebOsPowerStateError, WebOsRegistrationError};
     use base64::{engine::general_purpose::STANDARD, Engine as _};
     use rustls::crypto::ring;
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
@@ -1155,6 +1159,111 @@ mod tests {
             })
         ));
         assert!(store.token_path().is_dir());
+        server.join();
+    }
+
+    #[test]
+    fn authenticated_client_reads_typed_power_state() {
+        let dir = TestDir::new("power-state");
+        let store = token_store(&dir);
+        store
+            .persist(&token("power-state-client-key"))
+            .expect("persist stored token");
+        let server = spawn_plain_server(|socket| {
+            let registration = read_request(socket);
+            assert_eq!(registration["type"], "register");
+            assert_eq!(
+                registration["payload"]["client-key"],
+                "power-state-client-key"
+            );
+            send_json(
+                socket,
+                json!({
+                    "id": registration["id"],
+                    "type": "registered",
+                    "payload": {"client-key": "power-state-client-key"},
+                }),
+            );
+
+            let request = read_request(socket);
+            assert_eq!(request["id"], "request_1");
+            assert_eq!(request["type"], "request");
+            assert_eq!(
+                request["uri"],
+                "ssap://com.webos.service.tvpower/power/getPowerState"
+            );
+            assert_eq!(request["payload"], json!({}));
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "response",
+                    "payload": {"returnValue": true, "state": "Active"},
+                }),
+            );
+        });
+        let mut client = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+            || panic!("stored token should not prompt"),
+        )
+        .expect("authenticate power-state client");
+
+        assert_eq!(
+            client.power_state().expect("read power state"),
+            WebOsPowerState::Active
+        );
+        server.join();
+    }
+
+    #[test]
+    fn power_state_preserves_webos_error() {
+        let dir = TestDir::new("power-state-error");
+        let store = token_store(&dir);
+        store
+            .persist(&token("power-state-error-key"))
+            .expect("persist stored token");
+        let server = spawn_plain_server(|socket| {
+            let registration = read_request(socket);
+            send_json(
+                socket,
+                json!({
+                    "id": registration["id"],
+                    "type": "registered",
+                    "payload": {"client-key": "power-state-error-key"},
+                }),
+            );
+
+            let request = read_request(socket);
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "error",
+                    "error": "-401 not permitted",
+                }),
+            );
+        });
+        let mut client = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+            || panic!("stored token should not prompt"),
+        )
+        .expect("authenticate power-state client");
+
+        assert!(matches!(
+            client.power_state(),
+            Err(WebOsPowerStateError::Request {
+                source: WebOsClientError::WebOs {
+                    code: Some(-401),
+                    message,
+                },
+            }) if message == "not permitted"
+        ));
         server.join();
     }
 }

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -1,4 +1,11 @@
+use super::registration::{
+    parse_registration_message, WebOsRegistrationError, WebOsRegistrationEvent,
+    WebOsRegistrationRequest,
+};
 use super::tls::webos_tv_self_signed_client_config;
+use crate::platform_access_token::{
+    PlatformAccessToken, PlatformAccessTokenAcquisitionError, PlatformAccessTokenStore,
+};
 use serde_json::{json, Value};
 use std::error::Error;
 use std::fmt;
@@ -73,7 +80,27 @@ pub struct WebOsClient {
 }
 
 impl WebOsClient {
-    pub fn connect(
+    pub fn connect_authenticated<F>(
+        endpoint: WebOsEndpoint,
+        connect_timeout: Duration,
+        response_timeout: Duration,
+        token_store: &PlatformAccessTokenStore,
+        mut on_pairing_prompt: F,
+    ) -> Result<Self, WebOsAuthenticatedClientError>
+    where
+        F: FnMut(),
+    {
+        let mut client = Self::connect(endpoint, connect_timeout, response_timeout)
+            .map_err(|source| WebOsAuthenticatedClientError::Connect { source })?;
+        let mut registration = client.registration(&mut on_pairing_prompt);
+        token_store
+            .get_or_acquire(&mut registration)
+            .map_err(|source| WebOsAuthenticatedClientError::Authentication { source })?;
+
+        Ok(client)
+    }
+
+    fn connect(
         endpoint: WebOsEndpoint,
         connect_timeout: Duration,
         response_timeout: Duration,
@@ -117,6 +144,16 @@ impl WebOsClient {
         })
     }
 
+    fn registration<'client, 'prompt>(
+        &'client mut self,
+        on_pairing_prompt: &'prompt mut dyn FnMut(),
+    ) -> WebOsClientRegistration<'client, 'prompt> {
+        WebOsClientRegistration {
+            client: self,
+            on_pairing_prompt,
+        }
+    }
+
     pub fn send_request(&mut self, uri: &str, payload: Value) -> Result<Value, WebOsClientError> {
         let request_id = self.next_request_id()?;
         let request = json!({
@@ -138,14 +175,29 @@ impl WebOsClient {
     }
 
     fn exchange(&mut self, request_id: &str, request: Value) -> Result<Value, WebOsClientError> {
+        self.send_message(request)?;
+        let deadline = self.response_deadline()?;
+        let response = self.receive_correlated(request_id, deadline)?;
+        validate_response_message(response)
+    }
+
+    fn send_message(&mut self, request: Value) -> Result<(), WebOsClientError> {
         self.socket
             .send(Message::text(request.to_string()))
-            .map_err(|source| WebOsClientError::Send { source })?;
+            .map_err(|source| WebOsClientError::Send { source })
+    }
 
-        let deadline = Instant::now()
+    fn response_deadline(&self) -> Result<Instant, WebOsClientError> {
+        Instant::now()
             .checked_add(self.response_timeout)
-            .ok_or(WebOsClientError::InvalidTimeout { name: "response" })?;
+            .ok_or(WebOsClientError::InvalidTimeout { name: "response" })
+    }
 
+    fn receive_correlated(
+        &mut self,
+        request_id: &str,
+        deadline: Instant,
+    ) -> Result<Value, WebOsClientError> {
         loop {
             let remaining = deadline
                 .checked_duration_since(Instant::now())
@@ -195,6 +247,113 @@ impl WebOsClient {
                 Message::Binary(_) => return Err(WebOsClientError::UnexpectedBinaryFrame),
                 Message::Frame(_) => return Err(WebOsClientError::UnexpectedRawFrame),
             }
+        }
+    }
+}
+
+pub(crate) struct WebOsClientRegistration<'client, 'prompt> {
+    client: &'client mut WebOsClient,
+    on_pairing_prompt: &'prompt mut dyn FnMut(),
+}
+
+impl WebOsClientRegistration<'_, '_> {
+    pub(crate) fn register(
+        &mut self,
+        access_token: Option<&PlatformAccessToken>,
+    ) -> Result<PlatformAccessToken, WebOsClientRegistrationError> {
+        let request_id = self
+            .client
+            .next_request_id()
+            .map_err(|source| WebOsClientRegistrationError::Transport { source })?;
+        let request = WebOsRegistrationRequest::new(&request_id, access_token)
+            .map_err(|source| WebOsClientRegistrationError::Protocol { source })?;
+        self.client
+            .send_message(request.to_json_value())
+            .map_err(|source| WebOsClientRegistrationError::Transport { source })?;
+        let deadline = self
+            .client
+            .response_deadline()
+            .map_err(|source| WebOsClientRegistrationError::Transport { source })?;
+
+        loop {
+            let response = self
+                .client
+                .receive_correlated(&request_id, deadline)
+                .map_err(|source| WebOsClientRegistrationError::Transport { source })?;
+            let event = parse_registration_message(&request_id, &response.to_string())
+                .map_err(|source| WebOsClientRegistrationError::Protocol { source })?;
+
+            match event {
+                WebOsRegistrationEvent::PairingPrompt if access_token.is_some() => {
+                    return Err(WebOsClientRegistrationError::StoredTokenRequiresPairing)
+                }
+                WebOsRegistrationEvent::PairingPrompt => (self.on_pairing_prompt)(),
+                WebOsRegistrationEvent::Registered { access_token } => return Ok(access_token),
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum WebOsAuthenticatedClientError {
+    Connect {
+        source: WebOsClientError,
+    },
+    Authentication {
+        source: PlatformAccessTokenAcquisitionError,
+    },
+}
+
+impl fmt::Display for WebOsAuthenticatedClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Connect { source } => write!(f, "could not connect webOS client: {source}"),
+            Self::Authentication { source } => {
+                write!(f, "could not authenticate webOS client: {source}")
+            }
+        }
+    }
+}
+
+impl Error for WebOsAuthenticatedClientError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Connect { source } => Some(source),
+            Self::Authentication { source } => Some(source),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum WebOsClientRegistrationError {
+    Transport { source: WebOsClientError },
+    Protocol { source: WebOsRegistrationError },
+    StoredTokenRequiresPairing,
+}
+
+impl fmt::Display for WebOsClientRegistrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transport { source } => {
+                write!(f, "webOS registration transport failed: {source}")
+            }
+            Self::Protocol { source } => write!(f, "webOS registration failed: {source}"),
+            Self::StoredTokenRequiresPairing => {
+                write!(
+                    f,
+                    "webOS rejected the stored access token and requested pairing"
+                )
+            }
+        }
+    }
+}
+
+impl Error for WebOsClientRegistrationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Transport { source } => Some(source),
+            Self::Protocol { source } => Some(source),
+            Self::StoredTokenRequiresPairing => None,
         }
     }
 }
@@ -362,6 +521,13 @@ fn parse_correlated_frame(
         return Ok(None);
     }
 
+    Ok(Some(message))
+}
+
+fn validate_response_message(message: Value) -> Result<Value, WebOsClientError> {
+    let object = message
+        .as_object()
+        .expect("correlated websocket message root was already validated");
     let message_type = match object.get("type") {
         Some(Value::String(message_type)) => message_type,
         Some(_) => return Err(WebOsClientError::InvalidMessageType),
@@ -371,7 +537,7 @@ fn parse_correlated_frame(
         return Err(parse_webos_error(object));
     }
 
-    Ok(Some(message))
+    Ok(message)
 }
 
 fn parse_webos_error(message: &serde_json::Map<String, Value>) -> WebOsClientError {
@@ -394,14 +560,26 @@ fn parse_webos_error(message: &serde_json::Map<String, Value>) -> WebOsClientErr
 
 #[cfg(test)]
 mod tests {
-    use super::{WebOsClient, WebOsClientError, WebOsEndpoint};
+    use super::{
+        WebOsAuthenticatedClientError, WebOsClient, WebOsClientError, WebOsClientRegistrationError,
+        WebOsEndpoint,
+    };
+    use crate::auth::SystemUser;
+    use crate::platform_access_token::{
+        PlatformAccessToken, PlatformAccessTokenAcquisitionError, PlatformAccessTokenStore,
+        PlatformAccessTokenStoreError, PlatformAccessTokenStoreOperation,
+    };
+    use crate::web_os::WebOsRegistrationError;
     use base64::{engine::general_purpose::STANDARD, Engine as _};
     use rustls::crypto::ring;
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
     use rustls::{ServerConfig, ServerConnection, StreamOwned};
     use serde_json::{json, Value};
+    use std::fs;
     use std::io;
     use std::net::{TcpListener, TcpStream};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
     use std::thread::{self, JoinHandle};
     use std::time::Duration;
@@ -411,6 +589,50 @@ mod tests {
     const RESPONSE_TIMEOUT: Duration = Duration::from_millis(200);
     const TEST_CERTIFICATE_DER: &str = "MIIBkzCCATmgAwIBAgIUGCxGaL477t4FECFewoE+24e3aWQwCgYIKoZIzj0EAwIwHjEcMBoGA1UEAwwTTEcgQnVkZHkgRDMgVGVzdCBUVjAgFw0yNjA3MTEyMDUyMzBaGA8yMTI2MDYxNzIwNTIzMFowHjEcMBoGA1UEAwwTTEcgQnVkZHkgRDMgVGVzdCBUVjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABE8Q+pVxjrGZr5oQfOCxyA7rl7PVzI9U7ukGEp3PI7r8dWDlmcrT5GdNVXIhjza7yi9YRRjw66NaWAlQsd1zxZWjUzBRMB0GA1UdDgQWBBQmbnb3C0PKQVuvqb8oT0Ur6tZLkzAfBgNVHSMEGDAWgBQmbnb3C0PKQVuvqb8oT0Ur6tZLkzAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQDTL/fP5PjETr2XgdN9cBuSkMR8DD0ohRjvya0dfXhM4gIgKe13t3ClUgKULtYbtIa3mwcSCwSsAEfoRsZG5zFiCc8=";
     const TEST_PRIVATE_KEY_DER: &str = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgRQOBcIAKtXbi9IkKmq6PBMKSMlLega0uR6twK6hSmYmhRANCAARPEPqVcY6xma+aEHzgscgO65ez1cyPVO7pBhKdzyO6/HVg5ZnK0+RnTVVyIY82u8ovWEUY8OujWlgJULHdc8WV";
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(label: &str) -> Self {
+            let sequence = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "lg-buddy-web-os-client-{label}-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn token(value: &str) -> PlatformAccessToken {
+        PlatformAccessToken::new(value).expect("valid platform access token")
+    }
+
+    fn token_store(dir: &TestDir) -> PlatformAccessTokenStore {
+        #[cfg(unix)]
+        let owner = SystemUser::new(
+            "test-user",
+            unsafe { libc::geteuid() },
+            unsafe { libc::getegid() },
+            dir.path(),
+        );
+        #[cfg(not(unix))]
+        let owner = SystemUser::new("test-user", 0, 0, dir.path());
+
+        PlatformAccessTokenStore::for_primary_profile(&dir.path().join("config.env"), owner)
+            .expect("derive test token store")
+    }
 
     struct ScriptedServer {
         endpoint: WebOsEndpoint,
@@ -657,6 +879,282 @@ mod tests {
             .send_request("ssap://test/wss", json!({}))
             .expect("secure response");
         assert_eq!(response["payload"]["encrypted"], true);
+        server.join();
+    }
+
+    #[test]
+    fn authenticated_client_registers_with_stored_token_without_prompt_or_rewrite() {
+        let dir = TestDir::new("stored-token");
+        let store = token_store(&dir);
+        let original = token("stored-client-key");
+        store.persist(&original).expect("persist stored token");
+        let server = spawn_plain_server(|socket| {
+            let request = read_request(socket);
+            assert_eq!(request["type"], "register");
+            assert_eq!(request["payload"]["client-key"], "stored-client-key");
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "registered",
+                    "payload": {"client-key": "replacement-client-key"},
+                }),
+            );
+        });
+        let mut prompted = false;
+
+        let _client = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+            || prompted = true,
+        )
+        .expect("authenticate with stored token");
+
+        assert!(!prompted);
+        assert_eq!(store.load().expect("reload stored token"), Some(original));
+        server.join();
+    }
+
+    #[test]
+    fn authenticated_client_pairs_and_persists_new_token() {
+        let dir = TestDir::new("new-token");
+        let store = token_store(&dir);
+        let server = spawn_plain_server(|socket| {
+            let request = read_request(socket);
+            assert_eq!(request["type"], "register");
+            assert_eq!(request["payload"]["client-key"], Value::Null);
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "response",
+                    "payload": {"pairingType": "PROMPT", "returnValue": true},
+                }),
+            );
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "registered",
+                    "payload": {"client-key": "new-client-key"},
+                }),
+            );
+        });
+        let mut prompt_count = 0;
+
+        let _client = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+            || prompt_count += 1,
+        )
+        .expect("pair and authenticate client");
+
+        assert_eq!(prompt_count, 1);
+        assert_eq!(
+            store.load().expect("load acquired token"),
+            Some(token("new-client-key"))
+        );
+        server.join();
+    }
+
+    #[test]
+    fn stored_token_pairing_request_is_typed_and_preserves_token() {
+        let dir = TestDir::new("rejected-stored-token");
+        let store = token_store(&dir);
+        let original = token("rejected-client-key");
+        store.persist(&original).expect("persist stored token");
+        let server = spawn_plain_server(|socket| {
+            let request = read_request(socket);
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "response",
+                    "payload": {"pairingType": "PROMPT", "returnValue": true},
+                }),
+            );
+        });
+        let mut prompted = false;
+
+        let result = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+            || prompted = true,
+        );
+
+        assert!(matches!(
+            result,
+            Err(WebOsAuthenticatedClientError::Authentication {
+                source: PlatformAccessTokenAcquisitionError::Registration {
+                    source: WebOsClientRegistrationError::StoredTokenRequiresPairing,
+                },
+            })
+        ));
+        assert!(!prompted);
+        assert_eq!(store.load().expect("reload stored token"), Some(original));
+        server.join();
+    }
+
+    #[test]
+    fn pairing_rejection_does_not_create_token() {
+        let dir = TestDir::new("pairing-rejected");
+        let store = token_store(&dir);
+        let server = spawn_plain_server(|socket| {
+            let request = read_request(socket);
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "response",
+                    "payload": {"returnValue": false, "errorText": "pairing denied"},
+                }),
+            );
+        });
+
+        let result = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+            || {},
+        );
+
+        assert!(matches!(
+            result,
+            Err(WebOsAuthenticatedClientError::Authentication {
+                source: PlatformAccessTokenAcquisitionError::Registration {
+                    source: WebOsClientRegistrationError::Protocol {
+                        source: WebOsRegistrationError::PairingRejected {
+                            message: Some(message),
+                        },
+                    },
+                },
+            }) if message == "pairing denied"
+        ));
+        assert!(!store.token_path().exists());
+        server.join();
+    }
+
+    #[test]
+    fn registration_timeout_does_not_create_token() {
+        let dir = TestDir::new("registration-timeout");
+        let store = token_store(&dir);
+        let server = spawn_plain_server(|socket| {
+            let _request = read_request(socket);
+            thread::sleep(Duration::from_millis(150));
+        });
+
+        let result = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            Duration::from_millis(40),
+            &store,
+            || {},
+        );
+
+        assert!(matches!(
+            result,
+            Err(WebOsAuthenticatedClientError::Authentication {
+                source: PlatformAccessTokenAcquisitionError::Registration {
+                    source: WebOsClientRegistrationError::Transport {
+                        source: WebOsClientError::Timeout { .. },
+                    },
+                },
+            })
+        ));
+        assert!(!store.token_path().exists());
+        server.join();
+    }
+
+    #[test]
+    fn malformed_registration_does_not_create_token() {
+        let dir = TestDir::new("malformed-registration");
+        let store = token_store(&dir);
+        let server = spawn_plain_server(|socket| {
+            let request = read_request(socket);
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "registered",
+                    "payload": {},
+                }),
+            );
+        });
+
+        let result = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+            || {},
+        );
+
+        assert!(matches!(
+            result,
+            Err(WebOsAuthenticatedClientError::Authentication {
+                source: PlatformAccessTokenAcquisitionError::Registration {
+                    source: WebOsClientRegistrationError::Protocol {
+                        source: WebOsRegistrationError::MissingClientKey,
+                    },
+                },
+            })
+        ));
+        assert!(!store.token_path().exists());
+        server.join();
+    }
+
+    #[test]
+    fn persistence_failure_does_not_return_authenticated_client() {
+        let dir = TestDir::new("persistence-failure");
+        let store = token_store(&dir);
+        let token_path = store.token_path().to_path_buf();
+        let server = spawn_plain_server(|socket| {
+            let request = read_request(socket);
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "response",
+                    "payload": {"pairingType": "PROMPT", "returnValue": true},
+                }),
+            );
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "registered",
+                    "payload": {"client-key": "unpersisted-client-key"},
+                }),
+            );
+        });
+
+        let result = WebOsClient::connect_authenticated(
+            server.endpoint,
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+            || fs::create_dir_all(&token_path).expect("block token file replacement"),
+        );
+
+        assert!(matches!(
+            result,
+            Err(WebOsAuthenticatedClientError::Authentication {
+                source: PlatformAccessTokenAcquisitionError::Store {
+                    source: PlatformAccessTokenStoreError::Io {
+                        operation: PlatformAccessTokenStoreOperation::ReplaceToken,
+                        ..
+                    },
+                },
+            })
+        ));
+        assert!(store.token_path().is_dir());
         server.join();
     }
 }

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -85,16 +85,16 @@ impl WebOsClient {
         connect_timeout: Duration,
         response_timeout: Duration,
         token_store: &PlatformAccessTokenStore,
-        mut on_pairing_prompt: F,
+        mut on_auth_event: F,
     ) -> Result<Self, WebOsAuthenticatedClientError>
     where
-        F: FnMut(),
+        F: FnMut(WebOsAuthenticationEvent),
     {
         let mut client = Self::connect(endpoint, connect_timeout, response_timeout)
             .map_err(|source| WebOsAuthenticatedClientError::Connect { source })?;
-        let mut registration = client.registration(&mut on_pairing_prompt);
+        let mut registration = client.registration();
         token_store
-            .get_or_acquire(&mut registration)
+            .get_or_acquire(&mut registration, &mut on_auth_event)
             .map_err(|source| WebOsAuthenticatedClientError::Authentication { source })?;
 
         Ok(client)
@@ -144,14 +144,8 @@ impl WebOsClient {
         })
     }
 
-    fn registration<'client, 'prompt>(
-        &'client mut self,
-        on_pairing_prompt: &'prompt mut dyn FnMut(),
-    ) -> WebOsClientRegistration<'client, 'prompt> {
-        WebOsClientRegistration {
-            client: self,
-            on_pairing_prompt,
-        }
+    fn registration(&mut self) -> WebOsClientRegistration<'_> {
+        WebOsClientRegistration { client: self }
     }
 
     pub(crate) fn send_request(
@@ -255,16 +249,26 @@ impl WebOsClient {
     }
 }
 
-pub(crate) struct WebOsClientRegistration<'client, 'prompt> {
-    client: &'client mut WebOsClient,
-    on_pairing_prompt: &'prompt mut dyn FnMut(),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebOsAuthenticationEvent {
+    UsingStoredAccessToken,
+    PairingPrompt,
+    AccessTokenPersisted,
 }
 
-impl WebOsClientRegistration<'_, '_> {
-    pub(crate) fn register(
+pub(crate) struct WebOsClientRegistration<'client> {
+    client: &'client mut WebOsClient,
+}
+
+impl WebOsClientRegistration<'_> {
+    pub(crate) fn register<F>(
         &mut self,
         access_token: Option<&PlatformAccessToken>,
-    ) -> Result<PlatformAccessToken, WebOsClientRegistrationError> {
+        on_auth_event: &mut F,
+    ) -> Result<PlatformAccessToken, WebOsClientRegistrationError>
+    where
+        F: FnMut(WebOsAuthenticationEvent),
+    {
         let request_id = self
             .client
             .next_request_id()
@@ -291,7 +295,9 @@ impl WebOsClientRegistration<'_, '_> {
                 WebOsRegistrationEvent::PairingPrompt if access_token.is_some() => {
                     return Err(WebOsClientRegistrationError::StoredTokenRequiresPairing)
                 }
-                WebOsRegistrationEvent::PairingPrompt => (self.on_pairing_prompt)(),
+                WebOsRegistrationEvent::PairingPrompt => {
+                    on_auth_event(WebOsAuthenticationEvent::PairingPrompt)
+                }
                 WebOsRegistrationEvent::Registered { access_token } => return Ok(access_token),
             }
         }
@@ -565,8 +571,8 @@ fn parse_webos_error(message: &serde_json::Map<String, Value>) -> WebOsClientErr
 #[cfg(test)]
 mod tests {
     use super::{
-        WebOsAuthenticatedClientError, WebOsClient, WebOsClientError, WebOsClientRegistrationError,
-        WebOsEndpoint,
+        WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsClientError,
+        WebOsClientRegistrationError, WebOsEndpoint,
     };
     use crate::auth::SystemUser;
     use crate::platform_access_token::{
@@ -905,18 +911,21 @@ mod tests {
                 }),
             );
         });
-        let mut prompted = false;
+        let mut events = Vec::new();
 
         let _client = WebOsClient::connect_authenticated(
             server.endpoint,
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
-            || prompted = true,
+            |event| events.push(event),
         )
         .expect("authenticate with stored token");
 
-        assert!(!prompted);
+        assert_eq!(
+            events,
+            vec![WebOsAuthenticationEvent::UsingStoredAccessToken]
+        );
         assert_eq!(store.load().expect("reload stored token"), Some(original));
         server.join();
     }
@@ -946,18 +955,24 @@ mod tests {
                 }),
             );
         });
-        let mut prompt_count = 0;
+        let mut events = Vec::new();
 
         let _client = WebOsClient::connect_authenticated(
             server.endpoint,
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
-            || prompt_count += 1,
+            |event| events.push(event),
         )
         .expect("pair and authenticate client");
 
-        assert_eq!(prompt_count, 1);
+        assert_eq!(
+            events,
+            vec![
+                WebOsAuthenticationEvent::PairingPrompt,
+                WebOsAuthenticationEvent::AccessTokenPersisted,
+            ]
+        );
         assert_eq!(
             store.load().expect("load acquired token"),
             Some(token("new-client-key"))
@@ -982,14 +997,14 @@ mod tests {
                 }),
             );
         });
-        let mut prompted = false;
+        let mut events = Vec::new();
 
         let result = WebOsClient::connect_authenticated(
             server.endpoint,
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
-            || prompted = true,
+            |event| events.push(event),
         );
 
         assert!(matches!(
@@ -1000,7 +1015,10 @@ mod tests {
                 },
             })
         ));
-        assert!(!prompted);
+        assert_eq!(
+            events,
+            vec![WebOsAuthenticationEvent::UsingStoredAccessToken]
+        );
         assert_eq!(store.load().expect("reload stored token"), Some(original));
         server.join();
     }
@@ -1026,7 +1044,7 @@ mod tests {
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
-            || {},
+            |_| {},
         );
 
         assert!(matches!(
@@ -1059,7 +1077,7 @@ mod tests {
             CONNECT_TIMEOUT,
             Duration::from_millis(40),
             &store,
-            || {},
+            |_| {},
         );
 
         assert!(matches!(
@@ -1097,7 +1115,7 @@ mod tests {
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
-            || {},
+            |_| {},
         );
 
         assert!(matches!(
@@ -1144,7 +1162,11 @@ mod tests {
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
-            || fs::create_dir_all(&token_path).expect("block token file replacement"),
+            |event| {
+                if event == WebOsAuthenticationEvent::PairingPrompt {
+                    fs::create_dir_all(&token_path).expect("block token file replacement");
+                }
+            },
         );
 
         assert!(matches!(
@@ -1207,7 +1229,7 @@ mod tests {
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
-            || panic!("stored token should not prompt"),
+            |event| assert_eq!(event, WebOsAuthenticationEvent::UsingStoredAccessToken),
         )
         .expect("authenticate power-state client");
 
@@ -1251,7 +1273,7 @@ mod tests {
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
-            || panic!("stored token should not prompt"),
+            |event| assert_eq!(event, WebOsAuthenticationEvent::UsingStoredAccessToken),
         )
         .expect("authenticate power-state client");
 

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -1,0 +1,662 @@
+use super::tls::webos_tv_self_signed_client_config;
+use serde_json::{json, Value};
+use std::error::Error;
+use std::fmt;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::time::{Duration, Instant};
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{client_tls_with_config, Connector, HandshakeError, Message, WebSocket};
+
+const WEBOS_WS_PORT: u16 = 3000;
+const WEBOS_WSS_PORT: u16 = 3001;
+
+type WebOsSocket = WebSocket<MaybeTlsStream<TcpStream>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WebOsTransport {
+    Ws,
+    Wss,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WebOsEndpoint {
+    address: SocketAddr,
+    transport: WebOsTransport,
+}
+
+impl WebOsEndpoint {
+    pub fn ws(ip: Ipv4Addr) -> Self {
+        Self::ws_at(SocketAddr::new(IpAddr::V4(ip), WEBOS_WS_PORT))
+    }
+
+    /// Uses encrypted WSS while accepting the TV's self-signed certificate.
+    /// This protects traffic from passive observation but does not establish
+    /// the TV's identity through a trusted certificate authority.
+    pub fn wss(ip: Ipv4Addr) -> Self {
+        Self::wss_at(SocketAddr::new(IpAddr::V4(ip), WEBOS_WSS_PORT))
+    }
+
+    fn ws_at(address: SocketAddr) -> Self {
+        Self {
+            address,
+            transport: WebOsTransport::Ws,
+        }
+    }
+
+    fn wss_at(address: SocketAddr) -> Self {
+        Self {
+            address,
+            transport: WebOsTransport::Wss,
+        }
+    }
+
+    fn url(self) -> String {
+        let scheme = match self.transport {
+            WebOsTransport::Ws => "ws",
+            WebOsTransport::Wss => "wss",
+        };
+        format!("{scheme}://{}/", self.address)
+    }
+}
+
+impl fmt::Display for WebOsEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.url())
+    }
+}
+
+pub struct WebOsClient {
+    socket: WebOsSocket,
+    next_request_sequence: u64,
+    response_timeout: Duration,
+}
+
+impl WebOsClient {
+    pub fn connect(
+        endpoint: WebOsEndpoint,
+        connect_timeout: Duration,
+        response_timeout: Duration,
+    ) -> Result<Self, WebOsClientError> {
+        if connect_timeout.is_zero() {
+            return Err(WebOsClientError::InvalidTimeout { name: "connect" });
+        }
+        if response_timeout.is_zero() {
+            return Err(WebOsClientError::InvalidTimeout { name: "response" });
+        }
+
+        let stream = TcpStream::connect_timeout(&endpoint.address, connect_timeout)
+            .map_err(|source| WebOsClientError::Connect { endpoint, source })?;
+        stream
+            .set_nodelay(true)
+            .and_then(|_| stream.set_read_timeout(Some(connect_timeout)))
+            .and_then(|_| stream.set_write_timeout(Some(connect_timeout)))
+            .map_err(|source| WebOsClientError::ConfigureSocket { source })?;
+
+        let connector = match endpoint.transport {
+            WebOsTransport::Ws => Connector::Plain,
+            WebOsTransport::Wss => Connector::Rustls(webos_tv_self_signed_client_config()),
+        };
+        let (mut socket, _) =
+            match client_tls_with_config(endpoint.url(), stream, None, Some(connector)) {
+                Ok(connected) => connected,
+                Err(HandshakeError::Failure(source)) => {
+                    return Err(WebOsClientError::Handshake { source })
+                }
+                Err(HandshakeError::Interrupted(_)) => {
+                    return Err(WebOsClientError::HandshakeInterrupted)
+                }
+            };
+        set_read_timeout(&mut socket, response_timeout)
+            .map_err(|source| WebOsClientError::ConfigureSocket { source })?;
+
+        Ok(Self {
+            socket,
+            next_request_sequence: 0,
+            response_timeout,
+        })
+    }
+
+    pub fn send_request(&mut self, uri: &str, payload: Value) -> Result<Value, WebOsClientError> {
+        let request_id = self.next_request_id()?;
+        let request = json!({
+            "id": request_id,
+            "type": "request",
+            "uri": uri,
+            "payload": payload,
+        });
+
+        self.exchange(&request_id, request)
+    }
+
+    fn next_request_id(&mut self) -> Result<String, WebOsClientError> {
+        let sequence = self.next_request_sequence;
+        self.next_request_sequence = sequence
+            .checked_add(1)
+            .ok_or(WebOsClientError::RequestIdExhausted)?;
+        Ok(format!("request_{sequence}"))
+    }
+
+    fn exchange(&mut self, request_id: &str, request: Value) -> Result<Value, WebOsClientError> {
+        self.socket
+            .send(Message::text(request.to_string()))
+            .map_err(|source| WebOsClientError::Send { source })?;
+
+        let deadline = Instant::now()
+            .checked_add(self.response_timeout)
+            .ok_or(WebOsClientError::InvalidTimeout { name: "response" })?;
+
+        loop {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(|| WebOsClientError::Timeout {
+                    request_id: request_id.to_string(),
+                })?;
+            if remaining.is_zero() {
+                return Err(WebOsClientError::Timeout {
+                    request_id: request_id.to_string(),
+                });
+            }
+            set_read_timeout(&mut self.socket, remaining)
+                .map_err(|source| WebOsClientError::ConfigureSocket { source })?;
+
+            let message = match self.socket.read() {
+                Ok(message) => message,
+                Err(tungstenite::Error::Io(source))
+                    if matches!(
+                        source.kind(),
+                        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    return Err(WebOsClientError::Timeout {
+                        request_id: request_id.to_string(),
+                    })
+                }
+                Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
+                    return Err(WebOsClientError::ConnectionClosed {
+                        request_id: request_id.to_string(),
+                    })
+                }
+                Err(source) => return Err(WebOsClientError::Receive { source }),
+            };
+
+            match message {
+                Message::Text(text) => {
+                    if let Some(response) = parse_correlated_frame(request_id, text.as_str())? {
+                        return Ok(response);
+                    }
+                }
+                Message::Ping(_) | Message::Pong(_) => {}
+                Message::Close(_) => {
+                    return Err(WebOsClientError::ConnectionClosed {
+                        request_id: request_id.to_string(),
+                    })
+                }
+                Message::Binary(_) => return Err(WebOsClientError::UnexpectedBinaryFrame),
+                Message::Frame(_) => return Err(WebOsClientError::UnexpectedRawFrame),
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum WebOsClientError {
+    InvalidTimeout {
+        name: &'static str,
+    },
+    Connect {
+        endpoint: WebOsEndpoint,
+        source: io::Error,
+    },
+    ConfigureSocket {
+        source: io::Error,
+    },
+    Handshake {
+        source: tungstenite::Error,
+    },
+    HandshakeInterrupted,
+    RequestIdExhausted,
+    Send {
+        source: tungstenite::Error,
+    },
+    Timeout {
+        request_id: String,
+    },
+    ConnectionClosed {
+        request_id: String,
+    },
+    Receive {
+        source: tungstenite::Error,
+    },
+    MalformedJson {
+        source: serde_json::Error,
+    },
+    InvalidFrameRoot,
+    MissingResponseId,
+    InvalidResponseId,
+    MissingMessageType,
+    InvalidMessageType,
+    MissingWebOsErrorMessage,
+    InvalidWebOsErrorMessage,
+    WebOs {
+        code: Option<i32>,
+        message: String,
+    },
+    UnexpectedBinaryFrame,
+    UnexpectedRawFrame,
+}
+
+impl fmt::Display for WebOsClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidTimeout { name } => {
+                write!(f, "webOS {name} timeout must be greater than zero")
+            }
+            Self::Connect { endpoint, source } => {
+                write!(
+                    f,
+                    "could not connect to webOS endpoint `{endpoint}`: {source}"
+                )
+            }
+            Self::ConfigureSocket { source } => {
+                write!(f, "could not configure webOS socket: {source}")
+            }
+            Self::Handshake { source } => write!(f, "webOS websocket handshake failed: {source}"),
+            Self::HandshakeInterrupted => {
+                write!(f, "webOS websocket handshake was interrupted")
+            }
+            Self::RequestIdExhausted => write!(f, "webOS request ID sequence is exhausted"),
+            Self::Send { source } => write!(f, "could not send webOS request: {source}"),
+            Self::Timeout { request_id } => {
+                write!(f, "timed out waiting for webOS response `{request_id}`")
+            }
+            Self::ConnectionClosed { request_id } => write!(
+                f,
+                "webOS connection closed before response `{request_id}` arrived"
+            ),
+            Self::Receive { source } => write!(f, "could not receive webOS response: {source}"),
+            Self::MalformedJson { source } => {
+                write!(f, "webOS response is malformed JSON: {source}")
+            }
+            Self::InvalidFrameRoot => write!(f, "webOS response root is not an object"),
+            Self::MissingResponseId => write!(f, "webOS response has no request ID"),
+            Self::InvalidResponseId => write!(f, "webOS response request ID is not a string"),
+            Self::MissingMessageType => write!(f, "webOS response has no message type"),
+            Self::InvalidMessageType => write!(f, "webOS response message type is not a string"),
+            Self::MissingWebOsErrorMessage => {
+                write!(f, "webOS error response has no error message")
+            }
+            Self::InvalidWebOsErrorMessage => {
+                write!(f, "webOS error response message is not a string")
+            }
+            Self::WebOs {
+                code: Some(code),
+                message,
+            } => write!(f, "webOS error {code}: {message}"),
+            Self::WebOs {
+                code: None,
+                message,
+            } => write!(f, "webOS error: {message}"),
+            Self::UnexpectedBinaryFrame => write!(f, "webOS sent an unexpected binary frame"),
+            Self::UnexpectedRawFrame => write!(f, "webOS sent an unexpected raw frame"),
+        }
+    }
+}
+
+impl Error for WebOsClientError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Connect { source, .. } | Self::ConfigureSocket { source } => Some(source),
+            Self::Handshake { source } | Self::Send { source } | Self::Receive { source } => {
+                Some(source)
+            }
+            Self::MalformedJson { source } => Some(source),
+            Self::InvalidTimeout { .. }
+            | Self::HandshakeInterrupted
+            | Self::RequestIdExhausted
+            | Self::Timeout { .. }
+            | Self::ConnectionClosed { .. }
+            | Self::InvalidFrameRoot
+            | Self::MissingResponseId
+            | Self::InvalidResponseId
+            | Self::MissingMessageType
+            | Self::InvalidMessageType
+            | Self::MissingWebOsErrorMessage
+            | Self::InvalidWebOsErrorMessage
+            | Self::WebOs { .. }
+            | Self::UnexpectedBinaryFrame
+            | Self::UnexpectedRawFrame => None,
+        }
+    }
+}
+
+fn set_read_timeout(socket: &mut WebOsSocket, timeout: Duration) -> io::Result<()> {
+    let stream = match socket.get_mut() {
+        MaybeTlsStream::Plain(stream) => stream,
+        MaybeTlsStream::Rustls(stream) => &mut stream.sock,
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "unsupported webOS TLS stream",
+            ))
+        }
+    };
+    stream.set_read_timeout(Some(timeout))
+}
+
+fn parse_correlated_frame(
+    expected_request_id: &str,
+    raw_message: &str,
+) -> Result<Option<Value>, WebOsClientError> {
+    let message: Value = serde_json::from_str(raw_message)
+        .map_err(|source| WebOsClientError::MalformedJson { source })?;
+    let object = message
+        .as_object()
+        .ok_or(WebOsClientError::InvalidFrameRoot)?;
+    let actual_request_id = match object.get("id") {
+        Some(Value::String(request_id)) => request_id,
+        Some(_) => return Err(WebOsClientError::InvalidResponseId),
+        None => return Err(WebOsClientError::MissingResponseId),
+    };
+    if actual_request_id != expected_request_id {
+        return Ok(None);
+    }
+
+    let message_type = match object.get("type") {
+        Some(Value::String(message_type)) => message_type,
+        Some(_) => return Err(WebOsClientError::InvalidMessageType),
+        None => return Err(WebOsClientError::MissingMessageType),
+    };
+    if message_type == "error" {
+        return Err(parse_webos_error(object));
+    }
+
+    Ok(Some(message))
+}
+
+fn parse_webos_error(message: &serde_json::Map<String, Value>) -> WebOsClientError {
+    let error = match message.get("error") {
+        Some(Value::String(error)) => error,
+        Some(_) => return WebOsClientError::InvalidWebOsErrorMessage,
+        None => return WebOsClientError::MissingWebOsErrorMessage,
+    };
+    let mut parts = error.splitn(2, char::is_whitespace);
+    let first = parts.next().unwrap_or_default();
+    let (code, message) = match first.parse::<i32>() {
+        Ok(code) => (
+            Some(code),
+            parts.next().unwrap_or_default().trim().to_string(),
+        ),
+        Err(_) => (None, error.to_string()),
+    };
+    WebOsClientError::WebOs { code, message }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WebOsClient, WebOsClientError, WebOsEndpoint};
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use rustls::crypto::ring;
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+    use rustls::{ServerConfig, ServerConnection, StreamOwned};
+    use serde_json::{json, Value};
+    use std::io;
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::thread::{self, JoinHandle};
+    use std::time::Duration;
+    use tungstenite::{accept, Message, WebSocket};
+
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+    const RESPONSE_TIMEOUT: Duration = Duration::from_millis(200);
+    const TEST_CERTIFICATE_DER: &str = "MIIBkzCCATmgAwIBAgIUGCxGaL477t4FECFewoE+24e3aWQwCgYIKoZIzj0EAwIwHjEcMBoGA1UEAwwTTEcgQnVkZHkgRDMgVGVzdCBUVjAgFw0yNjA3MTEyMDUyMzBaGA8yMTI2MDYxNzIwNTIzMFowHjEcMBoGA1UEAwwTTEcgQnVkZHkgRDMgVGVzdCBUVjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABE8Q+pVxjrGZr5oQfOCxyA7rl7PVzI9U7ukGEp3PI7r8dWDlmcrT5GdNVXIhjza7yi9YRRjw66NaWAlQsd1zxZWjUzBRMB0GA1UdDgQWBBQmbnb3C0PKQVuvqb8oT0Ur6tZLkzAfBgNVHSMEGDAWgBQmbnb3C0PKQVuvqb8oT0Ur6tZLkzAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQDTL/fP5PjETr2XgdN9cBuSkMR8DD0ohRjvya0dfXhM4gIgKe13t3ClUgKULtYbtIa3mwcSCwSsAEfoRsZG5zFiCc8=";
+    const TEST_PRIVATE_KEY_DER: &str = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgRQOBcIAKtXbi9IkKmq6PBMKSMlLega0uR6twK6hSmYmhRANCAARPEPqVcY6xma+aEHzgscgO65ez1cyPVO7pBhKdzyO6/HVg5ZnK0+RnTVVyIY82u8ovWEUY8OujWlgJULHdc8WV";
+
+    struct ScriptedServer {
+        endpoint: WebOsEndpoint,
+        handle: JoinHandle<()>,
+    }
+
+    impl ScriptedServer {
+        fn join(self) {
+            self.handle.join().expect("scripted server thread");
+        }
+    }
+
+    fn spawn_plain_server<F>(script: F) -> ScriptedServer
+    where
+        F: FnOnce(&mut WebSocket<TcpStream>) + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind scripted server");
+        let endpoint = WebOsEndpoint::ws_at(listener.local_addr().expect("server address"));
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept client");
+            let mut socket = accept(stream).expect("accept websocket");
+            script(&mut socket);
+        });
+        ScriptedServer { endpoint, handle }
+    }
+
+    fn spawn_tls_server<F>(script: F) -> ScriptedServer
+    where
+        F: FnOnce(&mut WebSocket<StreamOwned<ServerConnection, TcpStream>>) + Send + 'static,
+    {
+        let certificate = CertificateDer::from(
+            STANDARD
+                .decode(TEST_CERTIFICATE_DER)
+                .expect("decode test certificate"),
+        );
+        let private_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+            STANDARD
+                .decode(TEST_PRIVATE_KEY_DER)
+                .expect("decode test private key"),
+        ));
+        let provider = Arc::new(ring::default_provider());
+        let config = ServerConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .expect("ring supports default TLS versions")
+            .with_no_client_auth()
+            .with_single_cert(vec![certificate], private_key)
+            .expect("build test TLS config");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind scripted TLS server");
+        let endpoint = WebOsEndpoint::wss_at(listener.local_addr().expect("server address"));
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept TLS client");
+            let connection =
+                ServerConnection::new(Arc::new(config)).expect("create TLS connection");
+            let stream = StreamOwned::new(connection, stream);
+            let mut socket = accept(stream).expect("accept secure websocket");
+            script(&mut socket);
+        });
+        ScriptedServer { endpoint, handle }
+    }
+
+    fn read_request<S: io::Read + io::Write>(socket: &mut WebSocket<S>) -> Value {
+        match socket.read().expect("read client request") {
+            Message::Text(text) => serde_json::from_str(text.as_str()).expect("request JSON"),
+            other => panic!("expected text request, got {other:?}"),
+        }
+    }
+
+    fn send_json<S: io::Read + io::Write>(socket: &mut WebSocket<S>, value: Value) {
+        socket
+            .send(Message::text(value.to_string()))
+            .expect("send scripted response");
+    }
+
+    #[test]
+    fn requests_use_stable_ids_and_return_the_matching_response() {
+        let server = spawn_plain_server(|socket| {
+            for sequence in 0..2 {
+                let request = read_request(socket);
+                let request_id = format!("request_{sequence}");
+                assert_eq!(request["id"], request_id);
+                assert_eq!(request["type"], "request");
+                assert_eq!(request["uri"], format!("ssap://test/{sequence}"));
+                send_json(
+                    socket,
+                    json!({
+                        "id": request_id,
+                        "type": "response",
+                        "payload": {"sequence": sequence},
+                    }),
+                );
+            }
+        });
+        let mut client = WebOsClient::connect(server.endpoint, CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
+            .expect("connect client");
+
+        for sequence in 0..2 {
+            let response = client
+                .send_request(&format!("ssap://test/{sequence}"), json!({}))
+                .expect("matching response");
+            assert_eq!(response["payload"]["sequence"], sequence);
+        }
+        server.join();
+    }
+
+    #[test]
+    fn unrelated_frame_is_ignored_before_matching_response() {
+        let server = spawn_plain_server(|socket| {
+            let request = read_request(socket);
+            let request_id = request["id"].as_str().expect("request ID");
+            send_json(
+                socket,
+                json!({"id": "subscription_0", "type": "response", "payload": {}}),
+            );
+            send_json(
+                socket,
+                json!({"id": request_id, "type": "response", "payload": {"ok": true}}),
+            );
+        });
+        let mut client = WebOsClient::connect(server.endpoint, CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
+            .expect("connect client");
+
+        let response = client
+            .send_request("ssap://test/correlated", json!({}))
+            .expect("matching response");
+        assert_eq!(response["payload"]["ok"], true);
+        server.join();
+    }
+
+    #[test]
+    fn wrong_response_id_is_not_accepted_and_deadline_is_absolute() {
+        let server = spawn_plain_server(|socket| {
+            let _request = read_request(socket);
+            send_json(
+                socket,
+                json!({"id": "wrong", "type": "response", "payload": {"ok": true}}),
+            );
+            thread::sleep(Duration::from_millis(150));
+        });
+        let mut client =
+            WebOsClient::connect(server.endpoint, CONNECT_TIMEOUT, Duration::from_millis(40))
+                .expect("connect client");
+
+        assert!(matches!(
+            client.send_request("ssap://test/wrong-id", json!({})),
+            Err(WebOsClientError::Timeout { request_id }) if request_id == "request_0"
+        ));
+        server.join();
+    }
+
+    #[test]
+    fn close_before_matching_response_is_typed() {
+        let server = spawn_plain_server(|socket| {
+            let _request = read_request(socket);
+            socket.send(Message::Close(None)).expect("send close");
+        });
+        let mut client = WebOsClient::connect(server.endpoint, CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
+            .expect("connect client");
+
+        assert!(matches!(
+            client.send_request("ssap://test/close", json!({})),
+            Err(WebOsClientError::ConnectionClosed { request_id })
+                if request_id == "request_0"
+        ));
+        server.join();
+    }
+
+    #[test]
+    fn malformed_text_frame_is_typed() {
+        let server = spawn_plain_server(|socket| {
+            let _request = read_request(socket);
+            socket
+                .send(Message::text("not-json"))
+                .expect("send malformed response");
+        });
+        let mut client = WebOsClient::connect(server.endpoint, CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
+            .expect("connect client");
+
+        assert!(matches!(
+            client.send_request("ssap://test/malformed", json!({})),
+            Err(WebOsClientError::MalformedJson { .. })
+        ));
+        server.join();
+    }
+
+    #[test]
+    fn webos_error_preserves_code_and_message() {
+        let server = spawn_plain_server(|socket| {
+            let request = read_request(socket);
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "error",
+                    "error": "-401 not permitted",
+                }),
+            );
+        });
+        let mut client = WebOsClient::connect(server.endpoint, CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
+            .expect("connect client");
+
+        assert!(matches!(
+            client.send_request("ssap://test/error", json!({})),
+            Err(WebOsClientError::WebOs {
+                code: Some(-401),
+                message,
+            }) if message == "not permitted"
+        ));
+        server.join();
+    }
+
+    #[test]
+    fn connection_failure_is_typed() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve address");
+        let endpoint = WebOsEndpoint::ws_at(listener.local_addr().expect("reserved address"));
+        drop(listener);
+
+        assert!(matches!(
+            WebOsClient::connect(endpoint, CONNECT_TIMEOUT, RESPONSE_TIMEOUT),
+            Err(WebOsClientError::Connect {
+                endpoint: failed_endpoint,
+                ..
+            }) if failed_endpoint == endpoint
+        ));
+    }
+
+    #[test]
+    fn wss_accepts_self_signed_tv_certificate() {
+        let server = spawn_tls_server(|socket| {
+            let request = read_request(socket);
+            send_json(
+                socket,
+                json!({
+                    "id": request["id"],
+                    "type": "response",
+                    "payload": {"encrypted": true},
+                }),
+            );
+        });
+        let mut client = WebOsClient::connect(server.endpoint, CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
+            .expect("connect secure client");
+
+        let response = client
+            .send_request("ssap://test/wss", json!({}))
+            .expect("secure response");
+        assert_eq!(response["payload"]["encrypted"], true);
+        server.join();
+    }
+}

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -1,0 +1,8 @@
+//! Native LG webOS protocol support.
+
+mod registration;
+
+pub use registration::{
+    parse_registration_message, WebOsRegistrationError, WebOsRegistrationEvent,
+    WebOsRegistrationRequest,
+};

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -7,8 +7,8 @@ mod tls;
 
 pub(crate) use client::WebOsClientRegistration;
 pub use client::{
-    WebOsAuthenticatedClientError, WebOsClient, WebOsClientError, WebOsClientRegistrationError,
-    WebOsEndpoint,
+    WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsClientError,
+    WebOsClientRegistrationError, WebOsEndpoint,
 };
 pub use power::{WebOsPowerState, WebOsPowerStateError};
 

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -1,6 +1,7 @@
 //! Native LG webOS protocol support.
 
 mod client;
+mod power;
 mod registration;
 mod tls;
 
@@ -9,6 +10,7 @@ pub use client::{
     WebOsAuthenticatedClientError, WebOsClient, WebOsClientError, WebOsClientRegistrationError,
     WebOsEndpoint,
 };
+pub use power::{WebOsPowerState, WebOsPowerStateError};
 
 pub use registration::{
     parse_registration_message, WebOsRegistrationError, WebOsRegistrationEvent,

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -1,6 +1,10 @@
 //! Native LG webOS protocol support.
 
+mod client;
 mod registration;
+mod tls;
+
+pub use client::{WebOsClient, WebOsClientError, WebOsEndpoint};
 
 pub use registration::{
     parse_registration_message, WebOsRegistrationError, WebOsRegistrationEvent,

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -4,7 +4,11 @@ mod client;
 mod registration;
 mod tls;
 
-pub use client::{WebOsClient, WebOsClientError, WebOsEndpoint};
+pub(crate) use client::WebOsClientRegistration;
+pub use client::{
+    WebOsAuthenticatedClientError, WebOsClient, WebOsClientError, WebOsClientRegistrationError,
+    WebOsEndpoint,
+};
 
 pub use registration::{
     parse_registration_message, WebOsRegistrationError, WebOsRegistrationEvent,

--- a/crates/lg-buddy/src/web_os/power.rs
+++ b/crates/lg-buddy/src/web_os/power.rs
@@ -1,0 +1,238 @@
+use super::{WebOsClient, WebOsClientError};
+use serde_json::{json, Value};
+use std::error::Error;
+use std::fmt;
+
+const GET_POWER_STATE_URI: &str = "ssap://com.webos.service.tvpower/power/getPowerState";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WebOsPowerState {
+    Active,
+    ActiveStandby,
+    ScreenOff,
+    Suspend,
+    PowerOff,
+    Unknown,
+    Other(String),
+}
+
+impl WebOsPowerState {
+    fn from_wire_value(value: String) -> Self {
+        match value.as_str() {
+            "Active" => Self::Active,
+            "Active Standby" => Self::ActiveStandby,
+            "Screen Off" => Self::ScreenOff,
+            "Suspend" => Self::Suspend,
+            "Power Off" => Self::PowerOff,
+            "Unknown" => Self::Unknown,
+            _ => Self::Other(value),
+        }
+    }
+}
+
+impl fmt::Display for WebOsPowerState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Active => "Active",
+            Self::ActiveStandby => "Active Standby",
+            Self::ScreenOff => "Screen Off",
+            Self::Suspend => "Suspend",
+            Self::PowerOff => "Power Off",
+            Self::Unknown => "Unknown",
+            Self::Other(value) => value,
+        };
+        write!(f, "{value}")
+    }
+}
+
+#[derive(Debug)]
+pub enum WebOsPowerStateError {
+    Request { source: WebOsClientError },
+    MissingPayload,
+    InvalidPayload,
+    MissingReturnValue,
+    InvalidReturnValue,
+    RequestRejected { message: Option<String> },
+    MissingState,
+    InvalidState,
+    EmptyState,
+}
+
+impl fmt::Display for WebOsPowerStateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request { source } => write!(f, "could not read webOS power state: {source}"),
+            Self::MissingPayload => write!(f, "webOS power-state response has no payload"),
+            Self::InvalidPayload => {
+                write!(f, "webOS power-state response payload is not an object")
+            }
+            Self::MissingReturnValue => {
+                write!(f, "webOS power-state response has no return value")
+            }
+            Self::InvalidReturnValue => {
+                write!(
+                    f,
+                    "webOS power-state response return value is not a boolean"
+                )
+            }
+            Self::RequestRejected {
+                message: Some(message),
+            } => write!(f, "webOS power-state request was rejected: {message}"),
+            Self::RequestRejected { message: None } => {
+                write!(f, "webOS power-state request was rejected")
+            }
+            Self::MissingState => write!(f, "webOS power-state response has no state"),
+            Self::InvalidState => write!(f, "webOS power-state response state is not a string"),
+            Self::EmptyState => write!(f, "webOS power-state response state is empty"),
+        }
+    }
+}
+
+impl Error for WebOsPowerStateError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Request { source } => Some(source),
+            Self::MissingPayload
+            | Self::InvalidPayload
+            | Self::MissingReturnValue
+            | Self::InvalidReturnValue
+            | Self::RequestRejected { .. }
+            | Self::MissingState
+            | Self::InvalidState
+            | Self::EmptyState => None,
+        }
+    }
+}
+
+impl WebOsClient {
+    pub fn power_state(&mut self) -> Result<WebOsPowerState, WebOsPowerStateError> {
+        let response = self
+            .send_request(GET_POWER_STATE_URI, json!({}))
+            .map_err(|source| WebOsPowerStateError::Request { source })?;
+        parse_power_state_response(&response)
+    }
+}
+
+fn parse_power_state_response(response: &Value) -> Result<WebOsPowerState, WebOsPowerStateError> {
+    let payload = match response.get("payload") {
+        Some(Value::Object(payload)) => payload,
+        Some(_) => return Err(WebOsPowerStateError::InvalidPayload),
+        None => return Err(WebOsPowerStateError::MissingPayload),
+    };
+
+    match payload.get("returnValue") {
+        Some(Value::Bool(true)) => {}
+        Some(Value::Bool(false)) => {
+            let message = payload
+                .get("errorText")
+                .or_else(|| payload.get("error"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            return Err(WebOsPowerStateError::RequestRejected { message });
+        }
+        Some(_) => return Err(WebOsPowerStateError::InvalidReturnValue),
+        None => return Err(WebOsPowerStateError::MissingReturnValue),
+    }
+
+    let state = match payload.get("state") {
+        Some(Value::String(state)) if state.trim().is_empty() => {
+            return Err(WebOsPowerStateError::EmptyState)
+        }
+        Some(Value::String(state)) => state.clone(),
+        Some(_) => return Err(WebOsPowerStateError::InvalidState),
+        None => return Err(WebOsPowerStateError::MissingState),
+    };
+
+    Ok(WebOsPowerState::from_wire_value(state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_power_state_response, WebOsPowerState, WebOsPowerStateError};
+    use serde_json::json;
+
+    #[test]
+    fn active_and_standby_states_parse_to_typed_values() {
+        let cases = [
+            ("Active", WebOsPowerState::Active),
+            ("Active Standby", WebOsPowerState::ActiveStandby),
+            ("Screen Off", WebOsPowerState::ScreenOff),
+            ("Suspend", WebOsPowerState::Suspend),
+        ];
+
+        for (wire_value, expected) in cases {
+            let response = json!({
+                "payload": {"returnValue": true, "state": wire_value},
+            });
+            let actual = parse_power_state_response(&response).expect("valid power state");
+            assert_eq!(actual, expected);
+            assert_eq!(actual.to_string(), wire_value);
+        }
+    }
+
+    #[test]
+    fn unknown_future_state_is_preserved() {
+        let response = json!({
+            "payload": {"returnValue": true, "state": "Eco Standby"},
+        });
+
+        assert_eq!(
+            parse_power_state_response(&response).expect("forward-compatible power state"),
+            WebOsPowerState::Other("Eco Standby".to_string())
+        );
+    }
+
+    #[test]
+    fn malformed_power_state_payloads_are_typed_errors() {
+        let cases = [
+            (json!({}), "missing-payload"),
+            (json!({"payload": []}), "invalid-payload"),
+            (json!({"payload": {"state": "Active"}}), "missing-return"),
+            (
+                json!({"payload": {"returnValue": "yes", "state": "Active"}}),
+                "invalid-return",
+            ),
+            (json!({"payload": {"returnValue": true}}), "missing-state"),
+            (
+                json!({"payload": {"returnValue": true, "state": 7}}),
+                "invalid-state",
+            ),
+            (
+                json!({"payload": {"returnValue": true, "state": " "}}),
+                "empty-state",
+            ),
+        ];
+
+        for (response, expected) in cases {
+            let error = parse_power_state_response(&response)
+                .expect_err("malformed power-state payload should fail");
+            assert!(
+                matches!(
+                    (&error, expected),
+                    (WebOsPowerStateError::MissingPayload, "missing-payload")
+                        | (WebOsPowerStateError::InvalidPayload, "invalid-payload")
+                        | (WebOsPowerStateError::MissingReturnValue, "missing-return")
+                        | (WebOsPowerStateError::InvalidReturnValue, "invalid-return")
+                        | (WebOsPowerStateError::MissingState, "missing-state")
+                        | (WebOsPowerStateError::InvalidState, "invalid-state")
+                        | (WebOsPowerStateError::EmptyState, "empty-state")
+                ),
+                "unexpected error for {expected}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_power_state_response_preserves_message() {
+        let response = json!({
+            "payload": {"returnValue": false, "errorText": "not available"},
+        });
+
+        assert!(matches!(
+            parse_power_state_response(&response),
+            Err(WebOsPowerStateError::RequestRejected {
+                message: Some(message),
+            }) if message == "not available"
+        ));
+    }
+}

--- a/crates/lg-buddy/src/web_os/registration.rs
+++ b/crates/lg-buddy/src/web_os/registration.rs
@@ -355,7 +355,7 @@ mod tests {
         let value = request.to_json_value();
         let expected_manifest = json!({
             "manifestVersion": 1,
-            "permissions": ["READ_POWER_STATE"],
+            "permissions": ["CONTROL_POWER", "READ_POWER_STATE"],
         });
 
         assert_eq!(value["type"], "register");

--- a/crates/lg-buddy/src/web_os/registration.rs
+++ b/crates/lg-buddy/src/web_os/registration.rs
@@ -1,0 +1,614 @@
+use crate::platform_access_token::{PlatformAccessToken, PlatformAccessTokenError};
+use serde_json::{json, Value};
+use std::error::Error;
+use std::fmt;
+use std::sync::OnceLock;
+
+const REGISTRATION_MESSAGE_TYPE: &str = "register";
+const PAIRING_PROMPT_TYPE: &str = "PROMPT";
+// Keep the dev probe grant limited to its first read-only operation. Expanding
+// permissions may invalidate stored client keys and require re-pairing.
+const REGISTRATION_MANIFEST_JSON: &str = include_str!("registration_manifest.json");
+
+static REGISTRATION_MANIFEST: OnceLock<Value> = OnceLock::new();
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct WebOsRegistrationRequest {
+    request_id: String,
+    access_token: Option<PlatformAccessToken>,
+}
+
+impl WebOsRegistrationRequest {
+    pub fn new(
+        request_id: impl Into<String>,
+        access_token: Option<&PlatformAccessToken>,
+    ) -> Result<Self, WebOsRegistrationError> {
+        let request_id = request_id.into();
+        if request_id.trim().is_empty() {
+            return Err(WebOsRegistrationError::EmptyRequestId);
+        }
+
+        Ok(Self {
+            request_id,
+            access_token: access_token.cloned(),
+        })
+    }
+
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    pub fn to_json_value(&self) -> Value {
+        let client_key = self
+            .access_token
+            .as_ref()
+            .map(PlatformAccessToken::as_secret_str);
+
+        json!({
+            "type": REGISTRATION_MESSAGE_TYPE,
+            "id": self.request_id,
+            "payload": {
+                "client-key": client_key,
+                "forcePairing": false,
+                "manifest": registration_manifest(),
+                "pairingType": PAIRING_PROMPT_TYPE,
+            },
+        })
+    }
+
+    pub fn to_json_string(&self) -> String {
+        serde_json::to_string(&self.to_json_value())
+            .expect("registration request contains only serializable JSON values")
+    }
+}
+
+impl fmt::Debug for WebOsRegistrationRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WebOsRegistrationRequest")
+            .field("request_id", &self.request_id)
+            .field("has_access_token", &self.access_token.is_some())
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WebOsRegistrationEvent {
+    PairingPrompt,
+    Registered { access_token: PlatformAccessToken },
+}
+
+#[derive(Debug)]
+pub enum WebOsRegistrationError {
+    EmptyRequestId,
+    MalformedJson(serde_json::Error),
+    InvalidRootMessage,
+    MissingRequestId,
+    InvalidRequestId,
+    UnexpectedRequestId { expected: String, actual: String },
+    MissingMessageType,
+    InvalidMessageType,
+    MissingPayload { message_type: String },
+    InvalidPayload { message_type: String },
+    UnexpectedMessageType { message_type: String },
+    UnexpectedRegistrationResponse,
+    PairingRejected { message: Option<String> },
+    MissingClientKey,
+    InvalidClientKeyType,
+    InvalidClientKey(PlatformAccessTokenError),
+    MissingWebOsErrorMessage,
+    InvalidWebOsErrorMessage,
+    WebOsError { code: Option<i32>, message: String },
+}
+
+impl fmt::Display for WebOsRegistrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyRequestId => write!(f, "webOS registration request ID cannot be empty"),
+            Self::MalformedJson(source) => {
+                write!(f, "webOS registration response is malformed JSON: {source}")
+            }
+            Self::InvalidRootMessage => {
+                write!(f, "webOS registration response root is not an object")
+            }
+            Self::MissingRequestId => write!(f, "webOS registration response has no request ID"),
+            Self::InvalidRequestId => {
+                write!(f, "webOS registration response request ID is not a string")
+            }
+            Self::UnexpectedRequestId { expected, actual } => write!(
+                f,
+                "webOS registration response ID `{actual}` does not match `{expected}`"
+            ),
+            Self::MissingMessageType => {
+                write!(f, "webOS registration response has no message type")
+            }
+            Self::InvalidMessageType => {
+                write!(
+                    f,
+                    "webOS registration response message type is not a string"
+                )
+            }
+            Self::MissingPayload { message_type } => write!(
+                f,
+                "webOS `{message_type}` registration response has no payload"
+            ),
+            Self::InvalidPayload { message_type } => write!(
+                f,
+                "webOS `{message_type}` registration response payload is not an object"
+            ),
+            Self::UnexpectedMessageType { message_type } => {
+                write!(
+                    f,
+                    "unexpected webOS registration message type `{message_type}`"
+                )
+            }
+            Self::UnexpectedRegistrationResponse => {
+                write!(f, "webOS registration response is not a pairing prompt")
+            }
+            Self::PairingRejected {
+                message: Some(message),
+            } => {
+                write!(f, "webOS pairing was rejected: {message}")
+            }
+            Self::PairingRejected { message: None } => write!(f, "webOS pairing was rejected"),
+            Self::MissingClientKey => {
+                write!(f, "webOS registered response has no client key")
+            }
+            Self::InvalidClientKeyType => {
+                write!(f, "webOS registered response client key is not a string")
+            }
+            Self::InvalidClientKey(source) => {
+                write!(
+                    f,
+                    "webOS registered response has an invalid client key: {source}"
+                )
+            }
+            Self::MissingWebOsErrorMessage => {
+                write!(f, "webOS error response has no error message")
+            }
+            Self::InvalidWebOsErrorMessage => {
+                write!(f, "webOS error response message is not a string")
+            }
+            Self::WebOsError {
+                code: Some(code),
+                message,
+            } => write!(f, "webOS registration error {code}: {message}"),
+            Self::WebOsError {
+                code: None,
+                message,
+            } => write!(f, "webOS registration error: {message}"),
+        }
+    }
+}
+
+impl Error for WebOsRegistrationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::MalformedJson(source) => Some(source),
+            Self::InvalidClientKey(source) => Some(source),
+            Self::EmptyRequestId
+            | Self::InvalidRootMessage
+            | Self::MissingRequestId
+            | Self::InvalidRequestId
+            | Self::UnexpectedRequestId { .. }
+            | Self::MissingMessageType
+            | Self::InvalidMessageType
+            | Self::MissingPayload { .. }
+            | Self::InvalidPayload { .. }
+            | Self::UnexpectedMessageType { .. }
+            | Self::UnexpectedRegistrationResponse
+            | Self::PairingRejected { .. }
+            | Self::MissingClientKey
+            | Self::InvalidClientKeyType
+            | Self::MissingWebOsErrorMessage
+            | Self::InvalidWebOsErrorMessage
+            | Self::WebOsError { .. } => None,
+        }
+    }
+}
+
+pub fn parse_registration_message(
+    expected_request_id: &str,
+    raw_message: &str,
+) -> Result<WebOsRegistrationEvent, WebOsRegistrationError> {
+    if expected_request_id.trim().is_empty() {
+        return Err(WebOsRegistrationError::EmptyRequestId);
+    }
+
+    let message: Value =
+        serde_json::from_str(raw_message).map_err(WebOsRegistrationError::MalformedJson)?;
+    let message = message
+        .as_object()
+        .ok_or(WebOsRegistrationError::InvalidRootMessage)?;
+
+    let actual_request_id = match message.get("id") {
+        Some(Value::String(request_id)) => request_id,
+        Some(_) => return Err(WebOsRegistrationError::InvalidRequestId),
+        None => return Err(WebOsRegistrationError::MissingRequestId),
+    };
+    if actual_request_id != expected_request_id {
+        return Err(WebOsRegistrationError::UnexpectedRequestId {
+            expected: expected_request_id.to_string(),
+            actual: actual_request_id.clone(),
+        });
+    }
+
+    let message_type = match message.get("type") {
+        Some(Value::String(message_type)) => message_type.as_str(),
+        Some(_) => return Err(WebOsRegistrationError::InvalidMessageType),
+        None => return Err(WebOsRegistrationError::MissingMessageType),
+    };
+
+    match message_type {
+        "response" => parse_pairing_prompt(message, message_type),
+        "registered" => parse_registered(message, message_type),
+        "error" => Err(parse_webos_error(message)),
+        other => Err(WebOsRegistrationError::UnexpectedMessageType {
+            message_type: other.to_string(),
+        }),
+    }
+}
+
+fn parse_pairing_prompt(
+    message: &serde_json::Map<String, Value>,
+    message_type: &str,
+) -> Result<WebOsRegistrationEvent, WebOsRegistrationError> {
+    let payload = required_payload(message, message_type)?;
+
+    if payload.get("returnValue").and_then(Value::as_bool) == Some(false) {
+        let rejection_message = payload
+            .get("errorText")
+            .or_else(|| payload.get("error"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        return Err(WebOsRegistrationError::PairingRejected {
+            message: rejection_message,
+        });
+    }
+
+    match payload.get("pairingType") {
+        Some(Value::String(pairing_type)) if pairing_type == PAIRING_PROMPT_TYPE => {
+            Ok(WebOsRegistrationEvent::PairingPrompt)
+        }
+        _ => Err(WebOsRegistrationError::UnexpectedRegistrationResponse),
+    }
+}
+
+fn parse_registered(
+    message: &serde_json::Map<String, Value>,
+    message_type: &str,
+) -> Result<WebOsRegistrationEvent, WebOsRegistrationError> {
+    let payload = required_payload(message, message_type)?;
+    let client_key = match payload.get("client-key") {
+        Some(Value::String(client_key)) => client_key,
+        Some(_) => return Err(WebOsRegistrationError::InvalidClientKeyType),
+        None => return Err(WebOsRegistrationError::MissingClientKey),
+    };
+    let access_token = PlatformAccessToken::new(client_key.clone())
+        .map_err(WebOsRegistrationError::InvalidClientKey)?;
+
+    Ok(WebOsRegistrationEvent::Registered { access_token })
+}
+
+fn parse_webos_error(message: &serde_json::Map<String, Value>) -> WebOsRegistrationError {
+    let error = match message.get("error") {
+        Some(Value::String(error)) => error,
+        Some(_) => return WebOsRegistrationError::InvalidWebOsErrorMessage,
+        None => return WebOsRegistrationError::MissingWebOsErrorMessage,
+    };
+    let (code, message) = split_webos_error(error);
+    WebOsRegistrationError::WebOsError { code, message }
+}
+
+fn required_payload<'a>(
+    message: &'a serde_json::Map<String, Value>,
+    message_type: &str,
+) -> Result<&'a serde_json::Map<String, Value>, WebOsRegistrationError> {
+    match message.get("payload") {
+        Some(Value::Object(payload)) => Ok(payload),
+        Some(_) => Err(WebOsRegistrationError::InvalidPayload {
+            message_type: message_type.to_string(),
+        }),
+        None => Err(WebOsRegistrationError::MissingPayload {
+            message_type: message_type.to_string(),
+        }),
+    }
+}
+
+fn split_webos_error(error: &str) -> (Option<i32>, String) {
+    let mut parts = error.splitn(2, char::is_whitespace);
+    let first = parts.next().unwrap_or_default();
+    match first.parse::<i32>() {
+        Ok(code) => (
+            Some(code),
+            parts.next().unwrap_or_default().trim().to_string(),
+        ),
+        Err(_) => (None, error.to_string()),
+    }
+}
+
+fn registration_manifest() -> &'static Value {
+    REGISTRATION_MANIFEST.get_or_init(|| {
+        serde_json::from_str(REGISTRATION_MANIFEST_JSON)
+            .expect("bundled webOS registration manifest must be valid JSON")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parse_registration_message, registration_manifest, WebOsRegistrationError,
+        WebOsRegistrationEvent, WebOsRegistrationRequest,
+    };
+    use crate::platform_access_token::{PlatformAccessToken, PlatformAccessTokenError};
+    use serde_json::{json, Value};
+
+    const REQUEST_ID: &str = "register_0";
+
+    fn token(value: &str) -> PlatformAccessToken {
+        PlatformAccessToken::new(value).expect("valid platform access token")
+    }
+
+    #[test]
+    fn registration_request_without_token_uses_minimal_unsigned_probe_manifest() {
+        let request =
+            WebOsRegistrationRequest::new(REQUEST_ID, None).expect("registration request");
+        let value = request.to_json_value();
+        let expected_manifest = json!({
+            "manifestVersion": 1,
+            "permissions": ["READ_POWER_STATE"],
+        });
+
+        assert_eq!(value["type"], "register");
+        assert_eq!(value["id"], REQUEST_ID);
+        assert_eq!(value["payload"]["client-key"], Value::Null);
+        assert_eq!(value["payload"]["forcePairing"], false);
+        assert_eq!(value["payload"]["pairingType"], "PROMPT");
+        assert_eq!(registration_manifest(), &expected_manifest);
+        assert_eq!(value["payload"]["manifest"], expected_manifest);
+        assert_eq!(
+            serde_json::from_str::<Value>(&request.to_json_string())
+                .expect("serialized registration request"),
+            value
+        );
+    }
+
+    #[test]
+    fn registration_request_with_token_includes_key_without_leaking_it_in_debug() {
+        let access_token = token("existing-client-key");
+        let request = WebOsRegistrationRequest::new(REQUEST_ID, Some(&access_token))
+            .expect("registration request");
+
+        assert_eq!(request.request_id(), REQUEST_ID);
+        assert_eq!(
+            request.to_json_value()["payload"]["client-key"],
+            access_token.as_secret_str()
+        );
+        let debug = format!("{request:?}");
+        assert!(debug.contains("has_access_token: true"));
+        assert!(!debug.contains(access_token.as_secret_str()));
+    }
+
+    #[test]
+    fn registration_request_rejects_empty_request_id() {
+        assert!(matches!(
+            WebOsRegistrationRequest::new(" ", None),
+            Err(WebOsRegistrationError::EmptyRequestId)
+        ));
+    }
+
+    #[test]
+    fn prompt_then_registered_transcript_produces_token() {
+        let prompt = json!({
+            "id": REQUEST_ID,
+            "type": "response",
+            "payload": {
+                "pairingType": "PROMPT",
+                "returnValue": true,
+            },
+        });
+        assert_eq!(
+            parse_registration_message(REQUEST_ID, &prompt.to_string())
+                .expect("parse pairing prompt"),
+            WebOsRegistrationEvent::PairingPrompt
+        );
+
+        let registered = json!({
+            "id": REQUEST_ID,
+            "type": "registered",
+            "payload": {"client-key": "new-client-key"},
+        });
+        assert_eq!(
+            parse_registration_message(REQUEST_ID, &registered.to_string())
+                .expect("parse registered response"),
+            WebOsRegistrationEvent::Registered {
+                access_token: token("new-client-key"),
+            }
+        );
+    }
+
+    #[test]
+    fn response_id_is_required_and_must_match() {
+        let cases = [
+            (
+                json!({"type": "registered", "payload": {"client-key": "key"}}),
+                "missing",
+            ),
+            (
+                json!({"id": 7, "type": "registered", "payload": {"client-key": "key"}}),
+                "invalid",
+            ),
+            (
+                json!({"id": "other", "type": "registered", "payload": {"client-key": "key"}}),
+                "unexpected",
+            ),
+        ];
+
+        for (message, expected) in cases {
+            let error = parse_registration_message(REQUEST_ID, &message.to_string())
+                .expect_err("request ID should fail validation");
+            assert!(
+                matches!(
+                    (&error, expected),
+                    (WebOsRegistrationError::MissingRequestId, "missing")
+                        | (WebOsRegistrationError::InvalidRequestId, "invalid")
+                        | (
+                            WebOsRegistrationError::UnexpectedRequestId { .. },
+                            "unexpected"
+                        )
+                ),
+                "unexpected error for {expected}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn registered_response_requires_non_empty_string_client_key() {
+        let cases = [
+            (
+                json!({"id": REQUEST_ID, "type": "registered", "payload": {}}),
+                "missing",
+            ),
+            (
+                json!({"id": REQUEST_ID, "type": "registered", "payload": {"client-key": 7}}),
+                "invalid-type",
+            ),
+            (
+                json!({"id": REQUEST_ID, "type": "registered", "payload": {"client-key": " "}}),
+                "empty",
+            ),
+        ];
+
+        for (message, expected) in cases {
+            let error = parse_registration_message(REQUEST_ID, &message.to_string())
+                .expect_err("invalid client key should fail");
+            assert!(
+                matches!(
+                    (&error, expected),
+                    (WebOsRegistrationError::MissingClientKey, "missing")
+                        | (WebOsRegistrationError::InvalidClientKeyType, "invalid-type")
+                        | (
+                            WebOsRegistrationError::InvalidClientKey(
+                                PlatformAccessTokenError::Empty
+                            ),
+                            "empty"
+                        )
+                ),
+                "unexpected error for {expected}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_pairing_is_a_typed_error_with_preserved_message() {
+        let response = json!({
+            "id": REQUEST_ID,
+            "type": "response",
+            "payload": {
+                "returnValue": false,
+                "errorText": "user rejected pairing",
+            },
+        });
+
+        assert!(matches!(
+            parse_registration_message(REQUEST_ID, &response.to_string()),
+            Err(WebOsRegistrationError::PairingRejected {
+                message: Some(message)
+            }) if message == "user rejected pairing"
+        ));
+    }
+
+    #[test]
+    fn webos_error_preserves_numeric_code_and_message() {
+        let response = json!({
+            "id": REQUEST_ID,
+            "type": "error",
+            "error": "-102 registration denied",
+        });
+
+        assert!(matches!(
+            parse_registration_message(REQUEST_ID, &response.to_string()),
+            Err(WebOsRegistrationError::WebOsError {
+                code: Some(-102),
+                message,
+            }) if message == "registration denied"
+        ));
+    }
+
+    #[test]
+    fn malformed_and_unexpected_messages_are_typed_errors() {
+        assert!(matches!(
+            parse_registration_message(REQUEST_ID, "not-json"),
+            Err(WebOsRegistrationError::MalformedJson(_))
+        ));
+        assert!(matches!(
+            parse_registration_message(REQUEST_ID, "[]"),
+            Err(WebOsRegistrationError::InvalidRootMessage)
+        ));
+
+        let cases = [
+            (json!({"id": REQUEST_ID, "payload": {}}), "missing-type"),
+            (
+                json!({"id": REQUEST_ID, "type": 7, "payload": {}}),
+                "invalid-type",
+            ),
+            (
+                json!({"id": REQUEST_ID, "type": "hello", "payload": {}}),
+                "unexpected-type",
+            ),
+            (
+                json!({"id": REQUEST_ID, "type": "registered"}),
+                "missing-payload",
+            ),
+            (
+                json!({"id": REQUEST_ID, "type": "registered", "payload": 7}),
+                "invalid-payload",
+            ),
+            (
+                json!({"id": REQUEST_ID, "type": "response", "payload": {"returnValue": true}}),
+                "unexpected-response",
+            ),
+            (json!({"id": REQUEST_ID, "type": "error"}), "missing-error"),
+            (
+                json!({"id": REQUEST_ID, "type": "error", "error": 7}),
+                "invalid-error",
+            ),
+        ];
+
+        for (message, expected) in cases {
+            let error = parse_registration_message(REQUEST_ID, &message.to_string())
+                .expect_err("malformed message should fail");
+            assert!(
+                matches!(
+                    (&error, expected),
+                    (WebOsRegistrationError::MissingMessageType, "missing-type")
+                        | (WebOsRegistrationError::InvalidMessageType, "invalid-type")
+                        | (
+                            WebOsRegistrationError::UnexpectedMessageType { .. },
+                            "unexpected-type"
+                        )
+                        | (
+                            WebOsRegistrationError::MissingPayload { .. },
+                            "missing-payload"
+                        )
+                        | (
+                            WebOsRegistrationError::InvalidPayload { .. },
+                            "invalid-payload"
+                        )
+                        | (
+                            WebOsRegistrationError::UnexpectedRegistrationResponse,
+                            "unexpected-response"
+                        )
+                        | (
+                            WebOsRegistrationError::MissingWebOsErrorMessage,
+                            "missing-error"
+                        )
+                        | (
+                            WebOsRegistrationError::InvalidWebOsErrorMessage,
+                            "invalid-error"
+                        )
+                ),
+                "unexpected error for {expected}: {error}"
+            );
+        }
+    }
+}

--- a/crates/lg-buddy/src/web_os/registration_manifest.json
+++ b/crates/lg-buddy/src/web_os/registration_manifest.json
@@ -1,0 +1,6 @@
+{
+  "manifestVersion": 1,
+  "permissions": [
+    "READ_POWER_STATE"
+  ]
+}

--- a/crates/lg-buddy/src/web_os/registration_manifest.json
+++ b/crates/lg-buddy/src/web_os/registration_manifest.json
@@ -1,6 +1,7 @@
 {
   "manifestVersion": 1,
   "permissions": [
+    "CONTROL_POWER",
     "READ_POWER_STATE"
   ]
 }

--- a/crates/lg-buddy/src/web_os/tls.rs
+++ b/crates/lg-buddy/src/web_os/tls.rs
@@ -1,0 +1,71 @@
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::{
+    ring, verify_tls12_signature, verify_tls13_signature, WebPkiSupportedAlgorithms,
+};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, Error, SignatureScheme};
+use std::fmt;
+use std::sync::Arc;
+
+pub(super) fn webos_tv_self_signed_client_config() -> Arc<ClientConfig> {
+    let provider = Arc::new(ring::default_provider());
+    let verifier = Arc::new(WebOsTvSelfSignedCertificateVerifier {
+        supported_algorithms: provider.signature_verification_algorithms,
+    });
+    let config = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .expect("ring supports rustls default protocol versions")
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_no_client_auth();
+
+    Arc::new(config)
+}
+
+// LG TVs use a self-signed certificate whose identity cannot be established
+// through the Web PKI. Keep handshake signature verification enabled so the
+// peer still proves possession of the certificate's private key.
+struct WebOsTvSelfSignedCertificateVerifier {
+    supported_algorithms: WebPkiSupportedAlgorithms,
+}
+
+impl fmt::Debug for WebOsTvSelfSignedCertificateVerifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("WebOsTvSelfSignedCertificateVerifier")
+    }
+}
+
+impl ServerCertVerifier for WebOsTvSelfSignedCertificateVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        verify_tls12_signature(message, cert, signature, &self.supported_algorithms)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        signature: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        verify_tls13_signature(message, cert, signature, &self.supported_algorithms)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.supported_algorithms.supported_schemes()
+    }
+}


### PR DESCRIPTION
## Summary

- add a profile-scoped `PlatformAccessTokenStore` with atomic persistence, config-owner ownership, and credential-safe permissions
- add the native webOS registration protocol, self-signed WSS transport, request correlation, typed errors, and authenticated client composition
- add a typed power-state call and a deliberately temporary, unadvertised `lg-buddy dev webos-auth-probe`
- keep all normal TV behavior on the existing Python/`bscpylgtv` path

## Why

This establishes the first native webOS foundation without changing end-user runtime behavior. Later native operations can build on one authenticated client boundary while the Python dependency remains the production implementation.

## Real-TV acceptance

- a fresh profile prompted for pairing, persisted `tvs/primary/access-token.json`, and returned `power_state=Active`
- the credential parsed successfully, used `0600` file permissions and `0700` parent directories, and was owned by the config owner
- a second run reused the stored credential without prompting or rewriting it
- the existing `.aiopylgtv.sqlite` remained byte-for-byte unchanged and the legacy client still returned `Active`
- hardware testing exposed that this TV gateway requires `CONTROL_POWER` alongside `READ_POWER_STATE`; the manifest remains unsigned and otherwise minimal

## Validation

- `cargo test -p lg-buddy` (540 passed, 1 manual hardware test ignored)
- 54 Cucumber scenarios / 628 steps passed
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo build --release -p lg-buddy`
- `cargo fmt --all -- --check`
- real-TV first-pairing and stored-token reuse runs

Part of #20.
Closes #47.
Closes #48.
