### PR TITLE
Add native webOS read operations

### DIFF
--- a/crates/lg-buddy/src/dev.rs
+++ b/crates/lg-buddy/src/dev.rs
@@ -3,7 +3,7 @@ use crate::config::{load_config, resolve_config_path_from_env, ConfigError, Conf
 use crate::platform_access_token::{PlatformAccessTokenStore, PlatformAccessTokenStoreError};
 use crate::web_os::{
     WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsEndpoint,
-    WebOsPowerState, WebOsPowerStateError,
+    WebOsForegroundApp, WebOsForegroundAppError, WebOsPowerState, WebOsPowerStateError,
 };
 use std::error::Error;
 use std::fmt;
@@ -15,10 +15,12 @@ use std::time::Duration;
 const WEBOS_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const WEBOS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
 const WEBOS_AUTH_PROBE_PREFIX: &str = "LG Buddy WebOS Auth Probe";
+const WEBOS_READ_PROBE_PREFIX: &str = "LG Buddy WebOS Read Probe";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DevCommand {
     WebOsAuthProbe,
+    WebOsReadProbe,
 }
 
 impl DevCommand {
@@ -29,23 +31,24 @@ impl DevCommand {
     {
         let mut args = args.into_iter();
         let subcommand = args.next().ok_or(DevParseError::MissingSubcommand)?;
-        if subcommand.as_ref() != "webos-auth-probe" {
-            return Err(DevParseError::UnknownSubcommand(
-                subcommand.as_ref().to_string(),
-            ));
-        }
+        let command = match subcommand.as_ref() {
+            "webos-auth-probe" => Self::WebOsAuthProbe,
+            "webos-read-probe" => Self::WebOsReadProbe,
+            other => return Err(DevParseError::UnknownSubcommand(other.to_string())),
+        };
 
         let arguments: Vec<String> = args.map(|arg| arg.as_ref().to_string()).collect();
         if !arguments.is_empty() {
-            return Err(DevParseError::UnexpectedArguments { arguments });
+            return Err(DevParseError::UnexpectedArguments { command, arguments });
         }
 
-        Ok(Self::WebOsAuthProbe)
+        Ok(command)
     }
 
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::WebOsAuthProbe => "dev webos-auth-probe",
+            Self::WebOsReadProbe => "dev webos-read-probe",
         }
     }
 }
@@ -54,7 +57,10 @@ impl DevCommand {
 pub enum DevParseError {
     MissingSubcommand,
     UnknownSubcommand(String),
-    UnexpectedArguments { arguments: Vec<String> },
+    UnexpectedArguments {
+        command: DevCommand,
+        arguments: Vec<String>,
+    },
 }
 
 impl fmt::Display for DevParseError {
@@ -64,9 +70,10 @@ impl fmt::Display for DevParseError {
             Self::UnknownSubcommand(subcommand) => {
                 write!(f, "unknown temporary dev command `{subcommand}`")
             }
-            Self::UnexpectedArguments { arguments } => write!(
+            Self::UnexpectedArguments { command, arguments } => write!(
                 f,
-                "unexpected arguments for `dev webos-auth-probe`: {}",
+                "unexpected arguments for `{}`: {}",
+                command.as_str(),
                 arguments.join(" ")
             ),
         }
@@ -84,12 +91,13 @@ pub enum DevError {
     TokenStore(PlatformAccessTokenStoreError),
     Authentication(WebOsAuthenticatedClientError),
     PowerState(WebOsPowerStateError),
+    ForegroundApp(WebOsForegroundAppError),
 }
 
 impl fmt::Display for DevError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Io(source) => write!(f, "could not write webOS auth probe output: {source}"),
+            Self::Io(source) => write!(f, "could not write webOS probe output: {source}"),
             Self::ConfigPath(source) => write!(f, "could not resolve probe config: {source}"),
             Self::Config(source) => write!(f, "could not load probe config: {source}"),
             Self::ConfigOwner(source) => {
@@ -99,9 +107,12 @@ impl fmt::Display for DevError {
                 write!(f, "could not construct probe access-token store: {source}")
             }
             Self::Authentication(source) => {
-                write!(f, "webOS auth probe authentication failed: {source}")
+                write!(f, "webOS probe authentication failed: {source}")
             }
-            Self::PowerState(source) => write!(f, "webOS auth probe state read failed: {source}"),
+            Self::PowerState(source) => write!(f, "webOS probe power-state read failed: {source}"),
+            Self::ForegroundApp(source) => {
+                write!(f, "webOS read probe foreground-app read failed: {source}")
+            }
         }
     }
 }
@@ -116,6 +127,7 @@ impl Error for DevError {
             Self::TokenStore(source) => Some(source),
             Self::Authentication(source) => Some(source),
             Self::PowerState(source) => Some(source),
+            Self::ForegroundApp(source) => Some(source),
         }
     }
 }
@@ -126,6 +138,7 @@ pub(crate) fn run_dev_command<W: Write>(
 ) -> Result<(), DevError> {
     match command {
         DevCommand::WebOsAuthProbe => run_webos_auth_probe(writer),
+        DevCommand::WebOsReadProbe => run_webos_read_probe(writer),
     }
 }
 
@@ -133,7 +146,7 @@ fn run_webos_auth_probe<W: Write>(writer: &mut W) -> Result<(), DevError> {
     let config_path = resolve_config_path_from_env().map_err(DevError::ConfigPath)?;
     let config = load_config(&config_path).map_err(DevError::Config)?;
     let owner = resolve_config_owner(&config_path).map_err(DevError::ConfigOwner)?;
-    let context = WebOsAuthProbeContext::new(&config_path, config.tv_ip, owner)?;
+    let context = WebOsProbeContext::new(&config_path, config.tv_ip, owner)?;
 
     run_webos_auth_probe_with(writer, &context, |endpoint, token_store, on_auth_event| {
         let mut client = WebOsClient::connect_authenticated(
@@ -148,12 +161,36 @@ fn run_webos_auth_probe<W: Write>(writer: &mut W) -> Result<(), DevError> {
     })
 }
 
-struct WebOsAuthProbeContext {
+fn run_webos_read_probe<W: Write>(writer: &mut W) -> Result<(), DevError> {
+    let config_path = resolve_config_path_from_env().map_err(DevError::ConfigPath)?;
+    let config = load_config(&config_path).map_err(DevError::Config)?;
+    let owner = resolve_config_owner(&config_path).map_err(DevError::ConfigOwner)?;
+    let context = WebOsProbeContext::new(&config_path, config.tv_ip, owner)?;
+
+    run_webos_read_probe_with(writer, &context, |endpoint, token_store, on_auth_event| {
+        let mut client = WebOsClient::connect_authenticated(
+            endpoint,
+            WEBOS_CONNECT_TIMEOUT,
+            WEBOS_RESPONSE_TIMEOUT,
+            token_store,
+            on_auth_event,
+        )
+        .map_err(DevError::Authentication)?;
+        let power_state = client.power_state().map_err(DevError::PowerState)?;
+        let foreground_app = client.foreground_app().map_err(DevError::ForegroundApp)?;
+        Ok(WebOsReadProbeResult {
+            power_state,
+            foreground_app,
+        })
+    })
+}
+
+struct WebOsProbeContext {
     endpoint: WebOsEndpoint,
     token_store: PlatformAccessTokenStore,
 }
 
-impl WebOsAuthProbeContext {
+impl WebOsProbeContext {
     fn new(config_path: &Path, tv_ip: Ipv4Addr, owner: SystemUser) -> Result<Self, DevError> {
         let token_store = PlatformAccessTokenStore::for_primary_profile(config_path, owner)
             .map_err(DevError::TokenStore)?;
@@ -166,7 +203,7 @@ impl WebOsAuthProbeContext {
 
 fn run_webos_auth_probe_with<W, F>(
     writer: &mut W,
-    context: &WebOsAuthProbeContext,
+    context: &WebOsProbeContext,
     probe: F,
 ) -> Result<(), DevError>
 where
@@ -177,12 +214,68 @@ where
         &mut dyn FnMut(WebOsAuthenticationEvent),
     ) -> Result<WebOsPowerState, DevError>,
 {
+    let power_state = execute_webos_probe(writer, context, WEBOS_AUTH_PROBE_PREFIX, probe)?;
+    writeln!(
+        writer,
+        "{WEBOS_AUTH_PROBE_PREFIX}: power_state={power_state}"
+    )
+    .map_err(DevError::Io)
+}
+
+struct WebOsReadProbeResult {
+    power_state: WebOsPowerState,
+    foreground_app: WebOsForegroundApp,
+}
+
+fn run_webos_read_probe_with<W, F>(
+    writer: &mut W,
+    context: &WebOsProbeContext,
+    probe: F,
+) -> Result<(), DevError>
+where
+    W: Write,
+    F: FnOnce(
+        WebOsEndpoint,
+        &PlatformAccessTokenStore,
+        &mut dyn FnMut(WebOsAuthenticationEvent),
+    ) -> Result<WebOsReadProbeResult, DevError>,
+{
+    let result = execute_webos_probe(writer, context, WEBOS_READ_PROBE_PREFIX, probe)?;
+    writeln!(
+        writer,
+        "{WEBOS_READ_PROBE_PREFIX}: power_state={}",
+        result.power_state
+    )
+    .and_then(|_| {
+        writeln!(
+            writer,
+            "{WEBOS_READ_PROBE_PREFIX}: foreground_app={}",
+            result.foreground_app
+        )
+    })
+    .map_err(DevError::Io)
+}
+
+fn execute_webos_probe<W, F, T>(
+    writer: &mut W,
+    context: &WebOsProbeContext,
+    prefix: &str,
+    probe: F,
+) -> Result<T, DevError>
+where
+    W: Write,
+    F: FnOnce(
+        WebOsEndpoint,
+        &PlatformAccessTokenStore,
+        &mut dyn FnMut(WebOsAuthenticationEvent),
+    ) -> Result<T, DevError>,
+{
     let mut progress_error = None;
     let probe_result = {
         let mut on_auth_event = |event| {
             if progress_error.is_none() {
                 progress_error =
-                    write_auth_event(writer, context.token_store.token_path(), event).err();
+                    write_auth_event(writer, prefix, context.token_store.token_path(), event).err();
             }
         };
         probe(context.endpoint, &context.token_store, &mut on_auth_event)
@@ -192,36 +285,29 @@ where
         return Err(DevError::Io(source));
     }
 
-    let power_state = probe_result?;
-    writeln!(
-        writer,
-        "{WEBOS_AUTH_PROBE_PREFIX}: power_state={power_state}"
-    )
-    .map_err(DevError::Io)
+    probe_result
 }
 
 fn write_auth_event<W: Write>(
     writer: &mut W,
+    prefix: &str,
     token_path: &Path,
     event: WebOsAuthenticationEvent,
 ) -> io::Result<()> {
     match event {
         WebOsAuthenticationEvent::UsingStoredAccessToken => {
-            writeln!(
-                writer,
-                "{WEBOS_AUTH_PROBE_PREFIX}: using stored access token."
-            )?;
+            writeln!(writer, "{prefix}: using stored access token.")?;
         }
         WebOsAuthenticationEvent::PairingPrompt => {
             writeln!(
                 writer,
-                "{WEBOS_AUTH_PROBE_PREFIX}: pairing required; accept the prompt on the TV."
+                "{prefix}: pairing required; accept the prompt on the TV."
             )?;
         }
         WebOsAuthenticationEvent::AccessTokenPersisted => {
             writeln!(
                 writer,
-                "{WEBOS_AUTH_PROBE_PREFIX}: stored access token at {}",
+                "{prefix}: stored access token at {}",
                 token_path.display()
             )?;
         }
@@ -232,15 +318,18 @@ fn write_auth_event<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::{
-        run_webos_auth_probe_with, DevCommand, DevError, DevParseError, WebOsAuthProbeContext,
+        run_webos_auth_probe_with, run_webos_read_probe_with, DevCommand, DevError, DevParseError,
+        WebOsProbeContext, WebOsReadProbeResult,
     };
     use crate::auth::SystemUser;
-    use crate::web_os::{WebOsAuthenticationEvent, WebOsPowerState, WebOsPowerStateError};
+    use crate::web_os::{
+        WebOsAuthenticationEvent, WebOsForegroundApp, WebOsPowerState, WebOsPowerStateError,
+    };
     use std::net::Ipv4Addr;
     use std::path::Path;
 
-    fn probe_context() -> WebOsAuthProbeContext {
-        WebOsAuthProbeContext::new(
+    fn probe_context() -> WebOsProbeContext {
+        WebOsProbeContext::new(
             Path::new("/tmp/lg-buddy-dev-probe/config.env"),
             Ipv4Addr::new(192, 0, 2, 42),
             SystemUser::new("test-user", 1000, 1000, "/tmp"),
@@ -249,10 +338,14 @@ mod tests {
     }
 
     #[test]
-    fn parser_accepts_only_webos_auth_probe() {
+    fn parser_accepts_only_known_webos_probes() {
         assert_eq!(
             DevCommand::parse(["webos-auth-probe"]),
             Ok(DevCommand::WebOsAuthProbe)
+        );
+        assert_eq!(
+            DevCommand::parse(["webos-read-probe"]),
+            Ok(DevCommand::WebOsReadProbe)
         );
         assert_eq!(
             DevCommand::parse(Vec::<String>::new()),
@@ -265,6 +358,14 @@ mod tests {
         assert_eq!(
             DevCommand::parse(["webos-auth-probe", "extra"]),
             Err(DevParseError::UnexpectedArguments {
+                command: DevCommand::WebOsAuthProbe,
+                arguments: vec!["extra".to_string()],
+            })
+        );
+        assert_eq!(
+            DevCommand::parse(["webos-read-probe", "extra"]),
+            Err(DevParseError::UnexpectedArguments {
+                command: DevCommand::WebOsReadProbe,
                 arguments: vec!["extra".to_string()],
             })
         );
@@ -321,6 +422,37 @@ LG Buddy WebOS Auth Probe: stored access token at /tmp/lg-buddy-dev-probe/tvs/pr
 LG Buddy WebOS Auth Probe: power_state=Active Standby\n"
         );
         assert!(!output.contains("client-key"));
+    }
+
+    #[test]
+    fn read_probe_reports_hardware_observed_state_and_foreground_app() {
+        let context = probe_context();
+        let mut output = Vec::new();
+
+        run_webos_read_probe_with(
+            &mut output,
+            &context,
+            |endpoint, token_store, on_auth_event| {
+                assert_eq!(endpoint.to_string(), "wss://192.0.2.42:3001/");
+                assert_eq!(
+                    token_store.token_path(),
+                    Path::new("/tmp/lg-buddy-dev-probe/tvs/primary/access-token.json")
+                );
+                on_auth_event(WebOsAuthenticationEvent::UsingStoredAccessToken);
+                Ok(WebOsReadProbeResult {
+                    power_state: WebOsPowerState::Active,
+                    foreground_app: WebOsForegroundApp::from_test_app_id("com.webos.app.hdmi3"),
+                })
+            },
+        )
+        .expect("run read probe");
+
+        assert_eq!(
+            String::from_utf8(output).expect("UTF-8 output"),
+            "LG Buddy WebOS Read Probe: using stored access token.\n\
+LG Buddy WebOS Read Probe: power_state=Active\n\
+LG Buddy WebOS Read Probe: foreground_app=com.webos.app.hdmi3\n"
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/dev.rs
+++ b/crates/lg-buddy/src/dev.rs
@@ -2,8 +2,9 @@ use crate::auth::{resolve_config_owner, AuthContextError, SystemUser};
 use crate::config::{load_config, resolve_config_path_from_env, ConfigError, ConfigPathError};
 use crate::platform_access_token::{PlatformAccessTokenStore, PlatformAccessTokenStoreError};
 use crate::web_os::{
-    WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsEndpoint,
-    WebOsForegroundApp, WebOsForegroundAppError, WebOsPowerState, WebOsPowerStateError,
+    WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsBacklightBrightness,
+    WebOsBacklightBrightnessError, WebOsClient, WebOsEndpoint, WebOsForegroundApp,
+    WebOsForegroundAppError, WebOsPowerState, WebOsPowerStateError,
 };
 use std::error::Error;
 use std::fmt;
@@ -92,6 +93,7 @@ pub enum DevError {
     Authentication(WebOsAuthenticatedClientError),
     PowerState(WebOsPowerStateError),
     ForegroundApp(WebOsForegroundAppError),
+    BacklightBrightness(WebOsBacklightBrightnessError),
 }
 
 impl fmt::Display for DevError {
@@ -113,6 +115,9 @@ impl fmt::Display for DevError {
             Self::ForegroundApp(source) => {
                 write!(f, "webOS read probe foreground-app read failed: {source}")
             }
+            Self::BacklightBrightness(source) => {
+                write!(f, "webOS read probe backlight read failed: {source}")
+            }
         }
     }
 }
@@ -128,6 +133,7 @@ impl Error for DevError {
             Self::Authentication(source) => Some(source),
             Self::PowerState(source) => Some(source),
             Self::ForegroundApp(source) => Some(source),
+            Self::BacklightBrightness(source) => Some(source),
         }
     }
 }
@@ -178,9 +184,13 @@ fn run_webos_read_probe<W: Write>(writer: &mut W) -> Result<(), DevError> {
         .map_err(DevError::Authentication)?;
         let power_state = client.power_state().map_err(DevError::PowerState)?;
         let foreground_app = client.foreground_app().map_err(DevError::ForegroundApp)?;
+        let backlight_brightness = client
+            .backlight_brightness()
+            .map_err(DevError::BacklightBrightness)?;
         Ok(WebOsReadProbeResult {
             power_state,
             foreground_app,
+            backlight_brightness,
         })
     })
 }
@@ -225,6 +235,7 @@ where
 struct WebOsReadProbeResult {
     power_state: WebOsPowerState,
     foreground_app: WebOsForegroundApp,
+    backlight_brightness: WebOsBacklightBrightness,
 }
 
 fn run_webos_read_probe_with<W, F>(
@@ -251,6 +262,13 @@ where
             writer,
             "{WEBOS_READ_PROBE_PREFIX}: foreground_app={}",
             result.foreground_app
+        )
+    })
+    .and_then(|_| {
+        writeln!(
+            writer,
+            "{WEBOS_READ_PROBE_PREFIX}: backlight={}",
+            result.backlight_brightness
         )
     })
     .map_err(DevError::Io)
@@ -323,7 +341,8 @@ mod tests {
     };
     use crate::auth::SystemUser;
     use crate::web_os::{
-        WebOsAuthenticationEvent, WebOsForegroundApp, WebOsPowerState, WebOsPowerStateError,
+        WebOsAuthenticationEvent, WebOsBacklightBrightness, WebOsForegroundApp, WebOsPowerState,
+        WebOsPowerStateError,
     };
     use std::net::Ipv4Addr;
     use std::path::Path;
@@ -425,7 +444,7 @@ LG Buddy WebOS Auth Probe: power_state=Active Standby\n"
     }
 
     #[test]
-    fn read_probe_reports_hardware_observed_state_and_foreground_app() {
+    fn read_probe_reports_hardware_observed_values() {
         let context = probe_context();
         let mut output = Vec::new();
 
@@ -442,6 +461,7 @@ LG Buddy WebOS Auth Probe: power_state=Active Standby\n"
                 Ok(WebOsReadProbeResult {
                     power_state: WebOsPowerState::Active,
                     foreground_app: WebOsForegroundApp::from_test_app_id("com.webos.app.hdmi3"),
+                    backlight_brightness: WebOsBacklightBrightness::from_test_percent(100),
                 })
             },
         )
@@ -451,7 +471,8 @@ LG Buddy WebOS Auth Probe: power_state=Active Standby\n"
             String::from_utf8(output).expect("UTF-8 output"),
             "LG Buddy WebOS Read Probe: using stored access token.\n\
 LG Buddy WebOS Read Probe: power_state=Active\n\
-LG Buddy WebOS Read Probe: foreground_app=com.webos.app.hdmi3\n"
+LG Buddy WebOS Read Probe: foreground_app=com.webos.app.hdmi3\n\
+LG Buddy WebOS Read Probe: backlight=100\n"
         );
     }
 

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -568,6 +568,12 @@ mod tests {
             )))
         );
         assert_eq!(
+            parse_args(["dev", "webos-read-probe"]),
+            Ok(ParseOutcome::Command(Command::Dev(
+                DevCommand::WebOsReadProbe
+            )))
+        );
+        assert_eq!(
             parse_args(["settings", "list"]),
             Ok(ParseOutcome::Command(Command::Settings(
                 SettingsCommand::List
@@ -737,6 +743,14 @@ mod tests {
         assert_eq!(
             parse_args(["dev", "webos-auth-probe", "extra"]),
             Err(ParseError::Dev(DevParseError::UnexpectedArguments {
+                command: DevCommand::WebOsAuthProbe,
+                arguments: vec!["extra".to_string()],
+            }))
+        );
+        assert_eq!(
+            parse_args(["dev", "webos-read-probe", "extra"]),
+            Err(ParseError::Dev(DevParseError::UnexpectedArguments {
+                command: DevCommand::WebOsReadProbe,
                 arguments: vec!["extra".to_string()],
             }))
         );
@@ -836,6 +850,7 @@ mod tests {
             );
         }
         assert!(!help.contains("webos-auth-probe"));
+        assert!(!help.contains("webos-read-probe"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -148,6 +148,15 @@ impl WebOsClient {
         })
     }
 
+    #[cfg(test)]
+    pub(super) fn connect_for_test(
+        endpoint: WebOsEndpoint,
+        connect_timeout: Duration,
+        response_timeout: Duration,
+    ) -> Result<Self, WebOsClientError> {
+        Self::connect(endpoint, connect_timeout, response_timeout)
+    }
+
     fn registration(&mut self) -> WebOsClientRegistration<'_> {
         WebOsClientRegistration { client: self }
     }

--- a/crates/lg-buddy/src/web_os/input.rs
+++ b/crates/lg-buddy/src/web_os/input.rs
@@ -1,0 +1,235 @@
+use super::{WebOsClient, WebOsClientError};
+use serde_json::{json, Value};
+use std::error::Error;
+use std::fmt;
+
+const GET_FOREGROUND_APP_URI: &str = "ssap://com.webos.applicationManager/getForegroundAppInfo";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebOsForegroundApp {
+    app_id: String,
+}
+
+impl WebOsForegroundApp {
+    pub fn app_id(&self) -> &str {
+        &self.app_id
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_app_id(app_id: impl Into<String>) -> Self {
+        Self {
+            app_id: app_id.into(),
+        }
+    }
+}
+
+impl fmt::Display for WebOsForegroundApp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.app_id)
+    }
+}
+
+#[derive(Debug)]
+pub enum WebOsForegroundAppError {
+    Request { source: WebOsClientError },
+    MissingPayload,
+    InvalidPayload,
+    MissingReturnValue,
+    InvalidReturnValue,
+    RequestRejected { message: Option<String> },
+    MissingAppId,
+    InvalidAppId,
+    EmptyAppId,
+}
+
+impl fmt::Display for WebOsForegroundAppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request { source } => write!(f, "could not read webOS foreground app: {source}"),
+            Self::MissingPayload => write!(f, "webOS foreground-app response has no payload"),
+            Self::InvalidPayload => {
+                write!(f, "webOS foreground-app response payload is not an object")
+            }
+            Self::MissingReturnValue => {
+                write!(f, "webOS foreground-app response has no return value")
+            }
+            Self::InvalidReturnValue => {
+                write!(
+                    f,
+                    "webOS foreground-app response return value is not a boolean"
+                )
+            }
+            Self::RequestRejected {
+                message: Some(message),
+            } => write!(f, "webOS foreground-app request was rejected: {message}"),
+            Self::RequestRejected { message: None } => {
+                write!(f, "webOS foreground-app request was rejected")
+            }
+            Self::MissingAppId => write!(f, "webOS foreground-app response has no app ID"),
+            Self::InvalidAppId => {
+                write!(f, "webOS foreground-app response app ID is not a string")
+            }
+            Self::EmptyAppId => write!(f, "webOS foreground-app response app ID is empty"),
+        }
+    }
+}
+
+impl Error for WebOsForegroundAppError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Request { source } => Some(source),
+            Self::MissingPayload
+            | Self::InvalidPayload
+            | Self::MissingReturnValue
+            | Self::InvalidReturnValue
+            | Self::RequestRejected { .. }
+            | Self::MissingAppId
+            | Self::InvalidAppId
+            | Self::EmptyAppId => None,
+        }
+    }
+}
+
+impl WebOsClient {
+    pub fn foreground_app(&mut self) -> Result<WebOsForegroundApp, WebOsForegroundAppError> {
+        let response = self
+            .send_request(GET_FOREGROUND_APP_URI, json!({}))
+            .map_err(|source| WebOsForegroundAppError::Request { source })?;
+        parse_foreground_app_response(&response)
+    }
+}
+
+fn parse_foreground_app_response(
+    response: &Value,
+) -> Result<WebOsForegroundApp, WebOsForegroundAppError> {
+    let payload = match response.get("payload") {
+        Some(Value::Object(payload)) => payload,
+        Some(_) => return Err(WebOsForegroundAppError::InvalidPayload),
+        None => return Err(WebOsForegroundAppError::MissingPayload),
+    };
+
+    match payload.get("returnValue") {
+        Some(Value::Bool(true)) => {}
+        Some(Value::Bool(false)) => {
+            let message = payload
+                .get("errorText")
+                .or_else(|| payload.get("error"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            return Err(WebOsForegroundAppError::RequestRejected { message });
+        }
+        Some(_) => return Err(WebOsForegroundAppError::InvalidReturnValue),
+        None => return Err(WebOsForegroundAppError::MissingReturnValue),
+    }
+
+    let app_id = match payload.get("appId") {
+        Some(Value::String(app_id)) if app_id.trim().is_empty() => {
+            return Err(WebOsForegroundAppError::EmptyAppId)
+        }
+        Some(Value::String(app_id)) => app_id.clone(),
+        Some(_) => return Err(WebOsForegroundAppError::InvalidAppId),
+        None => return Err(WebOsForegroundAppError::MissingAppId),
+    };
+
+    Ok(WebOsForegroundApp { app_id })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parse_foreground_app_response, WebOsForegroundApp, WebOsForegroundAppError,
+        GET_FOREGROUND_APP_URI,
+    };
+    use crate::web_os::test_support::ScriptedWebOsServer;
+    use crate::web_os::WebOsClient;
+    use serde_json::json;
+    use std::time::Duration;
+
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+    const RESPONSE_TIMEOUT: Duration = Duration::from_millis(200);
+
+    #[test]
+    fn foreground_app_request_matches_hardware_observed_transcript() {
+        let server = ScriptedWebOsServer::spawn(|peer| {
+            let request = peer.receive_json();
+            assert_eq!(request["id"], "request_0");
+            assert_eq!(request["type"], "request");
+            assert_eq!(request["uri"], GET_FOREGROUND_APP_URI);
+            assert_eq!(request["payload"], json!({}));
+            peer.send_json(json!({
+                "id": request["id"],
+                "type": "response",
+                "payload": {
+                    "appId": "com.webos.app.hdmi3",
+                    "returnValue": true,
+                },
+            }));
+        });
+        let mut client =
+            WebOsClient::connect_for_test(server.endpoint(), CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
+                .expect("connect client");
+
+        assert_eq!(
+            client.foreground_app().expect("read foreground app"),
+            WebOsForegroundApp {
+                app_id: "com.webos.app.hdmi3".to_string(),
+            }
+        );
+        server.finish();
+    }
+
+    #[test]
+    fn malformed_foreground_app_payloads_are_typed_errors() {
+        let cases = [
+            (json!({}), WebOsForegroundAppError::MissingPayload),
+            (
+                json!({"payload": []}),
+                WebOsForegroundAppError::InvalidPayload,
+            ),
+            (
+                json!({"payload": {"appId": "com.webos.app.hdmi3"}}),
+                WebOsForegroundAppError::MissingReturnValue,
+            ),
+            (
+                json!({"payload": {"returnValue": "yes", "appId": "com.webos.app.hdmi3"}}),
+                WebOsForegroundAppError::InvalidReturnValue,
+            ),
+            (
+                json!({"payload": {"returnValue": true}}),
+                WebOsForegroundAppError::MissingAppId,
+            ),
+            (
+                json!({"payload": {"returnValue": true, "appId": 3}}),
+                WebOsForegroundAppError::InvalidAppId,
+            ),
+            (
+                json!({"payload": {"returnValue": true, "appId": "  "}}),
+                WebOsForegroundAppError::EmptyAppId,
+            ),
+        ];
+
+        for (response, expected) in cases {
+            let actual =
+                parse_foreground_app_response(&response).expect_err("payload should be rejected");
+            assert_eq!(
+                std::mem::discriminant(&actual),
+                std::mem::discriminant(&expected)
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_foreground_app_response_preserves_message() {
+        assert!(matches!(
+            parse_foreground_app_response(&json!({
+                "payload": {
+                    "returnValue": false,
+                    "errorText": "foreground app unavailable",
+                },
+            })),
+            Err(WebOsForegroundAppError::RequestRejected {
+                message: Some(message),
+            }) if message == "foreground app unavailable"
+        ));
+    }
+}

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -1,6 +1,7 @@
 //! Native LG webOS protocol support.
 
 mod client;
+mod input;
 mod power;
 mod registration;
 #[cfg(test)]
@@ -12,6 +13,7 @@ pub use client::{
     WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsClientError,
     WebOsClientRegistrationError, WebOsEndpoint,
 };
+pub use input::{WebOsForegroundApp, WebOsForegroundAppError};
 pub use power::{WebOsPowerState, WebOsPowerStateError};
 
 pub use registration::{

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -2,6 +2,7 @@
 
 mod client;
 mod input;
+mod picture;
 mod power;
 mod registration;
 #[cfg(test)]
@@ -14,6 +15,7 @@ pub use client::{
     WebOsClientRegistrationError, WebOsEndpoint,
 };
 pub use input::{WebOsForegroundApp, WebOsForegroundAppError};
+pub use picture::{WebOsBacklightBrightness, WebOsBacklightBrightnessError};
 pub use power::{WebOsPowerState, WebOsPowerStateError};
 
 pub use registration::{

--- a/crates/lg-buddy/src/web_os/picture.rs
+++ b/crates/lg-buddy/src/web_os/picture.rs
@@ -1,0 +1,299 @@
+use super::{WebOsClient, WebOsClientError};
+use serde_json::{json, Value};
+use std::error::Error;
+use std::fmt;
+
+const GET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/getSystemSettings";
+const MAX_BACKLIGHT_BRIGHTNESS: u64 = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WebOsBacklightBrightness(u8);
+
+impl WebOsBacklightBrightness {
+    pub fn as_percent(self) -> u8 {
+        self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_percent(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for WebOsBacklightBrightness {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub enum WebOsBacklightBrightnessError {
+    Request { source: WebOsClientError },
+    MissingPayload,
+    InvalidPayload,
+    MissingReturnValue,
+    InvalidReturnValue,
+    RequestRejected { message: Option<String> },
+    MissingSettings,
+    InvalidSettings,
+    MissingBacklight,
+    InvalidBacklight,
+    BacklightOutOfRange { value: u64 },
+}
+
+impl fmt::Display for WebOsBacklightBrightnessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request { source } => {
+                write!(f, "could not read webOS backlight brightness: {source}")
+            }
+            Self::MissingPayload => {
+                write!(f, "webOS backlight-brightness response has no payload")
+            }
+            Self::InvalidPayload => {
+                write!(
+                    f,
+                    "webOS backlight-brightness response payload is not an object"
+                )
+            }
+            Self::MissingReturnValue => {
+                write!(f, "webOS backlight-brightness response has no return value")
+            }
+            Self::InvalidReturnValue => {
+                write!(
+                    f,
+                    "webOS backlight-brightness response return value is not a boolean"
+                )
+            }
+            Self::RequestRejected {
+                message: Some(message),
+            } => write!(
+                f,
+                "webOS backlight-brightness request was rejected: {message}"
+            ),
+            Self::RequestRejected { message: None } => {
+                write!(f, "webOS backlight-brightness request was rejected")
+            }
+            Self::MissingSettings => {
+                write!(f, "webOS backlight-brightness response has no settings")
+            }
+            Self::InvalidSettings => {
+                write!(
+                    f,
+                    "webOS backlight-brightness response settings are not an object"
+                )
+            }
+            Self::MissingBacklight => {
+                write!(
+                    f,
+                    "webOS backlight-brightness response has no backlight value"
+                )
+            }
+            Self::InvalidBacklight => {
+                write!(
+                    f,
+                    "webOS backlight-brightness response backlight value is not an integer"
+                )
+            }
+            Self::BacklightOutOfRange { value } => write!(
+                f,
+                "webOS backlight-brightness response value `{value}` is outside 0-100"
+            ),
+        }
+    }
+}
+
+impl Error for WebOsBacklightBrightnessError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Request { source } => Some(source),
+            Self::MissingPayload
+            | Self::InvalidPayload
+            | Self::MissingReturnValue
+            | Self::InvalidReturnValue
+            | Self::RequestRejected { .. }
+            | Self::MissingSettings
+            | Self::InvalidSettings
+            | Self::MissingBacklight
+            | Self::InvalidBacklight
+            | Self::BacklightOutOfRange { .. } => None,
+        }
+    }
+}
+
+impl WebOsClient {
+    pub fn backlight_brightness(
+        &mut self,
+    ) -> Result<WebOsBacklightBrightness, WebOsBacklightBrightnessError> {
+        let response = self
+            .send_request(
+                GET_SYSTEM_SETTINGS_URI,
+                json!({
+                    "category": "picture",
+                    "keys": ["backlight"],
+                }),
+            )
+            .map_err(|source| WebOsBacklightBrightnessError::Request { source })?;
+        parse_backlight_brightness_response(&response)
+    }
+}
+
+fn parse_backlight_brightness_response(
+    response: &Value,
+) -> Result<WebOsBacklightBrightness, WebOsBacklightBrightnessError> {
+    let payload = match response.get("payload") {
+        Some(Value::Object(payload)) => payload,
+        Some(_) => return Err(WebOsBacklightBrightnessError::InvalidPayload),
+        None => return Err(WebOsBacklightBrightnessError::MissingPayload),
+    };
+
+    match payload.get("returnValue") {
+        Some(Value::Bool(true)) => {}
+        Some(Value::Bool(false)) => {
+            let message = payload
+                .get("errorText")
+                .or_else(|| payload.get("error"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            return Err(WebOsBacklightBrightnessError::RequestRejected { message });
+        }
+        Some(_) => return Err(WebOsBacklightBrightnessError::InvalidReturnValue),
+        None => return Err(WebOsBacklightBrightnessError::MissingReturnValue),
+    }
+
+    let settings = match payload.get("settings") {
+        Some(Value::Object(settings)) => settings,
+        Some(_) => return Err(WebOsBacklightBrightnessError::InvalidSettings),
+        None => return Err(WebOsBacklightBrightnessError::MissingSettings),
+    };
+    let value = match settings.get("backlight") {
+        Some(Value::Number(value)) => value
+            .as_u64()
+            .ok_or(WebOsBacklightBrightnessError::InvalidBacklight)?,
+        Some(_) => return Err(WebOsBacklightBrightnessError::InvalidBacklight),
+        None => return Err(WebOsBacklightBrightnessError::MissingBacklight),
+    };
+    if value > MAX_BACKLIGHT_BRIGHTNESS {
+        return Err(WebOsBacklightBrightnessError::BacklightOutOfRange { value });
+    }
+
+    Ok(WebOsBacklightBrightness(value as u8))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parse_backlight_brightness_response, WebOsBacklightBrightness,
+        WebOsBacklightBrightnessError, GET_SYSTEM_SETTINGS_URI,
+    };
+    use crate::web_os::test_support::ScriptedWebOsServer;
+    use crate::web_os::WebOsClient;
+    use serde_json::json;
+    use std::time::Duration;
+
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+    const RESPONSE_TIMEOUT: Duration = Duration::from_millis(200);
+
+    #[test]
+    fn backlight_request_matches_hardware_observed_transcript() {
+        let server = ScriptedWebOsServer::spawn(|peer| {
+            let request = peer.receive_json();
+            assert_eq!(request["id"], "request_0");
+            assert_eq!(request["type"], "request");
+            assert_eq!(request["uri"], GET_SYSTEM_SETTINGS_URI);
+            assert_eq!(
+                request["payload"],
+                json!({
+                    "category": "picture",
+                    "keys": ["backlight"],
+                })
+            );
+            peer.send_json(json!({
+                "id": request["id"],
+                "type": "response",
+                "payload": {
+                    "category": "picture",
+                    "returnValue": true,
+                    "settings": {
+                        "backlight": 100,
+                    },
+                    "subscribed": false,
+                },
+            }));
+        });
+        let mut client =
+            WebOsClient::connect_for_test(server.endpoint(), CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
+                .expect("connect client");
+
+        assert_eq!(
+            client
+                .backlight_brightness()
+                .expect("read backlight brightness"),
+            WebOsBacklightBrightness(100)
+        );
+        server.finish();
+    }
+
+    #[test]
+    fn malformed_backlight_payloads_are_typed_errors() {
+        let cases = [
+            (json!({}), WebOsBacklightBrightnessError::MissingPayload),
+            (
+                json!({"payload": []}),
+                WebOsBacklightBrightnessError::InvalidPayload,
+            ),
+            (
+                json!({"payload": {"settings": {"backlight": 50}}}),
+                WebOsBacklightBrightnessError::MissingReturnValue,
+            ),
+            (
+                json!({"payload": {"returnValue": "yes", "settings": {"backlight": 50}}}),
+                WebOsBacklightBrightnessError::InvalidReturnValue,
+            ),
+            (
+                json!({"payload": {"returnValue": true}}),
+                WebOsBacklightBrightnessError::MissingSettings,
+            ),
+            (
+                json!({"payload": {"returnValue": true, "settings": []}}),
+                WebOsBacklightBrightnessError::InvalidSettings,
+            ),
+            (
+                json!({"payload": {"returnValue": true, "settings": {}}}),
+                WebOsBacklightBrightnessError::MissingBacklight,
+            ),
+            (
+                json!({"payload": {"returnValue": true, "settings": {"backlight": "50"}}}),
+                WebOsBacklightBrightnessError::InvalidBacklight,
+            ),
+            (
+                json!({"payload": {"returnValue": true, "settings": {"backlight": 101}}}),
+                WebOsBacklightBrightnessError::BacklightOutOfRange { value: 101 },
+            ),
+        ];
+
+        for (response, expected) in cases {
+            let actual = parse_backlight_brightness_response(&response)
+                .expect_err("payload should be rejected");
+            assert_eq!(
+                std::mem::discriminant(&actual),
+                std::mem::discriminant(&expected)
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_backlight_response_preserves_message() {
+        assert!(matches!(
+            parse_backlight_brightness_response(&json!({
+                "payload": {
+                    "returnValue": false,
+                    "errorText": "settings unavailable",
+                },
+            })),
+            Err(WebOsBacklightBrightnessError::RequestRejected {
+                message: Some(message),
+            }) if message == "settings unavailable"
+        ));
+    }
+}

--- a/crates/lg-buddy/src/web_os/registration.rs
+++ b/crates/lg-buddy/src/web_os/registration.rs
@@ -355,7 +355,7 @@ mod tests {
         let value = request.to_json_value();
         let expected_manifest = json!({
             "manifestVersion": 1,
-            "permissions": ["CONTROL_POWER", "READ_POWER_STATE"],
+            "permissions": ["CONTROL_POWER", "READ_POWER_STATE", "READ_RUNNING_APPS"],
         });
 
         assert_eq!(value["type"], "register");

--- a/crates/lg-buddy/src/web_os/registration.rs
+++ b/crates/lg-buddy/src/web_os/registration.rs
@@ -355,7 +355,12 @@ mod tests {
         let value = request.to_json_value();
         let expected_manifest = json!({
             "manifestVersion": 1,
-            "permissions": ["CONTROL_POWER", "READ_POWER_STATE", "READ_RUNNING_APPS"],
+            "permissions": [
+                "CONTROL_POWER",
+                "READ_POWER_STATE",
+                "READ_RUNNING_APPS",
+                "READ_SETTINGS"
+            ],
         });
 
         assert_eq!(value["type"], "register");

--- a/crates/lg-buddy/src/web_os/registration_manifest.json
+++ b/crates/lg-buddy/src/web_os/registration_manifest.json
@@ -3,6 +3,7 @@
   "permissions": [
     "CONTROL_POWER",
     "READ_POWER_STATE",
-    "READ_RUNNING_APPS"
+    "READ_RUNNING_APPS",
+    "READ_SETTINGS"
   ]
 }

--- a/crates/lg-buddy/src/web_os/registration_manifest.json
+++ b/crates/lg-buddy/src/web_os/registration_manifest.json
@@ -2,6 +2,7 @@
   "manifestVersion": 1,
   "permissions": [
     "CONTROL_POWER",
-    "READ_POWER_STATE"
+    "READ_POWER_STATE",
+    "READ_RUNNING_APPS"
   ]
 }


### PR DESCRIPTION
## Summary

- add typed native reads for the foreground app/current input and picture backlight brightness
- extend the temporary hidden `dev webos-read-probe` to exercise power, foreground app, and backlight over one authenticated connection
- grant only `READ_RUNNING_APPS` and `READ_SETTINGS` in addition to the existing power permissions
- encode credential-redacted, real-TV request/response transcripts in the shared scripted websocket server

## Impact

There is no end-user implementation switch in this change. Production TV operations still use bscpylgtv; the native reads are available only through the internal webOS API and temporary dev probe. Raw webOS JSON remains inside the `web_os` module, leaving domain mapping to #58.

## Hardware validation

Both new operations were validated against the configured LG webOS TV and matched the existing bscpylgtv results. The existing access token was reused without another pairing prompt. The permission boundary was also checked before each grant was added: foreground app required `READ_RUNNING_APPS`, and backlight required `READ_SETTINGS`.

Detailed redacted transcripts are recorded on #50:
- https://github.com/Staphylococcus/LG_Buddy/issues/50#issuecomment-5102465348
- https://github.com/Staphylococcus/LG_Buddy/issues/50#issuecomment-5102531370

## Validation

- `cargo test -p lg-buddy`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo build --release -p lg-buddy`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #50